### PR TITLE
Display author biography with style. :sunglasses:

### DIFF
--- a/bookwyrm/templates/author.html
+++ b/bookwyrm/templates/author.html
@@ -22,12 +22,11 @@
     </div>
 </div>
 
-<div class="block">
+<div class="block content">
     {% if author.bio %}
-    <p>
         {{ author.bio | to_markdown | safe }}
-    </p>
     {% endif %}
+
     {% if author.wikipedia_link %}
     <p><a href="{{ author.wikipedia_link }}" rel=”noopener” target="_blank">{% trans "Wikipedia" %}</a></p>
     {% endif %}


### PR DESCRIPTION
Markdown is parsed but styles are non existent for the generated markup on the author biography.

This PR:

- fixes an HTML oddity (`<p><p>…</p></p>`)
- displays the generated content with Bulma styles (`content`)