### PR TITLE
Gracefully handle expect but unsupported activities

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -52,10 +52,14 @@ def naive_parse(activity_objects, activity_json, serializer=None):
         if activity_json.get("publicKeyPem"):
             # ugh
             activity_json["type"] = "PublicKey"
+
+        activity_type = activity_json.get("type")
         try:
-            activity_type = activity_json["type"]
             serializer = activity_objects[activity_type]
         except KeyError as e:
+            # we know this exists and that we can't handle it
+            if activity_type in ["Question"]:
+                return None
             raise ActivitySerializerError(e)
 
     return serializer(activity_objects=activity_objects, **activity_json)

--- a/bookwyrm/activitypub/verbs.py
+++ b/bookwyrm/activitypub/verbs.py
@@ -58,7 +58,9 @@ class Update(Verb):
 
     def action(self):
         """ update a model instance from the dataclass """
-        self.object.to_model(allow_create=False)
+        obj = self.object
+        if obj:
+            self.object.to_model(allow_create=False)
 
 
 @dataclass(init=False)

--- a/bookwyrm/activitypub/verbs.py
+++ b/bookwyrm/activitypub/verbs.py
@@ -16,7 +16,11 @@ class Verb(ActivityObject):
 
     def action(self):
         """ usually we just want to update and save """
-        self.object.to_model()
+        obj = self.object
+        # it may return None if the object is invalid in an expected way
+        # ie, Question type
+        if obj:
+            obj.to_model()
 
 
 @dataclass(init=False)


### PR DESCRIPTION
This will prevent errors being thrown when `Question` activities are received (we don't support polls yet), but still throw errors when other unknown types show up, as they may be things we _should_ handle.