### PR TITLE
Restrict list creation form to authenticated users

### DIFF
--- a/bookwyrm/templates/lists/lists.html
+++ b/bookwyrm/templates/lists/lists.html
@@ -15,10 +15,12 @@
             {% endif %}
         </h1>
     </div>
+    {% if request.user.is_authenticated %}
     <div class="column is-narrow">
         {% trans "Create List" as button_text %}
         {% include 'snippets/toggle/open_button.html' with controls_text="create-list" icon="plus" text=button_text focus="create-list-header" %}
     </div>
+    {% endif %}
 </header>
 
 <div class="block">


### PR DESCRIPTION
When visiting the `/list` route on an instance while unauthenticated, the button to toggle the List creation form is shown. This PR aims to hide the button to unauthenticated visitors.