### PR TITLE
Don't delete non-form data when editing authors 

### DIFF
--- a/bookwyrm/forms.py
+++ b/bookwyrm/forms.py
@@ -210,6 +210,7 @@ class AuthorForm(CustomForm):
             "born",
             "died",
             "openlibrary_key",
+            "inventaire_id",
             "librarything_key",
             "goodreads_key",
         ]

--- a/bookwyrm/forms.py
+++ b/bookwyrm/forms.py
@@ -201,12 +201,17 @@ class EditionForm(CustomForm):
 class AuthorForm(CustomForm):
     class Meta:
         model = models.Author
-        exclude = [
-            "remote_id",
-            "origin_id",
-            "created_date",
-            "updated_date",
-            "search_vector",
+        fields = [
+            "last_edited_by",
+            "name",
+            "aliases",
+            "bio",
+            "wikipedia_link",
+            "born",
+            "died",
+            "openlibrary_key",
+            "librarything_key",
+            "goodreads_key",
         ]
 
 


### PR DESCRIPTION
Fixes #1584

This is a temporary fix. As @mouse-reeve has suggested, ultimately it would be good to re-import data from one or more of the linked data sources if there is anything missing, each time the author form is saved.