### PR TITLE
Fix editorconfig greediness 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ block_comment_end = */
 [{bw-dev,fr-dev,LICENSE}]
 max_line_length = off
 
-[*.{csv,json,html,md,mo,po,py,svg,tsv}]
+[*.{csv,json,html,md,po,py,svg,tsv}]
 max_line_length = off
 
 # `  ` at the end of a line is a line-break in markdown
@@ -32,10 +32,8 @@ indent_size = 2
 max_line_length = off
 
 # Computer generated files
-[{package.json,*.lock}]
+[{package.json,*.lock,*.mo}]
 indent_size = unset
 indent_style = unset
 max_line_length = unset
-
-[*.mo]
 insert_final_newline = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -20,9 +20,10 @@ block_comment_end = */
 [{bw-dev,fr-dev,LICENSE}]
 max_line_length = off
 
-[*.{csv,json,html,md,po,py,svg,tsv}]
+[*.{csv,json,html,md,mo,po,py,svg,tsv}]
 max_line_length = off
 
+# `  ` at the end of a line is a line-break in markdown
 [*.{md,markdown}]
 trim_trailing_whitespace = false
 
@@ -30,7 +31,11 @@ trim_trailing_whitespace = false
 indent_size = 2
 max_line_length = off
 
-[{package.json,yarn.lock}]
+# Computer generated files
+[{package.json,*.lock}]
 indent_size = unset
 indent_style = unset
 max_line_length = unset
+
+[*.mo]
+insert_final_newline = unset

--- a/.github/workflows/lint-frontend.yaml
+++ b/.github/workflows/lint-frontend.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
       - uses: actions/checkout@v2
 
       - name: Install modules
@@ -26,8 +26,13 @@ jobs:
 
       # See .stylelintignore for files that are not linted.
       - name: Run stylelint
-        run: yarn stylelint bookwyrm/static/**/*.css --report-needless-disables --report-invalid-scope-disables
+        run: >
+          yarn stylelint bookwyrm/static/**/*.css \
+            --report-needless-disables \
+            --report-invalid-scope-disables
 
       # See .eslintignore for files that are not linted.
       - name: Run ESLint
-        run: yarn eslint bookwyrm/static --ext .js,.jsx,.ts,.tsx
+        run: >
+          yarn eslint bookwyrm/static \
+            --ext .js,.jsx,.ts,.tsx


### PR DESCRIPTION
- Ignore computer generated files when linting.
- Include .mo files for consistency.
- Use multiline yaml syntax for `run` commands.

This PR should avoid [linting issues in some current or future PR](https://github.com/bookwyrm-social/bookwyrm/pull/860/checks?check_run_id=2260841186#step:4:13). It should also close https://github.com/SavinaRoja/bookwyrm/pull/1.