### PR TITLE
Use dash instead of vertical line to separate page name and site name

### DIFF
--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -4,7 +4,7 @@
 <!DOCTYPE html>
 <html lang="{% get_lang %}">
 <head>
-    <title>{% block title %}BookWyrm{% endblock %} | {{ site.name }}</title>
+    <title>{% block title %}BookWyrm{% endblock %} - {{ site.name }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{% static "css/vendor/bulma.min.css" %}">
     <link rel="stylesheet" href="{% static "css/vendor/icons.css" %}">
@@ -17,8 +17,8 @@
     {% else %}
     <meta name="twitter:card" content="summary">
     {% endif %}
-    <meta name="twitter:title" content="{% if title %}{{ title }} | {% endif %}{{ site.name }}">
-    <meta name="og:title" content="{% if title %}{{ title }} | {% endif %}{{ site.name }}">
+    <meta name="twitter:title" content="{% if title %}{{ title }} - {% endif %}{{ site.name }}">
+    <meta name="og:title" content="{% if title %}{{ title }} - {% endif %}{{ site.name }}">
     <meta name="twitter:description" content="{{ site.instance_tagline }}">
     <meta name="og:description" content="{{ site.instance_tagline }}">
 


### PR DESCRIPTION
Voiceover reads the tab as "vertical line bookwyrm" and I found it irritating. It reads better with a dash.