### PR TITLE
Removes scroll padding

### DIFF
--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -1,6 +1,5 @@
 html {
     scroll-behavior: smooth;
-    scroll-padding-top: 20%;
 }
 
 body {


### PR DESCRIPTION
This might be a just-me issue, but when I read text on a screen, I highlight it with my cursor as I go to help keep track of my place. When I'm looking at text towards the top of the screen, if I try to highlight it, the screen jumps up to the top of the page. 

Anyone trying to copy text will presumably also have this issue. 

This was added in #696 to improve the experience of looking at import items - I'm not sure if there's a solution that works for both these cases, but barring that, I think it makes sense to remove it. (cc @arkhi)