### PR TITLE
Tweaks mobile view for annual summary

### DIFF
--- a/bookwyrm/templates/annual_summary/layout.html
+++ b/bookwyrm/templates/annual_summary/layout.html
@@ -107,7 +107,7 @@
     <div class="columns is-mobile">
         <div class="column is-8 is-offset-2 has-text-centered">
             <h2 class="title is-3 is-serif">
-                {% blocktrans %}In {{ year }}, {{ display_name }} read {{ books_total }} books<br />for a total of {{ pages_total }} pages!{% endblocktrans %}
+                {% blocktrans with pages_total=pages_total|intcomma %}In {{ year }}, {{ display_name }} read {{ books_total }} books<br />for a total of {{ pages_total }} pages!{% endblocktrans %}
             </h2>
             <p class="subtitle is-5">{% trans "That’s great!" %}</p>
 
@@ -128,7 +128,7 @@
     </div>
 
     {% if book_pages_lowest and book_pages_highest %}
-    <div class="columns is-mobile is-align-items-center mt-5">
+    <div class="columns is-align-items-center mt-5">
         <div class="column is-2 is-offset-1">
             <a href="{{ book_pages_lowest.local_path }}">{% include 'snippets/book_cover.html' with book=book_pages_lowest cover_class='is-w-auto-tablet is-h-l-mobile' %}</a>
         </div>


### PR DESCRIPTION
before:
<img width="256" alt="Screen Shot 2021-12-28 at 7 11 27 AM" src="https://user-images.githubusercontent.com/1807695/147580684-5ca78e7a-2e59-4e77-974a-6d69d1257df0.png">

after:
<img width="257" alt="Screen Shot 2021-12-28 at 7 11 37 AM" src="https://user-images.githubusercontent.com/1807695/147580689-60cebedf-2d9e-4d60-970b-b354735b0594.png">

