### PR TITLE
Comment out trailing block ending in production nginx config template

### DIFF
--- a/nginx/production
+++ b/nginx/production
@@ -17,7 +17,8 @@ server {
 
 #     # redirect http to https
 #     return 301 https://your-domain.com$request_uri;
-# }
+}
+
 #
 # server {
 #     listen [::]:443 ssl http2;
@@ -54,7 +55,7 @@ server {
 #     location /static/ {
 #         alias /app/static/;
 #     }
-}
+# }
 
 # Reverse-Proxy server
 # server {


### PR DESCRIPTION
For people installing an instance with only the reverse proxy server, the hidden trailing `}` at the end of the second server block is quite hard to catch and it took me a good while to figure it out. Having the entire server commented out makes the whole process more understandable in my opinion.