### PR TITLE
Show label for content warning field

### DIFF
--- a/bookwyrm/templates/snippets/create_status/content_warning_field.html
+++ b/bookwyrm/templates/snippets/create_status/content_warning_field.html
@@ -1,6 +1,14 @@
 {% load i18n %}
-<div class="control{% if not parent_status.content_warning and not draft.content_warning %} is-hidden{% endif %}" id="spoilers_{{ uuid }}">
-    <label class="is-sr-only" for="id_content_warning_{{ uuid }}">{% trans "Spoiler alert:" %}</label>
+<div
+    class="field{% if not parent_status.content_warning and not draft.content_warning %} is-hidden{% endif %}"
+    id="spoilers_{{ uuid }}"
+>
+    <label
+        class="label"
+        for="id_content_warning_{{ uuid }}"
+    >
+        {% trans "Content warning:" %}
+    </label>
     <input
         type="text"
         name="content_warning"

--- a/bookwyrm/templates/snippets/create_status/layout.html
+++ b/bookwyrm/templates/snippets/create_status/layout.html
@@ -25,23 +25,19 @@ reply_parent: the Status object this post will be in reply to, if applicable
     <input type="hidden" name="reply_parent" value="{% firstof draft.reply_parent.id reply_parent.id %}">
     {% endblock %}
 
+    {% include "snippets/create_status/content_warning_field.html" %}
+
+    {# fields that go between the content warnings and the content field (ie, quote) #}
+    {% block pre_content_additions %}{% endblock %}
+
+    <label class="label" for="id_content_{{ type }}_{{ book.id }}{{ reply_parent.id }}">
+        {% block content_label %}
+            {% trans "Comment:" %}
+        {% endblock %}
+    </label>
+
     <div class="field">
-        <div class="control">
-            {% include "snippets/create_status/content_warning_field.html" %}
-        </div>
-
-        {# fields that go between the content warnings and the content field (ie, quote) #}
-        {% block pre_content_additions %}{% endblock %}
-
-        <label class="label" for="id_content_{{ type }}_{{ book.id }}{{ reply_parent.id }}">
-            {% block content_label %}
-                {% trans "Comment:" %}
-            {% endblock %}
-        </label>
-
-        <div class="control">
-            {% include "snippets/create_status/content_field.html" with placeholder=placeholder %}
-        </div>
+        {% include "snippets/create_status/content_field.html" with placeholder=placeholder %}
     </div>
 
     {# additional fields that go after the content block (ie, progress) #}


### PR DESCRIPTION
Before:
<img width="357" alt="Screen Shot 2021-09-18 at 11 12 44 AM" src="https://user-images.githubusercontent.com/1807695/133905692-3984ee8b-4c2d-4c0d-82fd-898b87f2c492.png">

After:
<img width="345" alt="Screen Shot 2021-09-18 at 12 01 41 PM" src="https://user-images.githubusercontent.com/1807695/133905788-85625207-6101-4134-aac5-0ae3f038dd32.png">

Works on #1420 