### PR TITLE
Fix reading actions and book links in Discover

### DIFF
--- a/bookwyrm/templates/discover/card-header.html
+++ b/bookwyrm/templates/discover/card-header.html
@@ -4,7 +4,21 @@
 {% with user_path=status.user.local_path username=status.user.display_name book_path=status.book.local_poth book_title=book|book_title %}
 
 {% if status.status_type == 'GeneratedNote' %}
-    {{ status.content|safe }}
+    {% if status.content == 'wants to read' %}
+        {% blocktrans trimmed %}
+        <a href="{{ user_path}}">{{ username }}</a> wants to read <a href="{{ book_path }}">{{ book_title }}</a>
+        {% endblocktrans %}
+    {% endif %}
+    {% if status.content == 'finished reading' %}
+        {% blocktrans trimmed %}
+        <a href="{{ user_path}}">{{ username }}</a> finished reading <a href="{{ book_path }}">{{ book_title }}</a>
+        {% endblocktrans %}
+    {% endif %}
+    {% if status.content == 'started reading' %}
+        {% blocktrans trimmed %}
+        <a href="{{ user_path}}">{{ username }}</a> started reading <a href="{{ book_path }}">{{ book_title }}</a>
+        {% endblocktrans %}
+    {% endif %}
 {% elif status.status_type == 'Rating' %}
     {% blocktrans trimmed %}
     <a href="{{ user_path}}">{{ username }}</a> rated <a href="{{ book_path }}">{{ book_title }}</a>

--- a/bookwyrm/templates/discover/card-header.html
+++ b/bookwyrm/templates/discover/card-header.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load utilities %}
 
-{% with user_path=status.user.local_path username=status.user.display_name book_path=status.book.local_poth book_title=book|book_title %}
+{% with user_path=status.user.local_path username=status.user.display_name book_path=book.local_path book_title=book|book_title %}
 
 {% if status.status_type == 'GeneratedNote' %}
     {% if status.content == 'wants to read' %}


### PR DESCRIPTION
Fixes #1595
Fixes #1596 

This uses the same technique as #1572 to ensure read statuses from `GeneratedNote`s are translated.
Also corrects the path for book links.