### PR TITLE
Display book identifiers in the list of Editions

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -67,31 +67,16 @@
             </div>
             {% endif %}
 
-            <section class="content is-clipped">
-                <dl>
-                    {% if book.isbn_13 %}
-                    <div class="is-flex is-justify-content-space-between is-align-items-center">
-                        <dt>{% trans "ISBN:" %}</dt>
-                        <dd itemprop="isbn">{{ book.isbn_13 }}</dd>
+            <section class="is-clipped">
+                {% with book=book %}
+                    <div class="content">
+                        {% include 'book/publisher_info.html' %}
                     </div>
-                    {% endif %}
 
-                    {% if book.oclc_number %}
-                    <div class="is-flex is-justify-content-space-between is-align-items-center">
-                        <dt>{% trans "OCLC Number:" %}</dt>
-                        <dd>{{ book.oclc_number }}</dd>
+                    <div class="my-3">
+                        {% include 'book/book_identifiers.html' %}
                     </div>
-                    {% endif %}
-
-                    {% if book.asin %}
-                    <div class="is-flex is-justify-content-space-between is-align-items-center">
-                        <dt>{% trans "ASIN:" %}</dt>
-                        <dd>{{ book.asin }}</dd>
-                    </div>
-                    {% endif %}
-                </dl>
-
-                {% include 'book/publisher_info.html' with book=book %}
+                {% endwith %}
 
                 {% if book.openlibrary_key %}
                 <p><a href="https://openlibrary.org/books/{{ book.openlibrary_key }}" target="_blank" rel="noopener">{% trans "View on OpenLibrary" %}</a></p>

--- a/bookwyrm/templates/book/book_identifiers.html
+++ b/bookwyrm/templates/book/book_identifiers.html
@@ -1,0 +1,27 @@
+{% spaceless %}
+
+{% load i18n %}
+
+<dl>
+    {% if book.isbn_13 %}
+        <div class="is-flex">
+            <dt class="mr-1">{% trans "ISBN:" %}</dt>
+            <dd itemprop="isbn">{{ book.isbn_13 }}</dd>
+        </div>
+    {% endif %}
+
+    {% if book.oclc_number %}
+        <div class="is-flex">
+            <dt class="mr-1">{% trans "OCLC Number:" %}</dt>
+            <dd>{{ book.oclc_number }}</dd>
+        </div>
+    {% endif %}
+
+    {% if book.asin %}
+        <div class="is-flex">
+            <dt class="mr-1">{% trans "ASIN:" %}</dt>
+            <dd>{{ book.asin }}</dd>
+        </div>
+    {% endif %}
+</dl>
+{% endspaceless %}

--- a/bookwyrm/templates/book/editions.html
+++ b/bookwyrm/templates/book/editions.html
@@ -28,7 +28,7 @@
 
             {% with book=book %}
                 <div class="columns is-multiline">
-                    <div class="column is-half content">
+                    <div class="column is-half">
                         {% include 'book/publisher_info.html' %}
                     </div>
 

--- a/bookwyrm/templates/book/editions.html
+++ b/bookwyrm/templates/book/editions.html
@@ -25,7 +25,18 @@
                     {{ book.title }}
                 </a>
             </h2>
-            {% include 'book/publisher_info.html' with book=book %}
+
+            {% with book=book %}
+                <div class="columns is-multiline">
+                    <div class="column is-half content">
+                        {% include 'book/publisher_info.html' %}
+                    </div>
+
+                    <div class="column is-half ">
+                        {% include 'book/book_identifiers.html' %}
+                    </div>
+                </div>
+            {% endwith %}
         </div>
         <div class="column is-3">
             {% include 'snippets/shelve_button/shelve_button.html' with book=book switch_mode=True %}


### PR DESCRIPTION
When searching for the edition of a book, it can be really useful to search it by ISBN or others.

I started refactoring the editions list but gave up because I was caught between the time it would spend to do it without Bulma and the fact I couldn’t see how to do what I wanted with Bulma. Changes are then minimal, which is not necessarily a bad thing. :)

- Add template for identifiers.
- Remove `space-between` that adds too much space on narrow views.
- Apply the `content` class only on publisher infos to avoid applying automatic styles to the book identifiers description list.