### PR TITLE
refactor shelf activity on book page

### DIFF
--- a/bookwyrm/static/js/status_cache.js
+++ b/bookwyrm/static/js/status_cache.js
@@ -90,6 +90,11 @@ let StatusCache = new class {
             trigger.removeAttribute('disabled');
         })
         .then(response => {
+            if (response.headers.get("forceReload")) {
+                BookWyrm.addRemoveClass(form, 'is-processing', true);
+                trigger.setAttribute('disabled', null);
+                return location.reload();
+            }
             if (!response.ok) {
                 throw new Error();
             }

--- a/bookwyrm/static/js/status_cache.js
+++ b/bookwyrm/static/js/status_cache.js
@@ -93,8 +93,10 @@ let StatusCache = new class {
             if (response.headers.get("forceReload")) {
                 BookWyrm.addRemoveClass(form, 'is-processing', true);
                 trigger.setAttribute('disabled', null);
+
                 return location.reload();
             }
+
             if (!response.ok) {
                 throw new Error();
             }

--- a/bookwyrm/static/js/status_cache.js
+++ b/bookwyrm/static/js/status_cache.js
@@ -194,7 +194,7 @@ let StatusCache = new class {
             .forEach(item => BookWyrm.addRemoveClass(item, "is-hidden", false));
 
         // Remove existing disabled states
-        // BUG: this affects all shelves, not just shelving status shelves
+
         button.querySelectorAll("[data-shelf-dropdown-identifier] button")
             .forEach(item => item.disabled = false);
 

--- a/bookwyrm/static/js/status_cache.js
+++ b/bookwyrm/static/js/status_cache.js
@@ -192,6 +192,7 @@ let StatusCache = new class {
             .forEach(item => BookWyrm.addRemoveClass(item, "is-hidden", false));
 
         // Remove existing disabled states
+        // BUG: this affects all shelves, not just shelving status shelves
         button.querySelectorAll("[data-shelf-dropdown-identifier] button")
             .forEach(item => item.disabled = false);
 

--- a/bookwyrm/static/js/status_cache.js
+++ b/bookwyrm/static/js/status_cache.js
@@ -74,7 +74,7 @@ let StatusCache = new class {
 
         // This allows the form to submit in the old fashioned way if there's a problem
 
-        if (!trigger || !form || response.headers.get("forceReload")) {
+        if (!trigger || !form) {
             return;
         }
 
@@ -90,7 +90,6 @@ let StatusCache = new class {
             trigger.removeAttribute('disabled');
         })
         .then(response => {
-
             if (!response.ok) {
                 throw new Error();
             }

--- a/bookwyrm/static/js/status_cache.js
+++ b/bookwyrm/static/js/status_cache.js
@@ -74,7 +74,7 @@ let StatusCache = new class {
 
         // This allows the form to submit in the old fashioned way if there's a problem
 
-        if (!trigger || !form) {
+        if (!trigger || !form || response.headers.get("forceReload")) {
             return;
         }
 
@@ -90,12 +90,6 @@ let StatusCache = new class {
             trigger.removeAttribute('disabled');
         })
         .then(response => {
-            if (response.headers.get("forceReload")) {
-                BookWyrm.addRemoveClass(form, 'is-processing', true);
-                trigger.setAttribute('disabled', null);
-
-                return location.reload();
-            }
 
             if (!response.ok) {
                 throw new Error();

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -161,12 +161,12 @@
                 {% for shelf in user_shelfbooks %}
                     <li class="box">
                         {% blocktrans with path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}<a href="{{ path }}">{{ shelf_name }}</a>{% endblocktrans %}
-                        {% if shelf.shelf.identifier|is_shelf_type:"readthrough" %}
-                            {% include 'snippets/shelve_button/shelve_button.html' %}
+                        {% if shelf.shelf.editable %}
+                        <div class="mb-3">
+                            {% include 'snippets/shelf_selector.html' with current=shelf.shelf class="is-small" %}
+                        </div>
                         {% else %}
-                            <div class="mb-3">
-                                {% include 'snippets/shelf_selector.html' with current=shelf.shelf class="is-small" %}
-                            </div>
+                        {% include 'snippets/shelve_button/shelve_button.html' %}
                         {% endif %}
                     </li>
                 {% endfor %}

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -162,7 +162,7 @@
                     <li class="box">
                         {% blocktrans with path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}<a href="{{ path }}">{{ shelf_name }}</a>{% endblocktrans %}
                         <div class="mb-3">
-                            {% include 'snippets/shelf_selector.html' with current=shelf.shelf class="is-small" readthrough=readthrough %}
+                            {% include 'snippets/shelf_selector.html' with shelf=shelf.shelf class="is-small" readthrough=readthrough %}
                         </div>
                     </li>
                 {% endfor %}

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -162,7 +162,7 @@
                     <li class="box">
                         {% blocktrans with path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}<a href="{{ path }}">{{ shelf_name }}</a>{% endblocktrans %}
                         <div class="mb-3">
-                            {% include 'snippets/shelf_selector.html' with current=shelf.shelf class="is-small" %}
+                            {% include 'snippets/shelf_selector.html' with current=shelf.shelf class="is-small" readthrough=readthrough %}
                         </div>
                     </li>
                 {% endfor %}

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -161,13 +161,9 @@
                 {% for shelf in user_shelfbooks %}
                     <li class="box">
                         {% blocktrans with path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}<a href="{{ path }}">{{ shelf_name }}</a>{% endblocktrans %}
-                        {% if shelf.shelf.editable %}
                         <div class="mb-3">
                             {% include 'snippets/shelf_selector.html' with current=shelf.shelf class="is-small" %}
                         </div>
-                        {% else %}
-                        {% include 'snippets/shelve_button/shelve_button.html' %}
-                        {% endif %}
                     </li>
                 {% endfor %}
                 </ul>

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -153,12 +153,25 @@
 
             {# user's relationship to the book #}
             <div class="block">
+                {% if user_shelfbooks.count > 0 %}
+                <h2 class="title is-5">
+                    {% trans "You have shelved this edition in:" %}
+                </h2>
+                <ul>
                 {% for shelf in user_shelfbooks %}
-                <p>
-                    {% blocktrans with path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}This edition is on your <a href="{{ path }}">{{ shelf_name }}</a> shelf.{% endblocktrans %}
-                    {% include 'snippets/shelf_selector.html' with current=shelf.shelf %}
-                </p>
+                    <li class="box">
+                        {% blocktrans with path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}<a href="{{ path }}">{{ shelf_name }}</a>{% endblocktrans %}
+                        {% if shelf.shelf.identifier|is_shelf_type:"readthrough" %}
+                            {% include 'snippets/shelve_button/shelve_button.html' %}
+                        {% else %}
+                            <div class="mb-3">
+                                {% include 'snippets/shelf_selector.html' with current=shelf.shelf class="is-small" %}
+                            </div>
+                        {% endif %}
+                    </li>
                 {% endfor %}
+                </ul>
+                {% endif %}
                 {% for shelf in other_edition_shelves %}
                 <p>
                 {% blocktrans with book_path=shelf.book.local_path shelf_path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}A <a href="{{ book_path }}">different edition</a> of this book is on your <a href="{{ shelf_path }}">{{ shelf_name }}</a> shelf.{% endblocktrans %}

--- a/bookwyrm/templates/snippets/reading_modals/finish_reading_modal.html
+++ b/bookwyrm/templates/snippets/reading_modals/finish_reading_modal.html
@@ -9,7 +9,7 @@ Finish "<em>{{ book_title }}</em>"
 {% endblock %}
 
 {% block modal-form-open %}
-<form name="finish-reading" action="{% url 'reading-status' 'finish' book.id %}" method="post" class="submit-status">
+<form name="finish-reading" action="{% url 'reading-status' 'finish' book.id %}" method="post" {% if not refresh %}class="submit-status"{% endif %}>
 {% csrf_token %}
 <input type="hidden" name="id" value="{{ readthrough.id }}">
 <input type="hidden" name="reading_status" value="read">

--- a/bookwyrm/templates/snippets/reading_modals/finish_reading_modal.html
+++ b/bookwyrm/templates/snippets/reading_modals/finish_reading_modal.html
@@ -13,6 +13,7 @@ Finish "<em>{{ book_title }}</em>"
 {% csrf_token %}
 <input type="hidden" name="id" value="{{ readthrough.id }}">
 <input type="hidden" name="reading_status" value="read">
+<input type="hidden" name="shelf" value="{{ move_from }}"> 
 {% endblock %}
 
 {% block reading-dates %}

--- a/bookwyrm/templates/snippets/reading_modals/start_reading_modal.html
+++ b/bookwyrm/templates/snippets/reading_modals/start_reading_modal.html
@@ -9,7 +9,7 @@ Start "<em>{{ book_title }}</em>"
 {% endblock %}
 
 {% block modal-form-open %}
-<form name="start-reading" action="{% url 'reading-status' 'start' book.id %}" method="post" class="submit-status">
+<form name="start-reading" action="{% url 'reading-status' 'start' book.id %}" method="post" {% if not refresh %}class="submit-status"{% endif %}>
 <input type="hidden" name="reading_status" value="reading">
 <input type="hidden" name="shelf" value="{{ move_from }}"> 
 {% csrf_token %}

--- a/bookwyrm/templates/snippets/reading_modals/start_reading_modal.html
+++ b/bookwyrm/templates/snippets/reading_modals/start_reading_modal.html
@@ -11,6 +11,7 @@ Start "<em>{{ book_title }}</em>"
 {% block modal-form-open %}
 <form name="start-reading" action="{% url 'reading-status' 'start' book.id %}" method="post" class="submit-status">
 <input type="hidden" name="reading_status" value="reading">
+<input type="hidden" name="shelf" value="{{ move_from }}"> 
 {% csrf_token %}
 {% endblock %}
 

--- a/bookwyrm/templates/snippets/reading_modals/want_to_read_modal.html
+++ b/bookwyrm/templates/snippets/reading_modals/want_to_read_modal.html
@@ -11,6 +11,7 @@ Want to Read "<em>{{ book_title }}</em>"
 {% block modal-form-open %}
 <form name="shelve" action="{% url 'reading-status' 'want' book.id %}" method="post" class="submit-status">
 <input type="hidden" name="reading_status" value="to-read">
+<input type="hidden" name="shelf" value="{{ move_from }}"> 
 {% csrf_token %}
 {% endblock %}
 

--- a/bookwyrm/templates/snippets/reading_modals/want_to_read_modal.html
+++ b/bookwyrm/templates/snippets/reading_modals/want_to_read_modal.html
@@ -9,7 +9,7 @@ Want to Read "<em>{{ book_title }}</em>"
 {% endblock %}
 
 {% block modal-form-open %}
-<form name="shelve" action="{% url 'reading-status' 'want' book.id %}" method="post" class="submit-status">
+<form name="shelve" action="{% url 'reading-status' 'want' book.id %}" method="post" {% if not refresh %}class="submit-status"{% endif %}>
 <input type="hidden" name="reading_status" value="to-read">
 <input type="hidden" name="shelf" value="{{ move_from }}"> 
 {% csrf_token %}

--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -1,5 +1,7 @@
 {% extends 'components/dropdown.html' %}
 {% load i18n %}
+{% load bookwyrm_tags %}
+
 {% block dropdown-trigger %}
 <span>{% trans "Move book" %}</span>
 <span class="icon icon-arrow-down" aria-hidden="true"></span>
@@ -7,6 +9,7 @@
 
 {% block dropdown-list %}
 {% for shelf in user_shelves %}
+{% if shelf.identifier|is_shelf_type:"custom" %}
 <li role="menuitem" class="dropdown-item p-0">
     <form name="shelve" action="/shelve/" method="post">
         {% csrf_token %}
@@ -16,6 +19,7 @@
         <button class="button is-fullwidth is-small shelf-option is-radiusless is-white" type="submit" {% if shelf.identifier == current.identifier %}disabled{% endif %}><span>{{ shelf.name }}</span></button>
     </form>
 </li>
+{% endif %}
 {% endfor %}
 <li class="navbar-divider" role="separator"></li>
 <li role="menuitem" class="dropdown-item p-0">

--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -78,11 +78,11 @@
 </li>
 {% endif %}
 
-{% include 'snippets/reading_modals/want_to_read_modal.html' with book=active_shelf.book controls_text="want_to_read" controls_uid=uuid move_from=current.id %}
+{% include 'snippets/reading_modals/want_to_read_modal.html' with book=active_shelf.book controls_text="want_to_read" controls_uid=uuid move_from=current.id refresh=True %}
 
-{% include 'snippets/reading_modals/start_reading_modal.html' with book=active_shelf.book controls_text="start_reading" controls_uid=uuid move_from=current.id %}
+{% include 'snippets/reading_modals/start_reading_modal.html' with book=active_shelf.book controls_text="start_reading" controls_uid=uuid move_from=current.id refresh=True %}
 
-{% include 'snippets/reading_modals/finish_reading_modal.html' with book=active_shelf.book controls_text="finish_reading" controls_uid=uuid  move_from=current.id readthrough=readthrough %}
+{% include 'snippets/reading_modals/finish_reading_modal.html' with book=active_shelf.book controls_text="finish_reading" controls_uid=uuid  move_from=current.id readthrough=readthrough refresh=True %}
 
 {% endwith %}
 {% endblock %}

--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -53,15 +53,30 @@
 {% endwith %}
 {% endif %}
 {% endfor %}
-<li class="navbar-divider" role="separator"></li>
+
+{% if shelf.identifier == 'all' %}
+{% for shelved_in in book.shelves.all %}
+<li class="navbar-divider m-0" role="separator" ></li>
 <li role="menuitem" class="dropdown-item p-0">
     <form name="shelve" action="/unshelve/" method="post">
         {% csrf_token %}
         <input type="hidden" name="book" value="{{ book.id }}">
-        <input type="hidden" name="shelf" value="{{ current.id }}">
-        <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">{% trans "Remove" %}</button>
+        <input type="hidden" name="shelf" value="{{ shelved_in.id }}">
+        <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">{% trans "Remove from" %} {{ shelved_in.name }}</button>
     </form>
 </li>
+{% endfor %}
+{% else %}
+<li class="navbar-divider" role="separator" ></li>
+<li role="menuitem" class="dropdown-item p-0">
+    <form name="shelve" action="/unshelve/" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="book" value="{{ book.id }}">
+        <input type="hidden" name="shelf" value="{{ shelf.id }}">
+        <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">{% trans "Remove from" %} {{ shelf.name }}</button>
+    </form>
+</li>
+{% endif %}
 
 {% include 'snippets/reading_modals/want_to_read_modal.html' with book=active_shelf.book controls_text="want_to_read" controls_uid=uuid move_from=current.id %}
 

--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -12,13 +12,7 @@
 {% with book.id|uuid as uuid %}
 {% active_shelf book as active_shelf %}
 {% for shelf in user_shelves %}
-<!--  TODO: 
-      #1 work out logic to both trigger the relevant modal for reading status ✅
-      #2 AND REMOVE FROM CURRENT SHELF ✅
-      #3 AND TRIGGER RELOAD even when readthrough shelf ✅
 
-      #4 disable if book is shelved on this shelf
--->
 {% if shelf.editable %}
 <li role="menuitem" class="dropdown-item p-0">
     <form name="shelve" action="/shelve/" method="post">
@@ -26,10 +20,11 @@
         <input type="hidden" name="book" value="{{ book.id }}">
         <input type="hidden" name="change-shelf-from" value="{{ current.identifier }}">
         <input type="hidden" name="shelf" value="{{ shelf.identifier }}">
-        <button class="button is-fullwidth is-small shelf-option is-radiusless is-white" type="submit" {% if shelf.identifier == current.identifier %}disabled{% endif %}><span>{{ shelf.name }}</span></button>
+        <button class="button is-fullwidth is-small shelf-option is-radiusless is-white" type="submit" {% if shelf in book.shelf_set.all %} disabled {% endif %}><span>{{ shelf.name }}</span></button>
     </form>
 </li>
 {% else%}
+{% comparison_bool shelf.identifier active_shelf.shelf.identifier as is_current %}
 {% with button_class="is-fullwidth is-small shelf-option is-radiusless is-white" %}
 <li role="menuitem" class="dropdown-item p-0">
 {% if shelf.identifier == 'reading' %}

--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -11,6 +11,8 @@
 {% block dropdown-list %}
 {% with book.id|uuid as uuid %}
 {% active_shelf book as active_shelf %}
+{% latest_read_through book request.user as readthrough %}
+
 {% for shelf in user_shelves %}
 
 {% if shelf.editable %}
@@ -66,8 +68,6 @@
 {% include 'snippets/reading_modals/start_reading_modal.html' with book=active_shelf.book controls_text="start_reading" controls_uid=uuid move_from=current.id %}
 
 {% include 'snippets/reading_modals/finish_reading_modal.html' with book=active_shelf.book controls_text="finish_reading" controls_uid=uuid  move_from=current.id readthrough=readthrough %}
-
-{% include 'snippets/reading_modals/progress_update_modal.html' with book=active_shelf.book controls_text="progress_update" controls_uid=uuid move_from=current.id readthrough=readthrough %}
 
 {% endwith %}
 {% endblock %}

--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -9,7 +9,7 @@
 
 {% block dropdown-list %}
 {% for shelf in user_shelves %}
-{% if shelf.identifier|is_shelf_type:"custom" %}
+{% if shelf.editable %}
 <li role="menuitem" class="dropdown-item p-0">
     <form name="shelve" action="/shelve/" method="post">
         {% csrf_token %}

--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -1,6 +1,7 @@
 {% extends 'components/dropdown.html' %}
 {% load i18n %}
 {% load bookwyrm_tags %}
+{% load utilities %}
 
 {% block dropdown-trigger %}
 <span>{% trans "Move book" %}</span>
@@ -8,7 +9,16 @@
 {% endblock %}
 
 {% block dropdown-list %}
+{% with book.id|uuid as uuid %}
+{% active_shelf book as active_shelf %}
 {% for shelf in user_shelves %}
+<!--  TODO: 
+      #1 work out logic to both trigger the relevant modal for reading status ✅
+      #2 AND REMOVE FROM CURRENT SHELF ✅
+      #3 AND TRIGGER RELOAD even when readthrough shelf ✅
+
+      #4 disable if book is shelved on this shelf
+-->
 {% if shelf.editable %}
 <li role="menuitem" class="dropdown-item p-0">
     <form name="shelve" action="/shelve/" method="post">
@@ -19,6 +29,31 @@
         <button class="button is-fullwidth is-small shelf-option is-radiusless is-white" type="submit" {% if shelf.identifier == current.identifier %}disabled{% endif %}><span>{{ shelf.name }}</span></button>
     </form>
 </li>
+{% else%}
+{% with button_class="is-fullwidth is-small shelf-option is-radiusless is-white" %}
+<li role="menuitem" class="dropdown-item p-0">
+{% if shelf.identifier == 'reading' %}
+
+{% trans "Start reading" as button_text %}
+{% url 'reading-status' 'start' book.id as fallback_url %}
+{% include 'snippets/toggle/toggle_button.html' with class=button_class text=button_text controls_text="start_reading" controls_uid=uuid focus="modal_title_start_reading" disabled=is_current fallback_url=fallback_url %}
+
+
+{% elif shelf.identifier == 'read' %}
+
+{% trans "Read" as button_text %}
+{% url 'reading-status' 'finish' book.id as fallback_url %}
+{% include 'snippets/toggle/toggle_button.html' with class=button_class text=button_text controls_text="finish_reading" controls_uid=uuid focus="modal_title_finish_reading" disabled=is_current fallback_url=fallback_url %}
+
+{% elif shelf.identifier == 'to-read' %}
+
+{% trans "Want to read" as button_text %}
+{% url 'reading-status' 'want' book.id as fallback_url %}
+{% include 'snippets/toggle/toggle_button.html' with class=button_class text=button_text controls_text="want_to_read" controls_uid=uuid focus="modal_title_want_to_read" disabled=is_current fallback_url=fallback_url %}
+
+{% endif %}
+</li>
+{% endwith %}
 {% endif %}
 {% endfor %}
 <li class="navbar-divider" role="separator"></li>
@@ -30,4 +65,14 @@
         <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">{% trans "Remove" %}</button>
     </form>
 </li>
+
+{% include 'snippets/reading_modals/want_to_read_modal.html' with book=active_shelf.book controls_text="want_to_read" controls_uid=uuid move_from=current.id %}
+
+{% include 'snippets/reading_modals/start_reading_modal.html' with book=active_shelf.book controls_text="start_reading" controls_uid=uuid move_from=current.id %}
+
+{% include 'snippets/reading_modals/finish_reading_modal.html' with book=active_shelf.book controls_text="finish_reading" controls_uid=uuid  move_from=current.id readthrough=readthrough %}
+
+{% include 'snippets/reading_modals/progress_update_modal.html' with book=active_shelf.book controls_text="progress_update" controls_uid=uuid move_from=current.id readthrough=readthrough %}
+
+{% endwith %}
 {% endblock %}

--- a/bookwyrm/templates/snippets/shelve_button/shelve_button_dropdown_options.html
+++ b/bookwyrm/templates/snippets/shelve_button/shelve_button_dropdown_options.html
@@ -32,7 +32,7 @@
 
         {% elif shelf.editable %}
 
-            <form name="shelve" action="/shelve/" method="post">
+            <form name="shelve" action="/shelve/" method="post" autocomplete="off">
                 {% csrf_token %}
                 <input type="hidden" name="book" value="{{ active_shelf.book.id }}">
                 <button class="button {{ class }}" name="shelf" type="submit" value="{{ shelf.identifier }}" {% if shelf in book.shelf_set.all %} disabled {% endif %}>

--- a/bookwyrm/templates/snippets/toggle/toggle_button.html
+++ b/bookwyrm/templates/snippets/toggle/toggle_button.html
@@ -1,6 +1,6 @@
 {% load utilities %}
 {% if fallback_url %}
-<form name="fallback_form_{{ 0|uuid }}" method="GET" action="{{ fallback_url }}">
+<form name="fallback_form_{{ 0|uuid }}" method="GET" action="{{ fallback_url }}" autocomplete="off">
 {% endif %}
 <button
     {% if not fallback_url %}

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -41,17 +41,6 @@ def get_book_description(book):
     return book.description or book.parent_work.description
 
 
-@register.filter(name="is_shelf_type")
-def is_shelf_type(current_shelf, shelf_type):
-    """is this shelf a readthrough shelf?"""
-    readthrough = current_shelf in ["to-read", "reading", "read"]
-    if shelf_type == "readthrough" and bool(readthrough):
-        return True
-    if shelf_type == "custom" and not readthrough:
-        return True
-    return False
-
-
 @register.filter(name="next_shelf")
 def get_next_shelf(current_shelf):
     """shelf you'd use to update reading progress"""

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -77,7 +77,8 @@ def related_status(notification):
 def active_shelf(context, book):
     """check what shelf a user has a book on, if any"""
     if hasattr(book, "current_shelves"):
-        return book.current_shelves[0] if len(book.current_shelves) else {"book": book}
+        read_shelves = [s for s in book.current_shelves if s.shelf.identifier in models.Shelf.READ_STATUS_IDENTIFIERS]
+        return read_shelves[0] if len(read_shelves) else {"book": book}
 
     shelf = (
         models.ShelfBook.objects.filter(

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -41,6 +41,17 @@ def get_book_description(book):
     return book.description or book.parent_work.description
 
 
+@register.filter(name="is_shelf_type")
+def shelf_type(current_shelf, shelf_type):
+    """is this shelf a readthrough shelf?"""
+    readthrough = current_shelf in ["to-read", "reading", "read"]
+    if shelf_type == "readthrough" and readthrough == True:
+        return True
+    if shelf_type == "custom" and readthrough == False:
+        return True
+    return False
+
+
 @register.filter(name="next_shelf")
 def get_next_shelf(current_shelf):
     """shelf you'd use to update reading progress"""

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -77,7 +77,11 @@ def related_status(notification):
 def active_shelf(context, book):
     """check what shelf a user has a book on, if any"""
     if hasattr(book, "current_shelves"):
-        read_shelves = [s for s in book.current_shelves if s.shelf.identifier in models.Shelf.READ_STATUS_IDENTIFIERS]
+        read_shelves = [
+            s
+            for s in book.current_shelves
+            if s.shelf.identifier in models.Shelf.READ_STATUS_IDENTIFIERS
+        ]
         return read_shelves[0] if len(read_shelves) else {"book": book}
 
     shelf = (

--- a/bookwyrm/templatetags/bookwyrm_tags.py
+++ b/bookwyrm/templatetags/bookwyrm_tags.py
@@ -42,12 +42,12 @@ def get_book_description(book):
 
 
 @register.filter(name="is_shelf_type")
-def shelf_type(current_shelf, shelf_type):
+def is_shelf_type(current_shelf, shelf_type):
     """is this shelf a readthrough shelf?"""
     readthrough = current_shelf in ["to-read", "reading", "read"]
-    if shelf_type == "readthrough" and readthrough == True:
+    if shelf_type == "readthrough" and bool(readthrough):
         return True
-    if shelf_type == "custom" and readthrough == False:
+    if shelf_type == "custom" and not readthrough:
         return True
     return False
 

--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -91,17 +91,18 @@ class ReadingStatus(View):
             handle_reading_status(request.user, desired_shelf, book, privacy)
 
         # if the request includes a "shelf" value we are using the 'move' button
-        if bool(request.POST.get("shelf")): 
+        if bool(request.POST.get("shelf")):
             # unshelve the existing shelf
             this_shelf = request.POST.get("shelf")
             if (
-                bool(current_status_shelfbook) and 
-                int(this_shelf) != int(current_status_shelfbook.shelf.id) and
-                current_status_shelfbook.shelf.identifier != desired_shelf.identifier
-                ):
+                bool(current_status_shelfbook)
+                and int(this_shelf) != int(current_status_shelfbook.shelf.id)
+                and current_status_shelfbook.shelf.identifier
+                != desired_shelf.identifier
+            ):
                 return unshelve(request, referer=referer, book_id=book_id)
             # don't try to unshelve a read status shelf: it has already been deleted.
-            return HttpResponse(headers={"forceReload" : "true"}) 
+            return HttpResponse(headers={"forceReload": "true"})
 
         if is_api_request(request):
             return HttpResponse()

--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -101,7 +101,7 @@ class ReadingStatus(View):
                 and current_status_shelfbook.shelf.identifier
                 != desired_shelf.identifier
             ):
-                return unshelve(request, referer=referer, book_id=book_id)
+                return unshelve(request, book_id=book_id)
 
         if is_api_request(request):
             return HttpResponse()

--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -102,8 +102,6 @@ class ReadingStatus(View):
                 != desired_shelf.identifier
             ):
                 return unshelve(request, referer=referer, book_id=book_id)
-            # don't try to unshelve a read status shelf: it has already been deleted.
-            return HttpResponse(headers={"forceReload": "true"})
 
         if is_api_request(request):
             return HttpResponse()

--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -17,6 +17,7 @@ from .helpers import load_date_in_user_tz_as_utc
 
 @method_decorator(login_required, name="dispatch")
 # pylint: disable=no-self-use
+# pylint: disable=too-many-return-statements
 class ReadingStatus(View):
     """consider reading a book"""
 

--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -86,8 +86,6 @@ class ReadingStatus(View):
         if request.POST.get("post-status"):
             # is it a comment?
             if request.POST.get("content"):
-                # BUG: there is a problem posting statuses with comments (doesn't force reload)
-                # there is a DIFFERENT problem *updating* read statuses/comments
                 return CreateStatus.as_view()(request, "comment")
             privacy = request.POST.get("privacy")
             handle_reading_status(request.user, desired_shelf, book, privacy)

--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -96,7 +96,11 @@ class ReadingStatus(View):
         if bool(request.POST.get("shelf")): 
             # unshelve the existing shelf
             this_shelf = request.POST.get("shelf")
-            if int(this_shelf) not in [1,2,3]:
+            if (
+                bool(current_status_shelfbook) and 
+                int(this_shelf) != int(current_status_shelfbook.shelf.id) and
+                current_status_shelfbook.shelf.identifier != desired_shelf.identifier
+                ):
                 return unshelve(request, referer=referer, book_id=book_id)
             # don't try to unshelve a read status shelf: it has already been deleted.
             return HttpResponse(headers={"forceReload" : "true"}) 

--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -86,15 +86,19 @@ class ReadingStatus(View):
         if request.POST.get("post-status"):
             # is it a comment?
             if request.POST.get("content"):
-                # BUG: there is a problem posting statuses for finishing
-                # check whether it existed before.
+                # BUG: there is a problem posting statuses with comments (doesn't force reload)
+                # there is a DIFFERENT problem *updating* read statuses/comments
                 return CreateStatus.as_view()(request, "comment")
             privacy = request.POST.get("privacy")
             handle_reading_status(request.user, desired_shelf, book, privacy)
 
+        # if the request includes a "shelf" value we are using the 'move' button
         if bool(request.POST.get("shelf")): 
-            if current_status_shelfbook is None:
+            # unshelve the existing shelf
+            this_shelf = request.POST.get("shelf")
+            if int(this_shelf) not in [1,2,3]:
                 return unshelve(request, referer=referer, book_id=book_id)
+            # don't try to unshelve a read status shelf: it has already been deleted.
             return HttpResponse(headers={"forceReload" : "true"}) 
 
         if is_api_request(request):

--- a/bookwyrm/views/shelf/shelf_actions.py
+++ b/bookwyrm/views/shelf/shelf_actions.py
@@ -1,7 +1,6 @@
 """ shelf views """
 from django.db import IntegrityError, transaction
 from django.contrib.auth.decorators import login_required
-from django.http.response import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.views.decorators.http import require_POST
 
@@ -92,7 +91,7 @@ def shelve(request):
 
 @login_required
 @require_POST
-def unshelve(request, referer=None, book_id=False):
+def unshelve(request, book_id=False):
     """remove a book from a user's shelf"""
     identity = book_id if book_id else request.POST.get("book")
     book = get_object_or_404(models.Edition, id=identity)

--- a/bookwyrm/views/shelf/shelf_actions.py
+++ b/bookwyrm/views/shelf/shelf_actions.py
@@ -102,5 +102,5 @@ def unshelve(request, referer=None, book_id=False):
     shelf_book.raise_not_deletable(request.user)
     shelf_book.delete()
     if bool(referer):
-        return HttpResponse(headers={"forceReload" : "true"}) 
+        return HttpResponse(headers={"forceReload": "true"})
     return redirect(request.headers.get("Referer", "/"))

--- a/bookwyrm/views/shelf/shelf_actions.py
+++ b/bookwyrm/views/shelf/shelf_actions.py
@@ -101,6 +101,4 @@ def unshelve(request, referer=None, book_id=False):
     )
     shelf_book.raise_not_deletable(request.user)
     shelf_book.delete()
-    if bool(referer):
-        return HttpResponse(headers={"forceReload": "true"})
     return redirect(request.headers.get("Referer", "/"))

--- a/bookwyrm/views/shelf/shelf_actions.py
+++ b/bookwyrm/views/shelf/shelf_actions.py
@@ -94,8 +94,8 @@ def shelve(request):
 @require_POST
 def unshelve(request, referer=None, book_id=False):
     """remove a book from a user's shelf"""
-    id = book_id if book_id else request.POST.get("book")
-    book = get_object_or_404(models.Edition, id=id)
+    identity = book_id if book_id else request.POST.get("book")
+    book = get_object_or_404(models.Edition, id=identity)
     shelf_book = get_object_or_404(
         models.ShelfBook, book=book, shelf__id=request.POST["shelf"]
     )

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -125,10 +125,6 @@ class CreateStatus(View):
             except Http404:
                 pass
 
-        # force page reload if this was triggered from 'move' button
-        if bool(request.POST.get("shelf")):
-            return HttpResponse(headers={"forceReload": "true"})
-
         if is_api_request(request):
             return HttpResponse()
         return redirect("/")

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -162,8 +162,6 @@ def update_progress(request, book_id):  # pylint: disable=unused-argument
 @require_POST
 def edit_readthrough(request):
     """can't use the form because the dates are too finnicky"""
-    # BUG when triggering finish reading with comments and no previous readthroughs
-    # this will 404
     readthrough = get_object_or_404(models.ReadThrough, id=request.POST.get("id"))
     readthrough.raise_not_editable(request.user)
 

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -126,7 +126,7 @@ class CreateStatus(View):
 
         # force page reload if this was triggered from 'move' button
         if bool(request.POST.get("shelf")):
-            return HttpResponse(headers={"forceReload" : "true"}) 
+            return HttpResponse(headers={"forceReload": "true"})
 
         if is_api_request(request):
             return HttpResponse()

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -118,10 +118,11 @@ class CreateStatus(View):
         status.save(created=created)
 
         # update a readthrough, if needed
-        try:
-            edit_readthrough(request)
-        except Http404:
-            pass
+        if bool(request.POST.get("id")):
+            try:
+                edit_readthrough(request)
+            except Http404:
+                pass
 
         # force page reload if this was triggered from 'move' button
         if bool(request.POST.get("shelf")):

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -117,11 +117,15 @@ class CreateStatus(View):
 
         status.save(created=created)
 
-        # update a readthorugh, if needed
+        # update a readthrough, if needed
         try:
             edit_readthrough(request)
         except Http404:
             pass
+
+        # force page reload if this was triggered from 'move' button
+        if bool(request.POST.get("shelf")):
+            return HttpResponse(headers={"forceReload" : "true"}) 
 
         if is_api_request(request):
             return HttpResponse()
@@ -157,6 +161,8 @@ def update_progress(request, book_id):  # pylint: disable=unused-argument
 @require_POST
 def edit_readthrough(request):
     """can't use the form because the dates are too finnicky"""
+    # BUG when triggering finish reading with comments and no previous readthroughs
+    # this will 404
     readthrough = get_object_or_404(models.ReadThrough, id=request.POST.get("id"))
     readthrough.raise_not_editable(request.user)
 

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -54,6 +54,7 @@ class CreateStatus(View):
         data = {"book": book}
         return TemplateResponse(request, "compose.html", data)
 
+    # pylint: disable=too-many-branches
     def post(self, request, status_type, existing_status_id=None):
         """create status of whatever type"""
         created = not existing_status_id


### PR DESCRIPTION
- disallow moving from custom shelf to a reading status shelf with `shelf_selector`
- always use `shelve_button` for moving books from a reading status shelf
- redesign shelf information as a list of boxes

Fixes #1582 

If the book is on a shelf, it will now display as shown below. Note that 

1. the heading only appears if the book has been shelved, and
2. it is not possible to move directly from a custom shelf to a reading status shelf, as seen in the image.

I haven't touched the reading status button so you can still add to a custom shelf using that. I find this a little confusing because it adds it rather than moving it, but that's not in scope for this fix so it's a conversation we can have, if necessary, some other time.

![Screen Shot 2021-11-15 at 8 53 01 pm](https://user-images.githubusercontent.com/17669239/141762780-cc6f23ca-951b-4562-8456-52e1f72f10b6.png)


