### PR TITLE
Directory: Homogenize cards heights

### DIFF
--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -53,6 +53,16 @@ body {
     background-color: transparent;
 }
 
+.card.is-stretchable {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.card.is-stretchable .card-content {
+    flex-grow: 1;
+}
+
 /** Shelving
  ******************************************************************************/
 

--- a/bookwyrm/templates/directory/directory.html
+++ b/bookwyrm/templates/directory/directory.html
@@ -41,7 +41,7 @@
 <div class="columns is-multiline">
     {% for user in users %}
     <div class="column is-one-third">
-        <div class="card block">
+        <div class="card is-stretchable">
             <div class="card-content">
                 <div class="media">
                     <a href="{{ user.local_path }}" class="media-left">
@@ -56,13 +56,13 @@
                     </div>
                 </div>
 
-                <div class="content">
+                <div>
                 {% if user.summary %}
                     {{ user.summary | to_markdown | safe | truncatechars_html:40 }}
                 {% else %}&nbsp;{% endif %}
                 </div>
             </div>
-            <footer class="card-footer content">
+            <footer class="card-footer">
                 {% if user != request.user %}
                 {% if user.mutuals %}
                 <div class="card-footer-item">


### PR DESCRIPTION
When the content of a profile card stretches it in height, the grid is not homogenous. This PR adds a CSS class that'll display cards as stretchable columns. The card content will be able to grow, which should always place the card footer at the bottom of the card.

### Before

![Screenshot_2021-04-25 lire boitam eu](https://user-images.githubusercontent.com/1781070/116004126-a5192a00-a601-11eb-9154-337c4b1530b5.png)

### After

![Screenshot_2021-04-25 lire boitam eu(1)](https://user-images.githubusercontent.com/1781070/116004134-a9ddde00-a601-11eb-9d3b-5e037f496ff6.png)
