### PR TITLE
Front-end: Fix Safari details display and enhance dropdown on mobile

### DIFF
--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -93,6 +93,10 @@ body {
     display: inline !important;
 }
 
+
+/** File input styles
+ ******************************************************************************/
+
 input[type=file]::file-selector-button {
     -moz-appearance: none;
     -webkit-appearance: none;
@@ -119,17 +123,12 @@ input[type=file]::file-selector-button:hover {
     color: #363636;
 }
 
-details .dropdown-menu {
-    display: block !important;
-}
 
-details.dropdown[open] summary.dropdown-trigger::before {
-    content: "";
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+/** General `details` element styles
+ ******************************************************************************/
+
+summary::-webkit-details-marker {
+    display: none;
 }
 
 summary::marker {
@@ -145,6 +144,55 @@ summary::marker {
     float: left;
     width: -webkit-fill-available;
     margin-top: 1em;
+}
+
+/** Details dropdown
+ ******************************************************************************/
+
+details.dropdown[open] summary.dropdown-trigger::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}
+
+details .dropdown-menu {
+    display: block !important;
+}
+
+details .dropdown-menu button {
+    /* Fix weird Safari defaults */
+    box-sizing: border-box;
+}
+
+details.dropdown .dropdown-menu button:focus-visible,
+details.dropdown .dropdown-menu a:focus-visible {
+    outline-style: auto;
+    outline-offset: -2px;
+}
+
+@media only screen and (max-width: 768px) {
+    details.dropdown[open] summary.dropdown-trigger::before {
+        background-color:  rgba(0, 0, 0, 0.5);
+        z-index: 30;
+    }
+    details .dropdown-menu {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex !important;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        z-index: 100;
+    }
+    details .dropdown-menu > * {
+        pointer-events: all;
+    }
 }
 
 /** Shelving

--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -93,7 +93,6 @@ body {
     display: inline !important;
 }
 
-
 /** File input styles
  ******************************************************************************/
 
@@ -122,7 +121,6 @@ input[type=file]::file-selector-button:hover {
     border-color: #b5b5b5;
     color: #363636;
 }
-
 
 /** General `details` element styles
  ******************************************************************************/
@@ -175,9 +173,10 @@ details.dropdown .dropdown-menu a:focus-visible {
 
 @media only screen and (max-width: 768px) {
     details.dropdown[open] summary.dropdown-trigger::before {
-        background-color:  rgba(0, 0, 0, 0.5);
+        background-color: rgba(0, 0, 0, 0.5);
         z-index: 30;
     }
+
     details .dropdown-menu {
         position: fixed;
         top: 0;
@@ -190,6 +189,7 @@ details.dropdown .dropdown-menu a:focus-visible {
         pointer-events: none;
         z-index: 100;
     }
+    
     details .dropdown-menu > * {
         pointer-events: all;
     }

--- a/bookwyrm/static/css/bookwyrm.css
+++ b/bookwyrm/static/css/bookwyrm.css
@@ -189,7 +189,7 @@ details.dropdown .dropdown-menu a:focus-visible {
         pointer-events: none;
         z-index: 100;
     }
-    
+
     details .dropdown-menu > * {
         pointer-events: all;
     }

--- a/bookwyrm/static/js/bookwyrm.js
+++ b/bookwyrm/static/js/bookwyrm.js
@@ -52,6 +52,12 @@ let BookWyrm = new class {
                     this.duplicateInput.bind(this)
             
             ))
+        document.querySelectorAll('details.dropdown')
+                .forEach(node => node.addEventListener(
+                    'toggle',
+                    this.handleDetailsDropdown.bind(this)
+            
+            ))
     }
 
     /**
@@ -481,5 +487,99 @@ let BookWyrm = new class {
         });
 
         textareaEl.parentNode.appendChild(copyButtonEl)
+    }
+
+    /**
+     * Handle the details dropdown component.
+     *
+     * @param  {Event} event - Event fired by a `details` element
+     *                         with the `dropdown` class name, on toggle.
+     * @return {undefined}
+     */
+    handleDetailsDropdown(event) {
+        const detailsElement = event.target;
+        const summaryElement = detailsElement.querySelector('summary');
+        const menuElement = detailsElement.querySelector('.dropdown-menu');
+        const htmlElement = document.querySelector('html');
+
+        if (detailsElement.open) {
+            // Focus first menu element
+            menuElement.querySelectorAll(
+                'a[href]:not([disabled]), button:not([disabled])'
+            )[0].focus();
+            // Enable focus trap
+            menuElement.addEventListener('keydown', this.handleFocusTrap);
+            // Close on Esc
+            detailsElement.addEventListener('keydown', handleEscKey);
+
+            // Clip page if Mobile
+            if (this.isMobile()) {
+                htmlElement.classList.add('is-clipped');
+            }
+        } else {
+            summaryElement.focus();
+            // Disable focus trap
+            menuElement.removeEventListener('keydown', this.handleFocusTrap);
+
+            // Unclip page
+            if (this.isMobile()) {
+                htmlElement.classList.remove('is-clipped');
+            }
+        }
+
+        function handleEscKey(event) {
+            if (event.key !== 'Escape') { 
+                return; 
+            }
+
+            summaryElement.click();
+        }
+    }
+
+    /**
+     * Check if windows matches mobile media query.
+     *
+     * @return {Boolean}
+     */
+    isMobile() {
+        return window.matchMedia("(max-width: 768px)").matches;
+    }
+
+    /**
+     * Focus trap handler
+     *
+     * @param  {Event} event - Keydown event.
+     * @return {undefined}
+     */
+    handleFocusTrap(event) {
+        if (event.key !== 'Tab') { 
+            return; 
+        }
+
+        const focusableEls = event.currentTarget.querySelectorAll(
+            [
+                'a[href]:not([disabled])',
+                'button:not([disabled])',
+                'textarea:not([disabled])',
+                'input:not([type="hidden"]):not([disabled])',
+                'select:not([disabled])',
+                'details:not([disabled])',
+                '[tabindex]:not([tabindex="-1"]):not([disabled])'
+            ].join(',')
+        );
+        const firstFocusableEl = focusableEls[0];  
+        const lastFocusableEl = focusableEls[focusableEls.length - 1];
+
+        if (event.shiftKey ) /* Shift + tab */ {
+            if (document.activeElement === firstFocusableEl) {
+                lastFocusableEl.focus();
+                event.preventDefault();
+            }
+        } else /* Tab */ {
+            if (document.activeElement === lastFocusableEl) {
+                firstFocusableEl.focus();
+                event.preventDefault();
+            }
+        }
     }
 }();

--- a/bookwyrm/static/js/bookwyrm.js
+++ b/bookwyrm/static/js/bookwyrm.js
@@ -507,8 +507,10 @@ let BookWyrm = new class {
             menuElement.querySelectorAll(
                 'a[href]:not([disabled]), button:not([disabled])'
             )[0].focus();
+            
             // Enable focus trap
             menuElement.addEventListener('keydown', this.handleFocusTrap);
+            
             // Close on Esc
             detailsElement.addEventListener('keydown', handleEscKey);
 
@@ -518,6 +520,7 @@ let BookWyrm = new class {
             }
         } else {
             summaryElement.focus();
+            
             // Disable focus trap
             menuElement.removeEventListener('keydown', this.handleFocusTrap);
 

--- a/bookwyrm/templates/components/dropdown.html
+++ b/bookwyrm/templates/components/dropdown.html
@@ -15,7 +15,7 @@
         {% block dropdown-trigger %}{% endblock %}
     </summary>
 
-    <div class="dropdown-menu control">
+    <div class="dropdown-menu">
         <ul
             id="menu_options_{{ uuid }}"
             class="dropdown-content p-0 is-clipped"


### PR DESCRIPTION
## Safari display bug

### Before

<img width="199" alt="image" src="https://user-images.githubusercontent.com/1781070/146599316-5946a7ec-bd9f-4389-bdd1-b85dc4384798.png">
<img width="133" alt="image" src="https://user-images.githubusercontent.com/1781070/146599713-c1c658b2-5061-4e98-b67a-c9176607e45f.png">


### After
<img width="175" alt="image" src="https://user-images.githubusercontent.com/1781070/146599121-50444adf-81aa-47b0-9dca-d6161d1a1260.png">
<img width="197" alt="image" src="https://user-images.githubusercontent.com/1781070/146599126-8a927a53-4c72-441a-a21d-6032eb3c667c.png">

## Nicer dropdowns on Mobile

### Before

<img width="268" alt="image" src="https://user-images.githubusercontent.com/1781070/146599563-fe660cf8-2774-4778-83ad-40042201cd49.png">

### After

<img width="269" alt="image" src="https://user-images.githubusercontent.com/1781070/146599669-cf153945-eae3-4723-a642-2d738066e1f0.png">
