### PR TITLE
Limit authors displayed in status

### DIFF
--- a/bookwyrm/templates/snippets/authors.html
+++ b/bookwyrm/templates/snippets/authors.html
@@ -1,9 +1,16 @@
 {% spaceless %}
+{% load i18n %}
+{% load humanize %}
 {% comment %}
     @todo The author property needs to be an Organization or a Person. We’ll be using Thing which is the more generic ancestor.
     @see https://schema.org/Author
 {% endcomment %}
-{% for author in book.authors.all %}
+{% firstof limit None as limit %}
+{% with subtraction_value='-'|add:limit %}
+{% with remainder_count=book.authors.count|add:subtraction_value %}
+{% with remainder_count_display=remainder_count|intcomma %}
+
+{% for author in book.authors.all|slice:limit %}
     <a
         href="{{ author.local_path }}"
         class="author"
@@ -12,6 +19,14 @@
         itemtype="https://schema.org/Thing"
     ><span
         itemprop="name"
-    >{{ author.name }}<span></a>{% if not forloop.last %}, {% endif %}
+        >{{ author.name }}<span></a>{% if not forloop.last %}, {% elif remainder_count > 0 %}, {% blocktrans trimmed count counter=remainder_count %}
+and {{ remainder_count_display }} other
+{% plural %}
+and {{ remainder_count_display }} others
+{% endblocktrans %}{% endif %}
 {% endfor %}
+
+{% endwith %}
+{% endwith %}
+{% endwith %}
 {% endspaceless %}

--- a/bookwyrm/templates/snippets/book_titleby.html
+++ b/bookwyrm/templates/snippets/book_titleby.html
@@ -1,8 +1,15 @@
 {% load i18n %}
 {% load utilities %}
+{% spaceless %}
+
 {% if book.authors %}
-{% blocktrans with path=book.local_path title=book|book_title %}<a href="{{ path }}">{{ title }}</a> by {% endblocktrans %}{% include 'snippets/authors.html' with book=book %}
+{% blocktrans trimmed with path=book.local_path title=book|book_title %}
+<a href="{{ path }}">{{ title }}</a> by
+{% endblocktrans %}
+{% include 'snippets/authors.html' with book=book limit=3 %}
+
 {% else %}
 <a href="{{ book.local_path }}">{{ book|book_title }}</a>
 {% endif %}
 
+{% endspaceless %}


### PR DESCRIPTION
Before:
<img width="779" alt="Screen Shot 2021-08-04 at 12 37 31 PM" src="https://user-images.githubusercontent.com/1807695/128244231-a5f729c0-0912-4be6-b19f-09c24a30447e.png">

After:
<img width="785" alt="Screen Shot 2021-08-04 at 12 36 44 PM" src="https://user-images.githubusercontent.com/1807695/128244270-6955e643-7721-4619-9e9e-800651643a90.png">

The full list is still displayed on the book page