### PR TITLE
Add configuration for the stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,29 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - bug
+  - high priority
+
+# Label to use when marking as stale
+staleLabel: staled
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity in the past 90 days. It is scheduled to be closed in 30 days, unless
+  someone give it some loving in the meantime.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been closed because nobody has shown it love in the past 120
+  days; poor thing. Comments are still open if someone wants to revive it.


### PR DESCRIPTION
We had a short chat with @mouse-reeve where I offered to look into having a stale bot, the purpose being what is stated on the [stalebot github repository](https://github.com/probot/stale#is-closing-stale-issues-really-a-good-idea):

> In an ideal world with infinite resources, there would be no need for this app.
>
> But in any successful software project, there's always more work to do than people to do it. As more and more work piles up, it becomes paralyzing. Just making decisions about what work should and shouldn't get done can exhaust all available resources. In the experience of the maintainers of this app—and the hundreds of other projects and organizations that use it—focusing on issues that are actively affecting humans is an effective method for prioritizing work.
>
> To some, a robot trying to close stale issues may seem inhospitable or offensive to contributors. But the alternative is to disrespect them by setting false expectations and implicitly ignoring their work. This app makes it explicit: if work is not progressing, then it's stale. A comment is all it takes to keep the conversation alive.

This is a proposal to tweak or close.

**The [stale bot needs to be installed](https://github.com/apps/stale)**, which is quick.

A summary of the settings is as follow:

- Automatically label issues and PR as `staled` after 90 days of inactivity (with comment).
- Automatically close issues and PR after 30 more days of inactivity (120 total; ±4 months) (with comment).

Issues and PR with the following labels **will not** be marked as staled:

- pinned
- security
- bug
- high priority

If you feel like updating numbers or comments, you can let me know here or on [matrix].