### PR TITLE
fix link formatter

### DIFF
--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -307,14 +307,14 @@ class StatusViews(TestCase):
         self.assertEqual(
             views.status.format_links(url), '<a href="%s">tech.lgbt/@bookwyrm</a>' % url
         )
-        url = "users.speakeasy.net/~lion/nb/book.pdf"
+        url = "https://users.speakeasy.net/~lion/nb/book.pdf"
         self.assertEqual(
             views.status.format_links(url),
             '<a href="%s">users.speakeasy.net/~lion/nb/book.pdf</a>' % url,
         )
-        url = "pkm.one/#/page/The%20Book%20which%20launched%20a%201000%20Note%20taking%20apps"
+        url = "https://pkm.one/#/page/The%20Book%20which%20launched%20a%201000%20Note%20taking%20apps"
         self.assertEqual(
-            views.status.format_links(url), '<a href="%s">%s</a>' % (url, url)
+            views.status.format_links(url), '<a href="%s">%s</a>' % (url, url[8:])
         )
 
     def test_to_markdown(self, *_):

--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -305,18 +305,16 @@ class StatusViews(TestCase):
         )
         url = "https://tech.lgbt/@bookwyrm"
         self.assertEqual(
-            views.status.format_links(url), 
-            '<a href="%s">tech.lgbt/@bookwyrm</a>' % url
+            views.status.format_links(url), '<a href="%s">tech.lgbt/@bookwyrm</a>' % url
         )
         url = "users.speakeasy.net/~lion/nb/book.pdf"
         self.assertEqual(
             views.status.format_links(url),
-            '<a href="%s">users.speakeasy.net/~lion/nb/book.pdf</a>' % url
+            '<a href="%s">users.speakeasy.net/~lion/nb/book.pdf</a>' % url,
         )
         url = "pkm.one/#/page/The%20Book%20which%20launched%20a%201000%20Note%20taking%20apps"
         self.assertEqual(
-            views.status.format_links(url),
-            '<a href="%s">%s</a>' % (url, url)
+            views.status.format_links(url), '<a href="%s">%s</a>' % (url, url)
         )
 
     def test_to_markdown(self, *_):

--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -303,6 +303,21 @@ class StatusViews(TestCase):
             '<a href="%s">openlibrary.org/search'
             "?q=arkady+strugatsky&mode=everything</a>" % url,
         )
+        url = "https://tech.lgbt/@bookwyrm"
+        self.assertEqual(
+            views.status.format_links(url), 
+            '<a href="%s">tech.lgbt/@bookwyrm</a>' % url
+        )
+        url = "users.speakeasy.net/~lion/nb/book.pdf"
+        self.assertEqual(
+            views.status.format_links(url),
+            '<a href="%s">users.speakeasy.net/~lion/nb/book.pdf</a>' % url
+        )
+        url = "pkm.one/#/page/The%20Book%20which%20launched%20a%201000%20Note%20taking%20apps"
+        self.assertEqual(
+            views.status.format_links(url),
+            '<a href="%s">%s</a>' % (url, url)
+        )
 
     def test_to_markdown(self, *_):
         """this is mostly handled in other places, but nonetheless"""

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -157,7 +157,7 @@ def format_links(content):
     formatted_content = ""
     for potential_link in content.split():
         try:
-            # raises an error on anything that's not a valid 
+            # raises an error on anything that's not a valid
             URLValidator(potential_link)
         except (ValidationError, UnicodeError):
             formatted_content += potential_link + " "
@@ -165,31 +165,33 @@ def format_links(content):
         wrapped = _wrapped(potential_link)
         if wrapped:
             wrapper_close = potential_link[-1]
-            formatted_content += potential_link[0] 
+            formatted_content += potential_link[0]
             potential_link = potential_link[1:-1]
 
         # so we can use everything but the scheme in the presentation of the link
         url = urlparse(potential_link)
         link = url.netloc + url.path + url.params
         if url.query != "":
-            link += "?" + url.query 
+            link += "?" + url.query
         if url.fragment != "":
             link += "#" + url.fragment
 
         formatted_content += '<a href="%s">%s</a>' % (potential_link, link)
 
         if wrapped:
-            formatted_content += wrapper_close 
+            formatted_content += wrapper_close
 
     return formatted_content
 
+
 def _wrapped(text):
-    """ check if a line of text is wrapped in parentheses, square brackets or curly brackets. return wrapped status """
-    wrappers = [("(", ")"), ("[","]"), ("{", "}")]
+    """check if a line of text is wrapped in parentheses, square brackets or curly brackets. return wrapped status"""
+    wrappers = [("(", ")"), ("[", "]"), ("{", "}")]
     for w in wrappers:
         if text[0] == w[0] and text[-1] == w[-1]:
-            return True 
+            return True
     return False
+
 
 def to_markdown(content):
     """catch links and convert to markdown"""

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -184,7 +184,7 @@ def format_links(content):
 
 
 def _wrapped(text):
-    """check if a line of text is wrapped in parentheses, square brackets or curly brackets. return wrapped status"""
+    """check if a line of text is wrapped"""
     wrappers = [("(", ")"), ("[", "]"), ("{", "}")]
     for wrapper in wrappers:
         if text[0] == wrapper[0] and text[-1] == wrapper[-1]:

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -1,5 +1,7 @@
 """ what are we here for if not for posting """
 import re
+from urllib.parse import urlparse
+
 from django.contrib.auth.decorators import login_required
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
@@ -8,10 +10,8 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views import View
+
 from markdown import markdown
-
-from urllib.parse import urlparse
-
 from bookwyrm import forms, models
 from bookwyrm.sanitize_html import InputHtmlParser
 from bookwyrm.settings import DOMAIN
@@ -153,7 +153,6 @@ def find_mentions(content):
 
 def format_links(content):
     """detect and format links"""
-    v = URLValidator()
     formatted_content = ""
     for potential_link in content.split():
         try:
@@ -187,8 +186,8 @@ def format_links(content):
 def _wrapped(text):
     """check if a line of text is wrapped in parentheses, square brackets or curly brackets. return wrapped status"""
     wrappers = [("(", ")"), ("[", "]"), ("{", "}")]
-    for w in wrappers:
-        if text[0] == w[0] and text[-1] == w[-1]:
+    for wrapper in wrappers:
+        if text[0] == wrapper[0] and text[-1] == wrapper[-1]:
             return True
     return False
 

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -7,7 +7,6 @@ from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
-from django.utils.html import urlize
 from django.views import View
 from markdown import markdown
 


### PR DESCRIPTION
resolves issue #1207

Instead of using regex to test for links and then replace them, I split the `content` by whitespace, then use the [django.core.validators.URLValidator](https://github.com/django/django/blob/3219dd3388c437b4bd869b76ddd43c9cdad05090/django/core/validators.py#L65) to test if the content is a link. If it is, I then use [urllib.parse.urlparse](https://docs.python.org/3/library/urllib.parse.html#url-parsing) to format it into a pretty link. I also made a function `_wrapped` which tests if the link is wrapped in parentheses, square brackets, or curly brackets, so it can wrap the link in the appropriate symbols during formatting. 

I also added some more test cases hitting those links (or similar ones) that @wakest put in the issue. 

`_wrapped` could maybe use some regex magic, but I'm no regex wizard 

