### PR TITLE
Remove last lingering traces of fedireads name

### DIFF
--- a/bookwyrm/management/commands/populate_streams.py
+++ b/bookwyrm/management/commands/populate_streams.py
@@ -6,7 +6,7 @@ from bookwyrm import activitystreams, models
 def populate_streams(stream=None):
     """build all the streams for all the users"""
     streams = [stream] if stream else activitystreams.streams.keys()
-    print("Populations streams", streams)
+    print("Populating streams", streams)
     users = models.User.objects.filter(
         local=True,
         is_active=True,

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -125,9 +125,9 @@ STREAMS = [
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": env("POSTGRES_DB", "fedireads"),
-        "USER": env("POSTGRES_USER", "fedireads"),
-        "PASSWORD": env("POSTGRES_PASSWORD", "fedireads"),
+        "NAME": env("POSTGRES_DB", "bookwyrm"),
+        "USER": env("POSTGRES_USER", "bookwyrm"),
+        "PASSWORD": env("POSTGRES_PASSWORD", "bookwyrm"),
         "HOST": env("POSTGRES_HOST", ""),
         "PORT": env("PGPORT", 5432),
     },

--- a/postgres-docker/Dockerfile
+++ b/postgres-docker/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /backups
 COPY ./backup.sh /backups
 COPY ./weed.sh /backups
 COPY ./cronfile /etc/cron.d/cronfile
-RUN apt-get update && apt-get -y install cron
+RUN apt-get update && apt-get -y --no-install-recommends install cron
 RUN chmod 0644 /etc/cron.d/cronfile
 RUN crontab /etc/cron.d/cronfile
 RUN touch /var/log/cron.log

--- a/postgres-docker/backup.sh
+++ b/postgres-docker/backup.sh
@@ -3,5 +3,5 @@ if [ -z "$POSTGRES_DB" ]; then
     echo "Database not specified, defaulting to bookwyrm"
 fi
 BACKUP_DB=${POSTGRES_DB:-bookwyrm}
-filename=backup__$(date +%F)
+filename=backup_${BACKUP_DB}_$(date +%F)
 pg_dump -U $BACKUP_DB > /backups/$filename.sql

--- a/postgres-docker/backup.sh
+++ b/postgres-docker/backup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 filename=backup__$(date +%F)
-pg_dump -U fedireads  > /backups/$filename.sql
+pg_dump -U bookwyrm  > /backups/$filename.sql

--- a/postgres-docker/backup.sh
+++ b/postgres-docker/backup.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+if [ -z "$POSTGRES_DB" ]; then
+    echo "Database not specified, defaulting to bookwyrm"
+fi
+BACKUP_DB=${POSTGRES_DB:-bookwyrm}
 filename=backup__$(date +%F)
-pg_dump -U bookwyrm  > /backups/$filename.sql
+pg_dump -U $BACKUP_DB > /backups/$filename.sql


### PR DESCRIPTION
The defaults should be irrelevant if there's an env file in place, but the backup script actually will break backups, I think.

I also was blown away at what `apt-get install cron` was bringing with it, after some digging I added the flag to not install "recommended" dependencies which gets us a bunch of stuff we definitely don't need.