### PR TITLE
Fix bw-dev resetdb, some tweaks to bw-dev

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -39,7 +39,9 @@ function makeitblack {
 }
 
 CMD=$1
-shift
+if [ -n "$CMD" ]; then
+    shift
+fi
 
 # show commands as they're executed
 set -x
@@ -56,9 +58,12 @@ case "$CMD" in
         ;;
     resetdb)
         clean
-        docker-compose up --build -d
+        # Start just the DB so no one else is using it
+        docker-compose up --build -d db
         execdb dropdb -U ${POSTGRES_USER} ${POSTGRES_DB}
         execdb createdb -U ${POSTGRES_USER} ${POSTGRES_DB}
+        # Now start up web so we can run the migrations
+        docker-compose up --build -d web
         initdb
         clean
         ;;
@@ -110,7 +115,14 @@ case "$CMD" in
     generate_preview_images)
         runweb python manage.py generate_preview_images $@
         ;;
+    runweb)
+        runweb "$@"
+        ;;
+    rundb)
+        rundb "$@"
+        ;;
     *)
+        set +x # No need to echo echo
         echo "Unrecognised command. Try: build, clean, up, initdb, resetdb, makemigrations, migrate, bash, shell, dbshell, restart_celery, test, pytest, test_report, black, populate_streams, generate_preview_images"
         ;;
 esac


### PR DESCRIPTION
The main fix here is for resetdb, it previously was failing to drop the
db for me, because `web` was up and running and using the database. This
commit spins up db by itself first so it can drop and re-create the
database successfully, then brings up web to run the migrations.

While I was in here, I also updated it so that when running `bw-dev`
without any command it will also print the helptext, rather than just
exiting silently, got rid of the double-echo of the helptext, and added
runweb/rundb commands to run arbitrary commands via bw-dev.

If the runweb/rundb commands seem like more complexity than they're worth we can take them back out, I just wanted them while I was tweaking things so I added them.