### PR TITLE
Fix lists layout for user

### DIFF
--- a/bookwyrm/templates/user/lists.html
+++ b/bookwyrm/templates/user/lists.html
@@ -23,7 +23,7 @@
 
 
 {% block panel %}
-<section class="block content">
+<section class="block">
     <form name="create-list" method="post" action="{% url 'lists' %}" class="box is-hidden" id="create-list">
         <header class="columns">
             <h3 class="title column">{% trans "Create list" %}</h3>


### PR DESCRIPTION
I did not see that coming. I thought the [global lists](https://bookwyrm.social/list) and user lists were using the same layout, but a stray `.content` is breaking the layout in [user lists](https://bookwyrm.social/user/mouse/lists for an example).

Before & after:

<img src="https://user-images.githubusercontent.com/277773/116752333-bac58f80-aa05-11eb-84dd-aab11c8835d4.png" alt="" width="45%" align="top"/> <img src="https://user-images.githubusercontent.com/277773/116752438-ddf03f00-aa05-11eb-9034-2bad647a4767.png" alt="" width="45%" align="top"/>

