### PR TITLE
Display half-stars in generated statuses for federation

### DIFF
--- a/bookwyrm/templates/snippets/generated_status/rating.html
+++ b/bookwyrm/templates/snippets/generated_status/rating.html
@@ -1,6 +1,6 @@
 {% load i18n %}{% load humanize %}{% load utilities %}
 
-{% blocktrans trimmed with title=book|book_title path=book.remote_id display_rating=rating|floatformat:"0" count counter=rating|add:0 %}
+{% blocktrans trimmed with title=book|book_title path=book.remote_id display_rating=rating|floatformat:"-1" count counter=rating|add:0 %}
 rated <em><a href="{{ path }}">{{ title }}</a></em>: {{ display_rating }} star
 {% plural %}
 rated <em><a href="{{ path }}">{{ title }}</a></em>: {{ display_rating }} stars

--- a/bookwyrm/templates/snippets/generated_status/review_pure_name.html
+++ b/bookwyrm/templates/snippets/generated_status/review_pure_name.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% if rating %}
 
-{% blocktrans with book_title=book.title|safe display_rating=rating|floatformat:"0" review_title=name|safe count counter=rating %}Review of "{{ book_title }}" ({{ display_rating }} star): {{ review_title }}{% plural %}Review of "{{ book_title }}" ({{ display_rating }} stars): {{ review_title }}{% endblocktrans %}
+{% blocktrans with book_title=book.title|safe display_rating=rating|floatformat:"-1" review_title=name|safe count counter=rating %}Review of "{{ book_title }}" ({{ display_rating }} star): {{ review_title }}{% plural %}Review of "{{ book_title }}" ({{ display_rating }} stars): {{ review_title }}{% endblocktrans %}
 
 {% else %}
 


### PR DESCRIPTION
Fixes #1505

before:
![image](https://user-images.githubusercontent.com/142250/136165337-5366f824-0743-4bad-a5f9-e93da9d1f887.png)

after:
![image](https://user-images.githubusercontent.com/142250/136178906-664a89bf-20b6-45b4-bbd8-8f02f5595607.png)
