### PR TITLE
translate all read statuses

### DIFF
--- a/bookwyrm/templates/snippets/status/headers/generatednote.html
+++ b/bookwyrm/templates/snippets/status/headers/generatednote.html
@@ -1,0 +1,11 @@
+{% if status.content == 'wants to read' %}
+    {% include 'snippets/status/headers/to_read.html' with book=status.mention_books.first %}
+{% endif %}
+
+{% if status.content == 'finished reading' %}
+    {% include 'snippets/status/headers/read.html' with book=status.mention_books.first %}
+{% endif %}
+
+{% if status.content == 'started reading' %}
+    {% include 'snippets/status/headers/reading.html' with book=status.mention_books.first %}
+{% endif %}

--- a/bookwyrm/templates/snippets/status/headers/note.html
+++ b/bookwyrm/templates/snippets/status/headers/note.html
@@ -3,13 +3,6 @@
 {% load status_display %}
 {% load utilities %}
 
-{% if status.status_type == 'GeneratedNote' %}
-{% with book=status.mention_books.first %}
-{{ status.content|safe }} <a href="{{ book.local_path }}">{{ book|book_title }}</a>
-{% endwith %}
-
-{% else %}
-
 {% with parent_status=status|parent %}
 {% if parent_status %}
 {% blocktrans trimmed with username=parent_status.user.display_name user_path=parent_status.user.local_path status_path=parent_status.local_path %}
@@ -18,5 +11,4 @@ replied to <a href="{{ user_path }}">{{ username}}</a>'s <a href="{{ status_path
 {% endif %}
 {% endwith %}
 
-{% endif %}
 {% endspaceless %}


### PR DESCRIPTION
This fixes #1566 - "Already translated strings sometimes show up untranslated in UI"

- add generatednote status header template
- include the relevant template (to-read/reading/read) based on the status.content
- remove GeneratedNote block from note status header template

This is probably not the most correct way of resolving the problem, but it's simple and it works.

![to-read](https://user-images.githubusercontent.com/17669239/138635279-c4f89442-174d-46a1-a3c4-586065d8330a.png)
--
![reading](https://user-images.githubusercontent.com/17669239/138635295-17f53cbd-e4d1-4483-80b4-b619b4eddd4a.png)
--
![read](https://user-images.githubusercontent.com/17669239/138635301-4a9cc942-ba89-47ab-8a32-124f7c74665e.png)


