### PR TITLE
Adds sync_media_to_s3 command

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -155,13 +155,13 @@ case "$CMD" in
             --acl public-read" "$@"
         ;;
     set_cors_to_s3)
-	set +x
+        set +x
         config_file=$1
         if [ -z "$config_file" ]; then
             echo "This command requires a JSON file containing a CORS configuration as an argument"
             exit 1
         fi
-	set -x
+        set -x
         awscommand "$(pwd):/bw"\
             "s3api put-bucket-cors\
             --bucket ${AWS_STORAGE_BUCKET_NAME}\

--- a/bw-dev
+++ b/bw-dev
@@ -146,7 +146,13 @@ case "$CMD" in
         awscommand "bookwyrm_media_volume:/images"\
             "s3 cp /images s3://${AWS_STORAGE_BUCKET_NAME}/images\
             --endpoint-url ${AWS_S3_ENDPOINT_URL}\
-            --recursive --acl public-read"
+            --recursive --acl public-read" "$@"
+        ;;
+    sync_media_to_s3)
+        awscommand "bookwyrm_media_volume:/images"\
+            "s3 sync /images s3://${AWS_STORAGE_BUCKET_NAME}/images\
+            --endpoint-url ${AWS_S3_ENDPOINT_URL}\
+            --acl public-read" "$@"
         ;;
     set_cors_to_s3)
         awscommand "$(pwd):/bw"\
@@ -184,6 +190,7 @@ case "$CMD" in
         echo "    generate_thumbnails"
         echo "    generate_preview_images [--all]"
         echo "    copy_media_to_s3"
+        echo "    sync_media_to_s3"
         echo "    set_cors_to_s3 [cors file]"
         echo "    runweb [command]"
         ;;

--- a/bw-dev
+++ b/bw-dev
@@ -131,7 +131,7 @@ case "$CMD" in
         makeitblack
         ;;
     populate_streams)
-        runweb python manage.py populate_streams $@
+        runweb python manage.py populate_streams "$@"
         ;;
     populate_suggestions)
         runweb python manage.py populate_suggestions
@@ -140,7 +140,7 @@ case "$CMD" in
         runweb python manage.py generateimages
         ;;
     generate_preview_images)
-        runweb python manage.py generate_preview_images $@
+        runweb python manage.py generate_preview_images "$@"
         ;;
     copy_media_to_s3)
         awscommand "bookwyrm_media_volume:/images"\
@@ -155,11 +155,18 @@ case "$CMD" in
             --acl public-read" "$@"
         ;;
     set_cors_to_s3)
+	set +x
+        config_file=$1
+        if [ -z "$config_file" ]; then
+            echo "This command requires a JSON file containing a CORS configuration as an argument"
+            exit 1
+        fi
+	set -x
         awscommand "$(pwd):/bw"\
             "s3api put-bucket-cors\
             --bucket ${AWS_STORAGE_BUCKET_NAME}\
             --endpoint-url ${AWS_S3_ENDPOINT_URL}\
-            --cors-configuration file:///bw/$@"
+            --cors-configuration file:///bw/$config_file" "$@"
         ;;
     runweb)
         runweb "$@"


### PR DESCRIPTION
This just uses the AWS CLI `sync` command instead of `copy`. Sync checks against existing files in the bucket before uploading, so it's a good bit slower for an initial upload (for which `copy` should be used instead), but way faster for syncing a few updated files to an already-populated bucket. There's a companion PR over at https://github.com/bookwyrm-social/documentation/pull/50 that documents its use.