### PR TITLE
Make webfinger match usernames in case insensitive manner

### DIFF
--- a/bookwyrm/tests/views/test_wellknown.py
+++ b/bookwyrm/tests/views/test_wellknown.py
@@ -51,6 +51,16 @@ class UserViews(TestCase):
         data = json.loads(result.getvalue())
         self.assertEqual(data["subject"], "acct:mouse@local.com")
 
+    def test_webfinger_case_sensitivty(self):
+        """ensure that webfinger queries are not case sensitive"""
+        request = self.factory.get("", {"resource": "acct:MoUsE@local.com"})
+        request.user = self.anonymous_user
+
+        result = views.webfinger(request)
+        self.assertIsInstance(result, JsonResponse)
+        data = json.loads(result.getvalue())
+        self.assertEqual(data["subject"], "acct:mouse@local.com")
+
     def test_nodeinfo_pointer(self):
         """just tells you where nodeinfo is"""
         request = self.factory.get("")

--- a/bookwyrm/views/wellknown.py
+++ b/bookwyrm/views/wellknown.py
@@ -20,7 +20,7 @@ def webfinger(request):
 
     username = resource.replace("acct:", "")
     try:
-        user = models.User.objects.get(username=username)
+        user = models.User.objects.get(username__iexact=username)
     except models.User.DoesNotExist:
         return HttpResponseNotFound("No account found")
 


### PR DESCRIPTION
Currently, Bookwyrm serves webfinger data by looking up the username in a case sensitive manner. This means that when you look up a webfinger address without using an account's canonical case, it will not return the account's data. This PR makes these lookups case-insensitive. 

I'm not sure if they're *supposed* to be case-insensitive. [RFC7565](https://datatracker.ietf.org/doc/html/rfc7565) says this, which maybe applies to this situation: 

> If an application needs to compare two 'acct' URIs (e.g., for purposes of authentication and authorization), it MUST do so using case normalization and percent-encoding normalization as specified in Sections 6.2.2.1 and 6.2.2.2 of RFC3986.

In practice, however, Mastodon, Pleroma, and Misskey all serve lookups in a case-insensitive manner, and Misskey lowercases all outgoing lookups (which means that right now it can't fetch Bookwyrm accounts with usernames that contain capitals)