### PR TITLE
Prevent stars from wrapping on multiple lines

### DIFF
--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -85,6 +85,13 @@ body {
     }
 }
 
+/** Stars
+ ******************************************************************************/
+
+.stars {
+    white-space: nowrap;
+}
+
 /** Stars in a review form
  *
  * Specificity makes hovering taking over checked inputs.


### PR DESCRIPTION
In some context, stars might be wrapping on the following line.

This PR fixes the issue.

![image](https://user-images.githubusercontent.com/277773/115957013-55066e80-a500-11eb-8424-bb2533643cbd.png)
![image](https://user-images.githubusercontent.com/277773/115957026-736c6a00-a500-11eb-9a2a-221ea908b293.png)
