### PR TITLE
removing quotes as they are interpreted as part of a value

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -69,7 +69,7 @@ AWS_SECRET_ACCESS_KEY=
 # or use_dominant_color_light / use_dominant_color_dark
 PREVIEW_BG_COLOR=use_dominant_color_light
 # Change to #FFF if you use use_dominant_color_dark
-PREVIEW_TEXT_COLOR="#363636"
+PREVIEW_TEXT_COLOR=#363636
 PREVIEW_IMG_WIDTH=1200
 PREVIEW_IMG_HEIGHT=630
-PREVIEW_DEFAULT_COVER_COLOR="#002549"
+PREVIEW_DEFAULT_COVER_COLOR=#002549

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -69,7 +69,7 @@ AWS_SECRET_ACCESS_KEY=
 # or use_dominant_color_light / use_dominant_color_dark
 PREVIEW_BG_COLOR=use_dominant_color_light
 # Change to #FFF if you use use_dominant_color_dark
-PREVIEW_TEXT_COLOR="#363636"
+PREVIEW_TEXT_COLOR=#363636
 PREVIEW_IMG_WIDTH=1200
 PREVIEW_IMG_HEIGHT=630
-PREVIEW_DEFAULT_COVER_COLOR="#002549"
+PREVIEW_DEFAULT_COVER_COLOR=#002549


### PR DESCRIPTION
quotes in env file are treated as a part of variable, removed.

fixes bookwyrm.preview_images.generate_edition_preview_image_task[6784c797-f91f-4d56-9cf3-3ffae5587e3f] raised unexpected: ValueError('unknown color specifier: '"#363636"'')