### PR TITLE
Only make notification count red for mentions

### DIFF
--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -160,7 +160,7 @@ class User(OrderedCollectionPageMixin, AbstractUser):
         """whether any of the unread notifications are conversations"""
         return self.notification_set.filter(
             read=False,
-            notification_type__in=["REPLY", "MENTION", "TAG"],
+            notification_type__in=["REPLY", "MENTION", "TAG", "REPORT"],
         ).exists()
 
     activity_serializer = activitypub.Person

--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -150,6 +150,19 @@ class User(OrderedCollectionPageMixin, AbstractUser):
         """for consistent naming"""
         return not self.is_active
 
+    @property
+    def unread_notification_count(self):
+        """ count of notifications, for the templates """
+        return self.notification_set.filter(read=False).count()
+
+    @property
+    def has_unread_mentions(self):
+        """ whether any of the unread notifications are conversations """
+        return self.notification_set.filter(
+            read=False,
+            notification_type__in=["REPLY", "MENTION", "TAG"],
+        ).exists()
+
     activity_serializer = activitypub.Person
 
     @classmethod

--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -152,12 +152,12 @@ class User(OrderedCollectionPageMixin, AbstractUser):
 
     @property
     def unread_notification_count(self):
-        """ count of notifications, for the templates """
+        """count of notifications, for the templates"""
         return self.notification_set.filter(read=False).count()
 
     @property
     def has_unread_mentions(self):
-        """ whether any of the unread notifications are conversations """
+        """whether any of the unread notifications are conversations"""
         return self.notification_set.filter(
             read=False,
             notification_type__in=["REPLY", "MENTION", "TAG"],

--- a/bookwyrm/static/js/bookwyrm.js
+++ b/bookwyrm/static/js/bookwyrm.js
@@ -97,10 +97,12 @@ let BookWyrm = new class {
     updateCountElement(counter, data) {
         const currentCount = counter.innerText;
         const count = data.count;
+        const hasMentions = data.has_mentions;
 
         if (count != currentCount) {
             this.addRemoveClass(counter.closest('[data-poll-wrapper]'), 'is-hidden', count < 1);
             counter.innerText = count;
+            this.addRemoveClass(counter.closest('[data-poll-wrapper]'), 'is-danger', hasMentions);
         }
     }
 

--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -135,8 +135,11 @@
                                 <span class="is-sr-only">{% trans "Notifications" %}</span>
                             </span>
                         </span>
-                        <span class="{% if not request.user|notification_count %}is-hidden {% endif %}tag is-danger is-medium transition-x" data-poll-wrapper>
-                            <span data-poll="notifications">{{ request.user | notification_count }}</span>
+                        <span
+                            class="{% if not request.user.unread_notification_count %}is-hidden {% elif request.user.has_unread_mentions %}is-danger {% endif %}tag is-medium transition-x"
+                            data-poll-wrapper
+                        >
+                            <span data-poll="notifications">{{ request.user.unread_notification_count }}</span>
                         </span>
                     </a>
                 </div>

--- a/bookwyrm/views/updates.py
+++ b/bookwyrm/views/updates.py
@@ -10,7 +10,8 @@ def get_notification_count(request):
     """any notifications waiting?"""
     return JsonResponse(
         {
-            "count": request.user.notification_set.filter(read=False).count(),
+            "count": request.user.unread_notification_count,
+            "has_mentions": request.user.has_unread_mentions,
         }
     )
 


### PR DESCRIPTION
The goal here is to make the notification count less obtrusive - for likes and boosts, there's nothing that I need to _do_, so there's no reason for the notification window to be quite so loud about it.

Unread notifications like boosts and favs:
<img width="236" alt="Screen Shot 2021-04-30 at 7 52 17 AM" src="https://user-images.githubusercontent.com/1807695/116713143-5d8bf880-a989-11eb-815f-c2492d69ac8a.png">

Unread replies and mentions:
<img width="273" alt="Screen Shot 2021-04-30 at 7 50 03 AM" src="https://user-images.githubusercontent.com/1807695/116713192-67adf700-a989-11eb-86a5-a966fe9498b3.png">

Works on #945 
