### PR TITLE
Filter for concise status timestamps

### DIFF
--- a/bookwyrm/templates/snippets/status/status_header.html
+++ b/bookwyrm/templates/snippets/status/status_header.html
@@ -92,7 +92,7 @@
 
         </h3>
         <p class="is-size-7 is-flex is-align-items-center">
-            <a href="{{ status.remote_id }}">{{ status.published_date|timesince }}</a>
+            <a href="{{ status.remote_id }}">{{ status.published_date|published_date }}</a>
             {% if status.progress %}
             <span class="ml-1">
             {% if status.progress_mode == 'PG' %}

--- a/bookwyrm/templatetags/status_display.py
+++ b/bookwyrm/templatetags/status_display.py
@@ -1,6 +1,8 @@
 """ template filters """
+from dateutil.relativedelta import relativedelta
 from django import template
-
+from django.contrib.humanize.templatetags.humanize import naturaltime, naturalday
+from django.utils import timezone
 from bookwyrm import models
 from bookwyrm.templatetags.utilities import get_user_identifier
 
@@ -41,3 +43,17 @@ def get_parent(status):
 def get_boosted(boost):
     """load a boosted status. have to do this or it won't get foreign keys"""
     return models.Status.objects.select_subclasses().get(id=boost.boosted_status.id)
+
+
+@register.filter(name="published_date")
+def get_published_date(date):
+    """less verbose combo of humanize filters"""
+    if not date:
+        return ""
+    now = timezone.now()
+    delta = relativedelta(now, date)
+    if delta.years:
+        return naturalday(date)
+    if delta.days:
+        return naturalday(date, "M j")
+    return naturaltime(date)


### PR DESCRIPTION
Outputs:
`4 minutes ago`
`11 hours ago`
`May 6`
`July 9, 2019`

The timestamps are translated in Django's internals, so they should work in all the available locales. Fixes #1029 