### PR TITLE
Recognize profile summary linebreaks + whitespace

### DIFF
--- a/bookwyrm/sanitize_html.py
+++ b/bookwyrm/sanitize_html.py
@@ -26,6 +26,8 @@ class InputHtmlParser(HTMLParser):  # pylint: disable=abstract-method
         self.output = []
         # if the html appears invalid, we just won't allow any at all
         self.allow_html = True
+        self.output.append(("data", "<style>.show-white-space{white-space:pre-wrap;}</style>"))
+        self.output.append(("data", "<span class=\"show-white-space\">"))
 
     def handle_starttag(self, tag, attrs):
         """check if the tag is valid"""
@@ -56,6 +58,7 @@ class InputHtmlParser(HTMLParser):  # pylint: disable=abstract-method
 
     def get_output(self):
         """convert the output from a list of tuples to a string"""
+        self.output.append(("data", "</span>"))
         if self.tag_stack:
             self.allow_html = False
         if not self.allow_html:

--- a/bookwyrm/sanitize_html.py
+++ b/bookwyrm/sanitize_html.py
@@ -26,8 +26,6 @@ class InputHtmlParser(HTMLParser):  # pylint: disable=abstract-method
         self.output = []
         # if the html appears invalid, we just won't allow any at all
         self.allow_html = True
-        self.output.append(("data", "<style>.show-white-space{white-space:pre-wrap;}</style>"))
-        self.output.append(("data", "<span class=\"show-white-space\">"))
 
     def handle_starttag(self, tag, attrs):
         """check if the tag is valid"""
@@ -58,7 +56,6 @@ class InputHtmlParser(HTMLParser):  # pylint: disable=abstract-method
 
     def get_output(self):
         """convert the output from a list of tuples to a string"""
-        self.output.append(("data", "</span>"))
         if self.tag_stack:
             self.allow_html = False
         if not self.allow_html:

--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -76,6 +76,10 @@ body {
     white-space: pre-wrap !important;
 }
 
+.display-inline p {
+    display: inline !important;
+}
+
 /** Shelving
  ******************************************************************************/
 

--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -72,6 +72,10 @@ body {
     flex-grow: 1;
 }
 
+.preserve-whitespace p {
+    white-space: pre-wrap !important;
+}
+
 /** Shelving
  ******************************************************************************/
 

--- a/bookwyrm/templates/directory/user_card.html
+++ b/bookwyrm/templates/directory/user_card.html
@@ -18,7 +18,7 @@
             </div>
         </div>
 
-        <div class="preserve-whitespace">
+        <div class="display-inline">
         {% if user.summary %}
             {{ user.summary|to_markdown|safe|truncatechars_html:40 }}
         {% else %}&nbsp;{% endif %}

--- a/bookwyrm/templates/directory/user_card.html
+++ b/bookwyrm/templates/directory/user_card.html
@@ -18,7 +18,7 @@
             </div>
         </div>
 
-        <div>
+        <div class="preserve-whitespace">
         {% if user.summary %}
             {{ user.summary|to_markdown|safe|truncatechars_html:40 }}
         {% else %}&nbsp;{% endif %}

--- a/bookwyrm/templates/directory/user_card.html
+++ b/bookwyrm/templates/directory/user_card.html
@@ -20,7 +20,7 @@
 
         <div>
         {% if user.summary %}
-            {{ user.summary|to_markdown|safe|truncatechars_html:81 }}
+            {{ user.summary|to_markdown|safe|truncatechars_html:40 }}
         {% else %}&nbsp;{% endif %}
         </div>
     </div>

--- a/bookwyrm/templates/directory/user_card.html
+++ b/bookwyrm/templates/directory/user_card.html
@@ -20,7 +20,7 @@
 
         <div>
         {% if user.summary %}
-            {{ user.summary|to_markdown|safe|truncatechars_html:40 }}
+            {{ user.summary|to_markdown|safe|truncatechars_html:81 }}
         {% else %}&nbsp;{% endif %}
         </div>
     </div>

--- a/bookwyrm/templates/user/layout.html
+++ b/bookwyrm/templates/user/layout.html
@@ -28,8 +28,10 @@
         </div>
 
         {% if user.summary %}
+        {% spaceless %}
         <div class="column box has-background-white-bis content preserve-whitespace">
             {{ user.summary|to_markdown|safe }}
+        {% endspaceless %}
         </div>
         {% endif %}
     </div>

--- a/bookwyrm/templates/user/layout.html
+++ b/bookwyrm/templates/user/layout.html
@@ -28,7 +28,7 @@
         </div>
 
         {% if user.summary %}
-        <div class="column box has-background-white-bis content">
+        <div class="column box has-background-white-bis content preserve-whitespace">
             {{ user.summary|to_markdown|safe }}
         </div>
         {% endif %}


### PR DESCRIPTION
Fix for #1225 
Uses inline CSS to change the white-space attribute of the text. Code is injected around the string during the HTML sanitation process so that it avoids being detected and striped by the HTMLParser, while still preserving the integrity of the Parser. By using the "data" tag it ensures the code will remain in place, even if the Parser determines any HTML tags in the original string should be removed.

Please let me know if there's a better way to do this, if I've missed any unforeseen consequences by making this change, or if there's a potential risk that this may be abused. Thank you :purple_heart: 