### PR TITLE
only show own shelves in shelf_selector dropdown

### DIFF
--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -63,16 +63,18 @@
 {% endfor %}
 
 {% if shelf.identifier == 'all' %}
-{% for shelved_in in book.shelves.all %}
+{% for user_shelf in user_shelves %}
+{% if user_shelf in book.shelves.all %}
 <li class="navbar-divider m-0" role="separator" ></li>
 <li role="menuitem" class="dropdown-item p-0">
     <form name="shelve" action="/unshelve/" method="post">
         {% csrf_token %}
         <input type="hidden" name="book" value="{{ book.id }}">
-        <input type="hidden" name="shelf" value="{{ shelved_in.id }}">
-        <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">{% trans "Remove from" %} {{ shelved_in.name }}</button>
+        <input type="hidden" name="shelf" value="{{ user_shelf.id }}">
+        <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">{% trans "Remove from" %} {{ user_shelf.name }}</button>
     </form>
 </li>
+{% endif %}
 {% endfor %}
 {% else %}
 <li class="navbar-divider" role="separator" ></li>


### PR DESCRIPTION
Fixes the problem of multiple "remove from" listings. Prior to this fix, ALL shelves linked to the book via a ShelfBook were listed, regardless of who the shelf belonged to.

Ideally for merging prior to #1740, which in combination should resolve #1643