### PR TITLE
Datepicker

### DIFF
--- a/bookwyrm/templates/author.html
+++ b/bookwyrm/templates/author.html
@@ -39,3 +39,6 @@
 </div>
 {% endblock %}
 
+{% block scripts %}
+{% include 'snippets/datepicker_js.html' %}
+{% endblock %}

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -333,4 +333,5 @@
 
 {% block scripts %}
 <script src="/static/js/vendor/tabs.js"></script>
+{% include 'snippets/datepicker_js.html' %}
 {% endblock %}

--- a/bookwyrm/templates/book/edit_book.html
+++ b/bookwyrm/templates/book/edit_book.html
@@ -133,7 +133,11 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_first_published_date">{% trans "First published date:" %}</label>
-                    <duet-date-picker identifier="id_first_published_date" name="first_published_date"{% if form.first_published_date.value %} value="{{ form.first_published_date.value|date:'Y-m-d' }}"{% endif %}></duet-date-picker>
+                    <duet-date-picker
+                        identifier="id_first_published_date"
+                        name="first_published_date"
+                        {% if form.first_published_date.value %}value="{{ form.first_published_date.value|date:'Y-m-d' }}"{% endif %}
+                    ></duet-date-picker>
                 </p>
                 {% for error in form.first_published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>
@@ -141,7 +145,11 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_published_date">{% trans "Published date:" %}</label>
-                    <duet-date-picker identifier="id_published_date" name="published_date"{% if form.published_date.value %} value="{{ form.published_date.value|date:'Y-m-d' }}"{% endif %}></duet-date-picker>
+                    <duet-date-picker
+                        identifier="id_published_date"
+                        name="published_date"
+                        {% if form.published_date.value %}value="{{ form.published_date.value|date:'Y-m-d' }}"{% endif %}
+                    ></duet-date-picker>
                 </p>
                 {% for error in form.published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>

--- a/bookwyrm/templates/book/edit_book.html
+++ b/bookwyrm/templates/book/edit_book.html
@@ -133,7 +133,7 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_first_published_date">{% trans "First published date:" %}</label>
-                    <input type="date" name="first_published_date" class="input" id="id_first_published_date"{% if form.first_published_date.value %} value="{{ form.first_published_date.value|date:'Y-m-d' }}"{% endif %}>
+                    <duet-date-picker identifier="id_first_published_date" name="first_published_date"{% if form.first_published_date.value %} value="{{ form.first_published_date.value|date:'Y-m-d' }}"{% endif %}></duet-date-picker>
                 </p>
                 {% for error in form.first_published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>
@@ -141,7 +141,7 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_published_date">{% trans "Published date:" %}</label>
-                    <input type="date" name="published_date" class="input" id="id_published_date"{% if form.published_date.value %} value="{{ form.published_date.value|date:'Y-m-d'}}"{% endif %}>
+                    <duet-date-picker identifier="id_published_date" name="published_date"{% if form.published_date.value %} value="{{ form.published_date.value|date:'Y-m-d' }}"{% endif %}></duet-date-picker>
                 </p>
                 {% for error in form.published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>
@@ -244,4 +244,8 @@
     {% endif %}
 </form>
 
+{% endblock %}
+
+{% block scripts %}
+{% include 'snippets/datepicker_js.html' %}
 {% endblock %}

--- a/bookwyrm/templates/book/editions.html
+++ b/bookwyrm/templates/book/editions.html
@@ -51,3 +51,7 @@
     {% include 'snippets/pagination.html' with page=editions path=request.path %}
 </div>
 {% endblock %}
+
+{% block scripts %}
+{% include 'snippets/datepicker_js.html' %}
+{% endblock %}

--- a/bookwyrm/templates/edit_author.html
+++ b/bookwyrm/templates/edit_author.html
@@ -81,3 +81,7 @@
 </form>
 
 {% endblock %}
+
+{% block scripts %}
+{% include 'snippets/datepicker_js.html' %}
+{% endblock %}

--- a/bookwyrm/templates/feed/feed_layout.html
+++ b/bookwyrm/templates/feed/feed_layout.html
@@ -105,4 +105,5 @@
 
 {% block scripts %}
 <script src="/static/js/vendor/tabs.js"></script>
+{% include 'snippets/datepicker_js.html' %}
 {% endblock %}

--- a/bookwyrm/templates/get_started/books.html
+++ b/bookwyrm/templates/get_started/books.html
@@ -64,3 +64,7 @@
 </form>
 {% endblock %}
 
+
+{% block scripts %}
+{% include 'snippets/datepicker_js.html' %}
+{% endblock %}

--- a/bookwyrm/templates/snippets/datepicker_js.html
+++ b/bookwyrm/templates/snippets/datepicker_js.html
@@ -1,0 +1,3 @@
+<script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.3.0/dist/duet/duet.esm.js"></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.3.0/dist/duet/duet.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.3.0/dist/duet/themes/default.css" />

--- a/bookwyrm/templates/snippets/readthrough_form.html
+++ b/bookwyrm/templates/snippets/readthrough_form.html
@@ -5,7 +5,11 @@
 <div class="field">
     <label class="label">
         {% trans "Started reading" %}
-        <input type="date" name="start_date" class="input" id="id_start_date-{{ readthrough.id }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
+        <duet-date-picker
+            identifier="id_start_date-{{ readthrough.id }}"
+            name="start_date"
+            value="{{ readthrough.start_date | date:'Y-m-d' }}">
+        </duet-date-picker>
     </label>
 </div>
 {# Only show progress for editing existing readthroughs #}
@@ -28,6 +32,10 @@
 <div class="field">
     <label class="label">
         {% trans "Finished reading" %}
-        <input type="date" name="finish_date" class="input" id="id_finish_date-{{ readthrough.id }}" value="{{ readthrough.finish_date | date:"Y-m-d" }}">
+        <duet-date-picker
+            identifier="id_finish_date-{{ readthrough.id }}"
+            name="finish_date"
+            value="{{ readthrough.finish_date | date:'Y-m-d' }}">
+        </duet-date-picker>
     </label>
 </div>

--- a/bookwyrm/templates/snippets/shelve_button/finish_reading_modal.html
+++ b/bookwyrm/templates/snippets/shelve_button/finish_reading_modal.html
@@ -17,13 +17,21 @@
     <div class="field">
         <label class="label">
             {% trans "Started reading" %}
-            <input type="date" name="start_date" class="input" id="finish_id_start_date-{{ uuid }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
+            <duet-date-picker
+                identifier="id_start_date-{{ uuid }}"
+                name="start_date"
+                value="{{ readthrough.start_date | date:'Y-m-d' }}"
+            ></duet-date-picker>
         </label>
     </div>
     <div class="field">
         <label class="label">
             {% trans "Finished reading" %}
-            <input type="date" name="finish_date" class="input" id="id_finish_date-{{ uuid }}" value="{% now "Y-m-d" %}">
+            <duet-date-picker
+                identifier="id_finish_date-{{ uuid }}"
+                name="finish_date"
+                value="{{ readthrough.finish_date | date:'Y-m-d' }}"
+            ></duet-date-picker>
         </label>
     </div>
 </section>

--- a/bookwyrm/templates/snippets/shelve_button/start_reading_modal.html
+++ b/bookwyrm/templates/snippets/shelve_button/start_reading_modal.html
@@ -15,7 +15,11 @@
     <div class="field">
         <label class="label">
             {% trans "Started reading" %}
-            <input type="date" name="start_date" class="input" id="start_id_start_date-{{ uuid }}" value="{% now "Y-m-d" %}">
+            <duet-date-picker
+                identifier="start_id_start_date-{{ uuid }}"
+                name="start_date"
+                value="{% now "Y-m-d" %}"
+            ></duet-date-picker>
         </label>
     </div>
 </section>

--- a/bookwyrm/templates/user/layout.html
+++ b/bookwyrm/templates/user/layout.html
@@ -81,3 +81,8 @@
 {% block panel %}{% endblock %}
 
 {% endblock %}
+
+
+{% block scripts %}
+{% include 'snippets/datepicker_js.html' %}
+{% endblock %}

--- a/bookwyrm/tests/views/test_book.py
+++ b/bookwyrm/tests/views/test_book.py
@@ -47,39 +47,6 @@ class BookViews(TestCase):
         )
         models.SiteSettings.objects.create()
 
-    def test_date_regression(self):
-        """ensure that creating a new book actually saves the published date fields
-
-        this was initially a regression due to using a custom date picker tag
-        """
-        first_published_date = "2021-04-20"
-        published_date = "2022-04-20"
-        self.local_user.groups.add(self.group)
-        view = views.EditBook.as_view()
-        form = forms.EditionForm(
-            {
-                "title": "New Title",
-                "last_edited_by": self.local_user.id,
-                "first_published_date": first_published_date,
-                "published_date": published_date,
-            }
-        )
-        request = self.factory.post("", form.data)
-        request.user = self.local_user
-
-        with patch("bookwyrm.connectors.connector_manager.local_search"):
-            result = view(request)
-        result.render()
-
-        self.assertContains(
-            result,
-            f'<input type="date" name="first_published_date" class="input" id="id_first_published_date" value="{first_published_date}">',
-        )
-        self.assertContains(
-            result,
-            f'<input type="date" name="published_date" class="input" id="id_published_date" value="{published_date}">',
-        )
-
     def test_book_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Book.as_view()


### PR DESCRIPTION
This switches from using the browser native datepicker, which isn't supported by Safari, to the [Duet datepicker](https://github.com/duetds/date-picker). It works well for me in VoiceOver, and should be well supported by other screen readers. And as a bonus it looks nice visually. (cc @rkingett)

Fixes #1039 
Fixes #1044 