### PR TITLE
Visually differentiates content warnings from statuses

### DIFF
--- a/bookwyrm/templates/snippets/status/content_status.html
+++ b/bookwyrm/templates/snippets/status/content_status.html
@@ -67,12 +67,15 @@
             {% endif %}
 
             {% if status.content_warning %}
-                <div>
-                    <p>{{ status.content_warning }}</p>
+                <div class="notification pt-2 pb-2 is-clearfix is-warning is-light">
+                    <p class="is-pulled-left">
+                        <strong>{% trans "Content warning:" %}</strong>
+                        {{ status.content_warning }}
+                    </p>
 
-                    {% trans "Show more" as button_text %}
+                    {% trans "Show status" as button_text %}
 
-                    {% with text=button_text class="is-small" controls_text="show_status_cw" controls_uid=status.id %}
+                    {% with text=button_text class="is-small is-pulled-right" icon_with_text="arrow-down" controls_text="show_status_cw" controls_uid=status.id %}
                         {% include 'snippets/toggle/open_button.html' %}
                     {% endwith %}
                 </div>
@@ -84,14 +87,6 @@
                     class="is-hidden"
                 {% endif %}
             >
-                {% if status.content_warning %}
-                    {% trans "Show less" as button_text %}
-
-                    {% with text=button_text class="is-small" controls_text="show_status_cw" controls_uid=status.id %}
-                        {% include 'snippets/toggle/close_button.html' %}
-                    {% endwith %}
-                {% endif %}
-
                 {% if status.quote %}
                     <div class="quote block">
                         <blockquote dir="auto" class="content mb-2">{{ status.quote|safe }}</blockquote>
@@ -140,6 +135,14 @@
                             {% endfor %}
                         </div>
                     </div>
+                {% endif %}
+
+                {% if status.content_warning %}
+                    {% trans "Hide status" as button_text %}
+
+                    {% with text=button_text class="is-small" controls_text="show_status_cw" controls_uid=status.id icon_with_text="arrow-up" %}
+                        {% include 'snippets/toggle/close_button.html' %}
+                    {% endwith %}
                 {% endif %}
             </div>
         </article>


### PR DESCRIPTION
The goal here is to make it visual clear when a status has a content warning, and how to open the status. In the current UI, content warnings look the same as regular statuses, and the buttons look the same as the button to expand a particularly long status.

Before:
<img width="777" alt="Screen Shot 2021-09-18 at 5 02 22 PM" src="https://user-images.githubusercontent.com/1807695/133911415-5b62431b-a7d2-4c29-b4bb-1011c8182859.png">
<img width="783" alt="Screen Shot 2021-09-18 at 5 02 28 PM" src="https://user-images.githubusercontent.com/1807695/133911416-83480e46-ab32-4496-86d9-665f10b1497b.png">

After:
<img width="779" alt="Screen Shot 2021-09-18 at 4 59 35 PM" src="https://user-images.githubusercontent.com/1807695/133911391-007bf9ca-fc99-481c-ad4a-bd6c1c113e97.png">
<img width="783" alt="Screen Shot 2021-09-18 at 4 59 44 PM" src="https://user-images.githubusercontent.com/1807695/133911388-33a97463-bca7-4386-b200-66ed01846e79.png">

Fixes #1430