### PR TITLE
Add backend parameter to Celery initializer

### DIFF
--- a/bookwyrm/tasks.py
+++ b/bookwyrm/tasks.py
@@ -9,4 +9,5 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "celerywyrm.settings")
 app = Celery(
     "tasks",
     broker=settings.CELERY_BROKER,
+    backend=settings.CELERY_RESULT_BACKEND
 )

--- a/bookwyrm/tasks.py
+++ b/bookwyrm/tasks.py
@@ -7,7 +7,5 @@ from bookwyrm import settings
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "celerywyrm.settings")
 app = Celery(
-    "tasks",
-    broker=settings.CELERY_BROKER,
-    backend=settings.CELERY_RESULT_BACKEND
+    "tasks", broker=settings.CELERY_BROKER, backend=settings.CELERY_RESULT_BACKEND
 )


### PR DESCRIPTION
This fixed an error when viewing imports for my setup. I was getting the error mentioned in [this StackOverflow post](https://stackoverflow.com/questions/23215311/celery-with-rabbitmq-attributeerror-disabledbackend-object-has-no-attribute) when trying to access `/import/`. StackOverflow suggested adding the `backend` argument to Celery's initializer, so I did that, and it seemed to do the trick. 