### PR TITLE
Front-end: Better forms

### DIFF
--- a/bookwyrm/templates/author/edit_author.html
+++ b/bookwyrm/templates/author/edit_author.html
@@ -29,67 +29,85 @@
     <div class="columns">
         <div class="column">
             <h2 class="title is-4">{% trans "Metadata" %}</h2>
-            <p class="mb-2"><label class="label" for="id_name">{% trans "Name:" %}</label> {{ form.name }}</p>
-            {% for error in form.name.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+            <div class="field">
+                <label class="label" for="id_name">{% trans "Name:" %}</label>
+                {{ form.name }}
+                {% for error in form.name.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
-            <p class="mb-2">
+            <div class="field">
                 <label class="label" for="id_aliases">{% trans "Aliases:" %}</label>
                 {{ form.aliases }}
                 <span class="help">{% trans "Separate multiple values with commas." %}</span>
-            </p>
-            {% for error in form.aliases.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+                {% for error in form.aliases.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
-            <p class="mb-2"><label class="label" for="id_bio">{% trans "Bio:" %}</label> {{ form.bio }}</p>
-            {% for error in form.bio.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+            <div class="field">
+                <label class="label" for="id_bio">{% trans "Bio:" %}</label>
+                {{ form.bio }}
+                {% for error in form.bio.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
-            <p class="mb-2"><label class="label" for="id_wikipedia_link">{% trans "Wikipedia link:" %}</label> {{ form.wikipedia_link }}</p>
+            <p class="field"><label class="label" for="id_wikipedia_link">{% trans "Wikipedia link:" %}</label> {{ form.wikipedia_link }}</p>
             {% for error in form.wikipedia_link.errors %}
             <p class="help is-danger">{{ error | escape }}</p>
             {% endfor %}
 
-            <p class="mb-2">
+            <div class="field">
                 <label class="label" for="id_born">{% trans "Birth date:" %}</label>
                 <input type="date" name="born" value="{{ form.born.value|date:'Y-m-d' }}" class="input" id="id_born">
-            </p>
-            {% for error in form.born.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+                {% for error in form.born.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
-            <p class="mb-2">
+            <div class="field">
                 <label class="label" for="id_died">{% trans "Death date:" %}</label>
                 <input type="date" name="died" value="{{ form.died.value|date:'Y-m-d' }}" class="input" id="id_died">
-            </p>
-            {% for error in form.died.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+                {% for error in form.died.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
         </div>
         <div class="column">
             <h2 class="title is-4">{% trans "Author Identifiers" %}</h2>
-            <p class="mb-2"><label class="label" for="id_openlibrary_key">{% trans "Openlibrary key:" %}</label> {{ form.openlibrary_key }}</p>
-            {% for error in form.openlibrary_key.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+            <div class="field">
+                <label class="label" for="id_openlibrary_key">{% trans "Openlibrary key:" %}</label>
+                {{ form.openlibrary_key }}
+                {% for error in form.openlibrary_key.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
-            <p class="mb-2"><label class="label" for="id_inventaire_id">{% trans "Inventaire ID:" %}</label> {{ form.inventaire_id }}</p>
-            {% for error in form.inventaire_id.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+            <div class="field">
+                <label class="label" for="id_inventaire_id">{% trans "Inventaire ID:" %}</label>
+                {{ form.inventaire_id }}
+                {% for error in form.inventaire_id.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
-            <p class="mb-2"><label class="label" for="id_librarything_key">{% trans "Librarything key:" %}</label> {{ form.librarything_key }}</p>
-            {% for error in form.librarything_key.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+            <div class="field">
+                <label class="label" for="id_librarything_key">{% trans "Librarything key:" %}</label>
+                {{ form.librarything_key }}
+                {% for error in form.librarything_key.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
-            <p class="mb-2"><label class="label" for="id_goodreads_key">{% trans "Goodreads key:" %}</label> {{ form.goodreads_key }}</p>
-            {% for error in form.goodreads_key.errors %}
-            <p class="help is-danger">{{ error | escape }}</p>
-            {% endfor %}
+            <div class="field">
+                <label class="label" for="id_goodreads_key">{% trans "Goodreads key:" %}</label>
+                {{ form.goodreads_key }}
+                {% for error in form.goodreads_key.errors %}
+                <p class="help is-danger">{{ error | escape }}</p>
+                {% endfor %}
+            </div>
 
         </div>
     </div>

--- a/bookwyrm/templates/book/edit_book.html
+++ b/bookwyrm/templates/book/edit_book.html
@@ -14,11 +14,25 @@
         {% endif %}
     </h1>
     {% if book %}
-    <div>
-        <p>{% trans "Added:" %} {{ book.created_date | naturaltime }}</p>
-        <p>{% trans "Updated:" %} {{ book.updated_date | naturaltime }}</p>
-        <p>{% trans "Last edited by:" %} <a href="{{ book.last_edited_by.remote_id }}">{{ book.last_edited_by.display_name }}</a></p>
-    </div>
+    <dl>
+        <div class="is-flex">
+            <dt class="has-text-weight-semibold">{% trans "Added:" %}</dt>
+            <dd class="ml-2">{{ book.created_date | naturaltime }}</dd>
+        </div>
+
+        <div class="is-flex">
+            <dt class="has-text-weight-semibold">{% trans "Updated:" %}</dt>
+            <dd class="ml-2">{{ book.updated_date | naturaltime }}</dd>
+        </div>
+
+        {% if book.last_edited_by %}
+        <div class="is-flex">
+            <dt class="has-text-weight-semibold">{% trans "Last edited by:" %}</dt>
+            <dd class="ml-2"><a href="{{ book.last_edited_by.remote_id }}">{{ book.last_edited_by.display_name }}</a></dd>
+        </div>
+        {% endif %}
+
+    </dl>
     {% endif %}
 </header>
 
@@ -38,21 +52,28 @@
     {% if confirm_mode %}
     <div class="box">
         <h2 class="title is-4">{% trans "Confirm Book Info" %}</h2>
-        <div class="columns">
+        <div class="columns mb-4">
             {% if author_matches %}
             <input type="hidden" name="author-match-count" value="{{ author_matches|length }}">
             <div class="column is-half">
                 {% for author in author_matches %}
-                <fieldset class="mb-4">
-                    <legend class="title is-5 mb-1">{% blocktrans with name=author.name %}Is "{{ name }}" an existing author?{% endblocktrans %}</legend>
+                <fieldset>
+                    <legend class="title is-5 mb-1">
+                        {% blocktrans with name=author.name %}Is "{{ name }}" an existing author?{% endblocktrans %}
+                    </legend>
                     {% with forloop.counter0 as counter %}
                     {% for match in author.matches %}
-                    <label><input type="radio" name="author_match-{{ counter }}" value="{{ match.id }}" required> {{ match.name }}</label>
+                    <label class="label mb-2">
+                        <input type="radio" name="author_match-{{ counter }}" value="{{ match.id }}" required>
+                        {{ match.name }}
+                    </label>
                     <p class="help">
                         <a href="{{ match.local_path }}" target="_blank">{% blocktrans with book_title=match.book_set.first.title %}Author of <em>{{ book_title }}</em>{% endblocktrans %}</a>
                     </p>
                     {% endfor %}
-                    <label><input type="radio" name="author_match-{{ counter }}" value="{{ author.name }}" required> {% trans "This is a new author" %}</label>
+                    <label class="label">
+                        <input type="radio" name="author_match-{{ counter }}" value="{{ author.name }}" required> {% trans "This is a new author" %}
+                    </label>
                     {% endwith %}
                 </fieldset>
                 {% endfor %}
@@ -64,11 +85,17 @@
             {% if not book %}
             <div class="column is-half">
                 <fieldset>
-                    <legend class="title is-5 mb-1">{% trans "Is this an edition of an existing work?" %}</legend>
+                    <legend class="title is-5 mb-1">
+                        {% trans "Is this an edition of an existing work?" %}
+                    </legend>
                     {% for match in book_matches %}
-                    <label class="label"><input type="radio" name="parent_work" value="{{ match.parent_work.id }}"> {{ match.parent_work.title }}</label>
+                    <label class="label">
+                        <input type="radio" name="parent_work" value="{{ match.parent_work.id }}"> {{ match.parent_work.title }}
+                    </label>
                     {% endfor %}
-                    <label><input type="radio" name="parent_work" value="0" required> {% trans "This is a new work" %}</label>
+                    <label>
+                        <input type="radio" name="parent_work" value="0" required> {% trans "This is a new work" %}
+                    </label>
                 </fieldset>
             </div>
             {% endif %}
@@ -89,76 +116,79 @@
             <section class="block">
                 <h2 class="title is-4">{% trans "Metadata" %}</h2>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_title">{% trans "Title:" %}</label>
                     <input type="text" name="title" value="{{ form.title.value|default:'' }}" maxlength="255" class="input" required="" id="id_title">
-                </p>
-                {% for error in form.title.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.title.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_subtitle">{% trans "Subtitle:" %}</label>
                     <input type="text" name="subtitle" value="{{ form.subtitle.value|default:'' }}" maxlength="255" class="input" id="id_subtitle">
-                </p>
-                {% for error in form.subtitle.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.subtitle.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2"><label class="label" for="id_description">{% trans "Description:" %}</label> {{ form.description }} </p>
-                {% for error in form.description.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_description">{% trans "Description:" %}</label>
+                    {{ form.description }}
+                    {% for error in form.description.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_series">{% trans "Series:" %}</label>
                     <input type="text" class="input" name="series" id="id_series" value="{{ form.series.value|default:'' }}">
-                </p>
-                {% for error in form.series.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.series.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_series_number">{% trans "Series number:" %}</label>
                     {{ form.series_number }}
-                </p>
-                {% for error in form.series_number.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.series_number.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_languages">{% trans "Languages:" %}</label>
                     {{ form.languages }}
                     <span class="help">{% trans "Separate multiple values with commas." %}</span>
-                </p>
-                {% for error in form.languages.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.languages.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_publishers">{% trans "Publisher:" %}</label>
                     {{ form.publishers }}
                     <span class="help">{% trans "Separate multiple values with commas." %}</span>
-                </p>
-                {% for error in form.publishers.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.publishers.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_first_published_date">{% trans "First published date:" %}</label>
                     <input type="date" name="first_published_date" class="input" id="id_first_published_date"{% if form.first_published_date.value %} value="{{ form.first_published_date.value|date:'Y-m-d' }}"{% endif %}>
-                </p>
-                {% for error in form.first_published_date.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.first_published_date.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2">
+                <div class="field">
                     <label class="label" for="id_published_date">{% trans "Published date:" %}</label>
                     <input type="date" name="published_date" class="input" id="id_published_date"{% if form.published_date.value %} value="{{ form.published_date.value|date:'Y-m-d'}}"{% endif %}>
-                </p>
-                {% for error in form.published_date.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                    {% for error in form.published_date.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
             </section>
 
             <section class="block">
@@ -166,16 +196,23 @@
                 {% if book.authors.exists %}
                 <fieldset>
                     {% for author in book.authors.all %}
-                    <label class="label mb-2">
-                        <input type="checkbox" name="remove_authors" value="{{ author.id }}" {% if author.id|stringformat:"i" in remove_authors %}checked{% endif %}>
-                        {% blocktrans with name=author.name path=author.local_path %}Remove <a href="{{ path }}">{{ name }}</a>{% endblocktrans %}
-                    </label>
+                    <div class="is-flex is-justify-content-space-between">
+                        <label class="label mb-2">
+                            <input type="checkbox" name="remove_authors" value="{{ author.id }}" {% if author.id|stringformat:"i" in remove_authors %}checked{% endif %}>
+                            {% blocktrans with name=author.name %}Remove {{ name }}{% endblocktrans %}
+                        </label>
+                        <p class="help">
+                            <a href="{{ author.local_path }}">{% blocktrans with name=author.name %}Author page for {{ name }}{% endblocktrans %}</a>
+                        </p>
+                    </div>
                     {% endfor %}
                 </fieldset>
                 {% endif %}
-                <label class="label" for="id_add_author">{% trans "Add Authors:" %}</label>
-                <input class="input" type="text" name="add_author" id="id_add_author" placeholder="{% trans 'John Doe, Jane Smith' %}" value="{{ add_author }}" {% if confirm_mode %}readonly{% endif %}>
-                <span class="help">{% trans "Separate multiple values with commas." %}</span>
+                <div class="field">
+                    <label class="label" for="id_add_author">{% trans "Add Authors:" %}</label>
+                    <input class="input" type="text" name="add_author" id="id_add_author" placeholder="{% trans 'John Doe, Jane Smith' %}" value="{{ add_author }}" {% if confirm_mode %}readonly{% endif %}>
+                    <span class="help">{% trans "Separate multiple values with commas." %}</span>
+                </div>
             </section>
         </div>
 
@@ -188,17 +225,17 @@
 
                 <div class="column">
                     <div class="block">
-                        <p>
+                        <div class="field">
                             <label class="label" for="id_cover">{% trans "Upload cover:" %}</label>
                             {{ form.cover }}
-                        </p>
+                        </div>
                         {% if book %}
-                        <p>
+                        <div class="field">
                             <label class="label" for="id_cover_url">
                                 {% trans "Load cover from url:" %}
                             </label>
                             <input class="input" name="cover-url" id="id_cover_url">
-                        </p>
+                        </div>
                         {% endif %}
                         {% for error in form.cover.errors %}
                         <p class="help is-danger">{{ error | escape }}</p>
@@ -209,51 +246,72 @@
 
             <div class="block">
                 <h2 class="title is-4">{% trans "Physical Properties" %}</h2>
-                <p class="mb-2"><label class="label" for="id_physical_format">{% trans "Format:" %}</label> {{ form.physical_format }} </p>
-                {% for error in form.physical_format.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
-                {% for error in form.physical_format.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_physical_format">{% trans "Format:" %}</label>
+                    {{ form.physical_format }}
+                    {% for error in form.physical_format.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2"><label class="label" for="id_pages">{% trans "Pages:" %}</label> {{ form.pages }} </p>
-                {% for error in form.pages.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_pages">{% trans "Pages:" %}</label>
+                    {{ form.pages }}
+                    {% for error in form.pages.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
             </div>
 
             <div class="block">
                 <h2 class="title is-4">{% trans "Book Identifiers" %}</h2>
-                <p class="mb-2"><label class="label" for="id_isbn_13">{% trans "ISBN 13:" %}</label> {{ form.isbn_13 }} </p>
-                {% for error in form.isbn_13.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_isbn_13">{% trans "ISBN 13:" %}</label>
+                    {{ form.isbn_13 }}
+                    {% for error in form.isbn_13.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2"><label class="label" for="id_isbn_10">{% trans "ISBN 10:" %}</label> {{ form.isbn_10 }} </p>
-                {% for error in form.isbn_10.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_isbn_10">{% trans "ISBN 10:" %}</label>
+                    {{ form.isbn_10 }}
+                    {% for error in form.isbn_10.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2"><label class="label" for="id_openlibrary_key">{% trans "Openlibrary ID:" %}</label> {{ form.openlibrary_key }} </p>
-                {% for error in form.openlibrary_key.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_openlibrary_key">{% trans "Openlibrary ID:" %}</label>
+                    {{ form.openlibrary_key }}
+                    {% for error in form.openlibrary_key.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2"><label class="label" for="id_inventaire_id">{% trans "Inventaire ID:" %}</label> {{ form.inventaire_id }} </p>
-                {% for error in form.inventaire_id.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_inventaire_id">{% trans "Inventaire ID:" %}</label>
+                    {{ form.inventaire_id }}
+                    {% for error in form.inventaire_id.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2"><label class="label" for="id_oclc_number">{% trans "OCLC Number:" %}</label> {{ form.oclc_number }} </p>
-                {% for error in form.oclc_number.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_oclc_number">{% trans "OCLC Number:" %}</label>
+                    {{ form.oclc_number }}
+                    {% for error in form.oclc_number.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
 
-                <p class="mb-2"><label class="label" for="id_asin">{% trans "ASIN:" %}</label> {{ form.asin }} </p>
-                {% for error in form.ASIN.errors %}
-                <p class="help is-danger">{{ error | escape }}</p>
-                {% endfor %}
+                <div class="field">
+                    <label class="label" for="id_asin">{% trans "ASIN:" %}</label>
+                    {{ form.asin }}
+                    {% for error in form.ASIN.errors %}
+                    <p class="help is-danger">{{ error | escape }}</p>
+                    {% endfor %}
+                </div>
             </div>
         </div>
     </div>
@@ -261,7 +319,7 @@
     {% if not confirm_mode %}
     <div class="block">
         <button class="button is-primary" type="submit">{% trans "Save" %}</button>
-        <a class="button" href="{{ book.local_path}}">{% trans "Cancel" %}</a>
+        <a class="button" href="{{ book.local_path }}">{% trans "Cancel" %}</a>
     </div>
     {% endif %}
 </form>

--- a/bookwyrm/templates/import.html
+++ b/bookwyrm/templates/import.html
@@ -41,8 +41,8 @@
                 </label>
             </div>
             <div class="field">
-                <label class="label">
-                    <p>{% trans "Privacy setting for imported reviews:" %}</p>
+                <label>
+                    <span class="label">{% trans "Privacy setting for imported reviews:" %}</span>
                     {% include 'snippets/privacy_select.html' with no_label=True %}
                 </label>
             </div>

--- a/bookwyrm/templates/import_status.html
+++ b/bookwyrm/templates/import_status.html
@@ -8,13 +8,17 @@
 <div class="block">
     <h1 class="title">{% trans "Import Status" %}</h1>
 
-    <p>
-        {% trans "Import started:" %} {{ job.created_date | naturaltime }}
-    </p>
-    {% if job.complete %}
-    <p>
-        {% trans "Import completed:" %} {{ task.date_done | naturaltime }}
-    </p>
+    <dl>
+        <div class="is-flex">
+            <dt class="has-text-weight-medium">{% trans "Import started:" %}</dt>
+            <dd class="ml-2">{{ job.created_date | naturaltime }}</dd>
+        </div>
+        {% if job.complete %}
+        <div class="is-flex">
+            <dt class="has-text-weight-medium">{% trans "Import completed:" %}</dt>
+            <dd class="ml-2">{{ task.date_done | naturaltime }}</dd>
+        </div>
+    </dl>
     {% elif task.failed %}
     <div class="notification is-danger">{% trans "TASK FAILED" %}</div>
     {% endif %}
@@ -22,8 +26,9 @@
 
 <div class="block">
     {% if not job.complete %}
-    {% trans "Import still in progress." %}
     <p>
+        {% trans "Import still in progress." %}
+        <br/>
         {% trans "(Hit reload to update!)" %}
     </p>
     {% endif %}
@@ -49,16 +54,13 @@
         <fieldset id="failed-imports">
             <ul>
             {% for item in failed_items %}
-                <li class="pb-1">
-                    <input class="checkbox" type="checkbox" name="import_item" value="{{ item.id }}" id="import-item-{{ item.id }}">
-                    <label for="import-item-{{ item.id }}">
-                        Line {{ item.index }}:
-                        <strong>{{ item.data.Title }}</strong> by
-                        {{ item.data.Author }}
-                    </label>
-                    <p>
+                <li class="mb-2 is-flex is-align-items-start">
+                    <input class="checkbox mt-1" type="checkbox" name="import_item" value="{{ item.id }}" id="import-item-{{ item.id }}">
+                    <label class="ml-1" for="import-item-{{ item.id }}">
+                        {% blocktrans with index=item.index title=item.data.Title author=item.data.Author %}Line {{ index }}: <strong>{{ title }}</strong> by {{ author }}{% endblocktrans %}
+                        <br/>
                         {{ item.fail_reason }}.
-                    </p>
+                    </label>
                 </li>
             {% endfor %}
             </ul>

--- a/bookwyrm/templates/settings/edit_server.html
+++ b/bookwyrm/templates/settings/edit_server.html
@@ -26,14 +26,14 @@
     {% csrf_token %}
     <div class="columns">
         <div class="column is-half">
-            <div>
+            <div class="field">
                 <label class="label" for="id_server_name">{% trans "Instance:" %}</label>
                 <input type="text" name="server_name" maxlength="255" class="input" required id="id_server_name" value="{{ form.server_name.value|default:'' }}" placeholder="domain.com">
                 {% for error in form.server_name.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>
                 {% endfor %}
             </div>
-            <div>
+            <div class="field">
                 <label class="label" for="id_status">{% trans "Status:" %}</label>
                 <div class="select">
                     <select name="status" class="" id="id_status">
@@ -44,14 +44,14 @@
             </div>
         </div>
         <div class="column is-half">
-            <div>
+            <div class="field">
                 <label class="label" for="id_application_type">{% trans "Software:" %}</label>
                 <input type="text" name="application_type" maxlength="255" class="input" id="id_application_type" value="{{ form.application_type.value|default:'' }}">
                 {% for error in form.application_type.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>
                 {% endfor %}
             </div>
-            <div>
+            <div class="field">
                 <label class="label" for="id_application_version">{% trans "Version:" %}</label>
                 <input type="text" name="application_version" maxlength="255" class="input" id="id_application_version" value="{{ form.application_version.value|default:'' }}">
                 {% for error in form.application_version.errors %}
@@ -60,10 +60,10 @@
             </div>
         </div>
     </div>
-    <p>
+    <div class="field">
         <label class="label" for="id_notes">{% trans "Notes:" %}</label>
         <textarea name="notes" cols="None" rows="None" class="textarea" id="id_notes">{{ form.notes.value|default:'' }}</textarea>
-    </p>
+    </div>
 
     <button type="submit" class="button is-primary">{% trans "Save" %}</button>
 </form>

--- a/bookwyrm/templates/settings/site.html
+++ b/bookwyrm/templates/settings/site.html
@@ -11,23 +11,23 @@
     {% csrf_token %}
     <section class="block" id="instance-info">
         <h2 class="title is-4">{% trans "Instance Info" %}</h2>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_name">{% trans "Instance Name:" %}</label>
             {{ site_form.name }}
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_instance_tagline">{% trans "Tagline:" %}</label>
             {{ site_form.instance_tagline }}
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_instance_description">{% trans "Instance description:" %}</label>
             {{ site_form.instance_description }}
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_code_of_conduct">{% trans "Code of conduct:" %}</label>
             {{ site_form.code_of_conduct }}
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_privacy_policy">{% trans "Privacy Policy:" %}</label>
             {{ site_form.privacy_policy }}
         </div>
@@ -57,19 +57,19 @@
 
     <section class="block" id="footer">
         <h2 class="title is-4">{% trans "Footer Content" %}</h2>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_support_link">{% trans "Support link:" %}</label>
             <input type="text" name="support_link" maxlength="255" class="input" id="id_support_link" placeholder="https://www.patreon.com/bookwyrm"{% if site.support_link %} value="{{ site.support_link  }}"{% endif %}>
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_support_title">{% trans "Support title:" %}</label>
             <input type="text" name="support_title" maxlength="100" class="input" id="id_support_title" placeholder="Patreon"{% if site.support_title %} value="{{ site.support_title }}"{% endif %}>
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_admin_email">{% trans "Admin email:" %}</label>
             {{ site_form.admin_email }}
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_footer_item">{% trans "Additional info:" %}</label>
             {{ site_form.footer_item }}
         </div>
@@ -79,15 +79,19 @@
 
     <section class="block" id="registration">
         <h2 class="title is-4">{% trans "Registration" %}</h2>
-        <div class="control">
-            <label class="label" for="id_allow_registration">{% trans "Allow registration:" %}
-            {{ site_form.allow_registration }}
+        <div class="field">
+            <label class="label" for="id_allow_registration">
+                {{ site_form.allow_registration }}
+                {% trans "Allow registration" %}
+            </label>
         </div>
-        <div class="control">
-            <label class="label" for="id_allow_invite_requests">{% trans "Allow invite requests:" %}
-            {{ site_form.allow_invite_requests }}
+        <div class="field">
+            <label class="label" for="id_allow_invite_requests">
+                {{ site_form.allow_invite_requests }}
+                {% trans "Allow invite requests" %}
+            </label>
         </div>
-        <div class="control">
+        <div class="field">
             <label class="label" for="id_registration_closed_text">{% trans "Registration closed text:" %}</label>
             {{ site_form.registration_closed_text }}
         </div>

--- a/bookwyrm/templates/snippets/readthrough_form.html
+++ b/bookwyrm/templates/snippets/readthrough_form.html
@@ -3,10 +3,10 @@
 <input type="hidden" name="id" value="{{ readthrough.id }}">
 <input type="hidden" name="book" value="{{ book.id }}">
 <div class="field">
-    <label class="label" tabindex="0" id="add-readthrough-focus">
+    <label class="label" tabindex="0" id="add-readthrough-focus" for="id_start_date-{{ readthrough.id }}">
         {% trans "Started reading" %}
-        <input type="date" name="start_date" class="input" id="id_start_date-{{ readthrough.id }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
     </label>
+    <input type="date" name="start_date" class="input" id="id_start_date-{{ readthrough.id }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
 </div>
 {# Only show progress for editing existing readthroughs #}
 {% if readthrough.id and not readthrough.finish_date %}
@@ -26,8 +26,8 @@
 </div>
 {% endif %}
 <div class="field">
-    <label class="label">
+    <label class="label" for="id_finish_date-{{ readthrough.id }}">
         {% trans "Finished reading" %}
-        <input type="date" name="finish_date" class="input" id="id_finish_date-{{ readthrough.id }}" value="{{ readthrough.finish_date | date:"Y-m-d" }}">
     </label>
+    <input type="date" name="finish_date" class="input" id="id_finish_date-{{ readthrough.id }}" value="{{ readthrough.finish_date | date:"Y-m-d" }}">
 </div>

--- a/bookwyrm/templates/snippets/shelve_button/finish_reading_modal.html
+++ b/bookwyrm/templates/snippets/shelve_button/finish_reading_modal.html
@@ -15,16 +15,16 @@
     {% csrf_token %}
     <input type="hidden" name="id" value="{{ readthrough.id }}">
     <div class="field">
-        <label class="label">
+        <label class="label" for="finish_id_start_date-{{ uuid }}">
             {% trans "Started reading" %}
-            <input type="date" name="start_date" class="input" id="finish_id_start_date-{{ uuid }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
         </label>
+        <input type="date" name="start_date" class="input" id="finish_id_start_date-{{ uuid }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
     </div>
     <div class="field">
-        <label class="label">
+        <label class="label" for="id_finish_date-{{ uuid }}">
             {% trans "Finished reading" %}
-            <input type="date" name="finish_date" class="input" id="id_finish_date-{{ uuid }}" value="{% now "Y-m-d" %}">
         </label>
+        <input type="date" name="finish_date" class="input" id="id_finish_date-{{ uuid }}" value="{% now "Y-m-d" %}">
     </div>
 </section>
 {% endblock %}

--- a/bookwyrm/templates/snippets/shelve_button/finish_reading_modal.html
+++ b/bookwyrm/templates/snippets/shelve_button/finish_reading_modal.html
@@ -38,7 +38,7 @@
         </label>
         {% include 'snippets/privacy_select.html' %}
     </div>
-    <div class="column">
+    <div class="column has-text-right">
         <button type="submit" class="button is-success">{% trans "Save" %}</button>
         {% trans "Cancel" as button_text %}
         {% include 'snippets/toggle/close_button.html' with text=button_text controls_text="finish-reading" controls_uid=uuid %}

--- a/bookwyrm/templates/snippets/shelve_button/start_reading_modal.html
+++ b/bookwyrm/templates/snippets/shelve_button/start_reading_modal.html
@@ -13,10 +13,10 @@
 <section class="modal-card-body">
     {% csrf_token %}
     <div class="field">
-        <label class="label">
+        <label class="label" for="start_id_start_date-{{ uuid }}">
             {% trans "Started reading" %}
-            <input type="date" name="start_date" class="input" id="start_id_start_date-{{ uuid }}" value="{% now "Y-m-d" %}">
         </label>
+        <input type="date" name="start_date" class="input" id="start_id_start_date-{{ uuid }}" value="{% now "Y-m-d" %}">
     </div>
 </section>
 {% endblock %}
@@ -30,7 +30,7 @@
         </label>
         {% include 'snippets/privacy_select.html' %}
     </div>
-    <div class="column">
+    <div class="column has-text-right">
         <button class="button is-success" type="submit">{% trans "Save" %}</button>
         {% trans "Cancel" as button_text %}
         {% include 'snippets/toggle/toggle_button.html' with text=button_text controls_text="start-reading" controls_uid=uuid %}

--- a/bookwyrm/templates/widgets/clearable_file_input_with_warning.html
+++ b/bookwyrm/templates/widgets/clearable_file_input_with_warning.html
@@ -1,3 +1,24 @@
 {% load i18n %}
-{% include "django/forms/widgets/clearable_file_input.html" %}
-<span class="help file-cta is-hidden file-too-big">{% trans "File exceeds maximum size: 10MB" %}</span>
+{% load utilities %}
+
+{% if widget.is_initial %}
+<p class="mb-1">
+  {{ widget.initial_text }}:
+  <a href="{{ widget.value.url }}">{{ widget.value|truncatepath:10 }}</a>
+</p>
+{% if not widget.required %}
+<p class="mb-1">
+  <label class="has-text-weight-normal">
+      <input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
+      {{ widget.clear_checkbox_label }}
+  </label>{% endif %}
+</p>
+<p class="mb-1">
+{{ widget.input_text }}:
+{% else %}
+<p class="mb-1">
+{% endif %}
+    <input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+    <span class="help file-cta is-hidden file-too-big">{% trans "File exceeds maximum size: 10MB" %}</span>
+</p>
+

--- a/bookwyrm/templates/widgets/clearable_file_input_with_warning.html
+++ b/bookwyrm/templates/widgets/clearable_file_input_with_warning.html
@@ -3,22 +3,22 @@
 
 {% if widget.is_initial %}
 <p class="mb-1">
-  {{ widget.initial_text }}:
-  <a href="{{ widget.value.url }}">{{ widget.value|truncatepath:10 }}</a>
+    {{ widget.initial_text }}:
+    <a href="{{ widget.value.url }}">{{ widget.value|truncatepath:10 }}</a>
 </p>
 {% if not widget.required %}
 <p class="mb-1">
-  <label class="has-text-weight-normal">
-      <input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
-      {{ widget.clear_checkbox_label }}
-  </label>{% endif %}
+    <label class="has-text-weight-normal">
+            <input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
+            {{ widget.clear_checkbox_label }}
+    </label>{% endif %}
 </p>
 <p class="mb-1">
 {{ widget.input_text }}:
 {% else %}
 <p class="mb-1">
 {% endif %}
-    <input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
-    <span class="help file-cta is-hidden file-too-big">{% trans "File exceeds maximum size: 10MB" %}</span>
+        <input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+        <span class="help file-cta is-hidden file-too-big">{% trans "File exceeds maximum size: 10MB" %}</span>
 </p>
 

--- a/bookwyrm/templatetags/utilities.py
+++ b/bookwyrm/templatetags/utilities.py
@@ -1,4 +1,5 @@
 """ template filters for really common utilities """
+import os
 from uuid import uuid4
 from django import template
 
@@ -33,3 +34,15 @@ def get_title(book):
 def comparison_bool(str1, str2):
     """idk why I need to write a tag for this, it reutrns a bool"""
     return str1 == str2
+
+
+@register.filter(is_safe=True)
+def truncatepath(value, arg):
+    """Truncate a path by removing all directories except the first and truncating ."""
+    path = os.path.normpath(value.name)
+    path_list = path.split(os.sep)
+    try:
+        length = int(arg)
+    except ValueError:  # invalid literal for int()
+        return path_list[-1]  # Fail silently.
+    return "%s/…%s" % (path_list[0], path_list[-1][-length:])


### PR DESCRIPTION
Some fixes and enhancements for many forms. 

- Use `class="field"` when possible for more consistent spacing between form fields
- Only allow `input[type="checkbox"]` or `input[type="checkbox"]` inside `<label>`
- Truncate file URL in clearable_file_input
- Place checkboxes and radios before label text
- Disallow interactive elments (like `a`) inside `label`