### PR TITLE
Accessibility: add language to `lang` attr on `html` tag

### DIFF
--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -1,7 +1,7 @@
 {% load bookwyrm_tags %}
 {% load i18n %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{% get_lang %}">
 <head>
     <title>{% block title %}BookWyrm{% endblock %} | {{ site.name }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -1,7 +1,7 @@
 """ template filters """
 from uuid import uuid4
 
-from django import template
+from django import template, utils
 from django.db.models import Avg
 
 from bookwyrm import models, views
@@ -217,3 +217,10 @@ def active_read_through(book, user):
 def comparison_bool(str1, str2):
     """ idk why I need to write a tag for this, it reutrns a bool """
     return str1 == str2
+
+
+@register.simple_tag(takes_context=False)
+def get_lang():
+    """ get current language, strip to the first two letters """
+    language = utils.translation.get_language()
+    return language[0:language.find('-')]

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -223,4 +223,4 @@ def comparison_bool(str1, str2):
 def get_lang():
     """ get current language, strip to the first two letters """
     language = utils.translation.get_language()
-    return language[0:language.find('-')]
+    return language[0 : language.find('-')]

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -223,4 +223,5 @@ def comparison_bool(str1, str2):
 def get_lang():
     """ get current language, strip to the first two letters """
     language = utils.translation.get_language()
-    return language[0 : language.find('-')]
+    return language[0 : language.find("-")]
+

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -224,4 +224,3 @@ def get_lang():
     """ get current language, strip to the first two letters """
     language = utils.translation.get_language()
     return language[0 : language.find("-")]
-


### PR DESCRIPTION
I only use the first subtag of the language string given by `get_language()`, because `get_language()` returns an all-lowercase string, and I don't know if it'll be considered valid by browsers.