### PR TITLE
 When fetching ActivityPub and ActivityStreams documents, ensure that…

### DIFF
--- a/bookwyrm/connectors/abstract_connector.py
+++ b/bookwyrm/connectors/abstract_connector.py
@@ -228,7 +228,7 @@ def get_data(url, params=None, timeout=10):
             url,
             params=params,
             headers={
-                "Accept": "application/json; charset=utf-8",
+                "Accept": "application/activity+json, application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\", application/json; charset=utf-8",
                 "User-Agent": settings.USER_AGENT,
             },
             timeout=timeout,


### PR DESCRIPTION
… both of those document types are permitted by the Accept header, per the ActivityPub and ActivityStreams specifications. Fixes #1564