### PR TITLE
increasing rsa key size

### DIFF
--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -15,7 +15,7 @@ MAX_SIGNATURE_AGE = 300
 def create_key_pair():
     """a new public/private key pair, used for creating new users"""
     random_generator = Random.new().read
-    key = RSA.generate(1024, random_generator)
+    key = RSA.generate(2048, random_generator)
     private_key = key.export_key().decode("utf8")
     public_key = key.public_key().export_key().decode("utf8")
 


### PR DESCRIPTION
should address this issue:

Creation of an RSA key uses  bits, which is below 2048 and considered breakable.

Not sure if that breaks anything - have to be careful..
