### PR TITLE
pagination list navigation using a range of pages such as provided by get_elided_page_range

### DIFF
--- a/bookwyrm/templates/snippets/pagination.html
+++ b/bookwyrm/templates/snippets/pagination.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<nav class="pagination" aria-label="pagination">
+<nav class="pagination is-centered" aria-label="pagination">
     <a
         class="pagination-previous {% if not page.has_previous %}is-disabled{% endif %}"
         {% if page.has_previous %}
@@ -23,4 +23,18 @@
         {% trans "Next" %}
         <span class="icon icon-arrow-right" aria-hidden="true"></span>
     </a>
+
+    {% if page.has_other_pages and page_range %}
+        <ul class="pagination-list">
+        {% for num in page_range %}
+            {% if num == page.number %}
+                <li><a class="pagination-link is-current" aria-label="Page {{ num }}" aria-current="page">{{ num }}</a></li>
+            {% elif num == '…' %}
+                <li><span class="pagination-ellipsis">&hellip;</span></li>
+            {% else %}
+                <li><a class="pagination-link" aria-label="Goto page {{ num }}" href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ num }}{{ anchor }}">{{ num }}</a></li>
+            {% endif %}
+        {% endfor %}
+        </ul>
+    {% endif %}
 </nav>

--- a/bookwyrm/views/list.py
+++ b/bookwyrm/views/list.py
@@ -156,9 +156,13 @@ class List(View):
                     ).order_by("-updated_date")
                 ][: 5 - len(suggestions)]
 
+        page = paginated.get_page(request.GET.get("page"))
         data = {
             "list": book_list,
-            "items": paginated.get_page(request.GET.get("page")),
+            "items": page,
+            "page_range": paginated.get_elided_page_range(
+                page.number, on_each_side=2, on_ends=1
+            ),
             "pending_count": book_list.listitem_set.filter(approved=False).count(),
             "suggested_books": suggestions,
             "list_form": forms.ListForm(instance=book_list),


### PR DESCRIPTION
Updated the snippet for pagination to now handle a variable of `page_range`. If there are other pages, and if this variable is present, it creates a `<ul class="pagination-list">...` per documentation here: https://bulma.io/documentation/components/pagination/

The paginated book list view now uses this enhancement, providing the results of `Paginator.get_elided_page_range` (added in Django 3.2) to the templating.