### PR TITLE
Change thumbnail generation strategy

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -191,7 +191,7 @@ USER_AGENT = f"{agent} (BookWyrm/{VERSION}; +https://{DOMAIN}/)"
 ENABLE_THUMBNAIL_GENERATION = env.bool("ENABLE_THUMBNAIL_GENERATION", False)
 IMAGEKIT_CACHEFILE_DIR = "thumbnails"
 #IMAGEKIT_DEFAULT_CACHEFILE_BACKEND = "imagekit.cachefiles.backends.Celery"
-IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = "imagekit.cachefiles.strategies.Optimistic"
+IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = "bookwyrm.thumbnail_generation.Strategy"
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -190,7 +190,7 @@ USER_AGENT = f"{agent} (BookWyrm/{VERSION}; +https://{DOMAIN}/)"
 # Imagekit generated thumbnails
 ENABLE_THUMBNAIL_GENERATION = env.bool("ENABLE_THUMBNAIL_GENERATION", False)
 IMAGEKIT_CACHEFILE_DIR = "thumbnails"
-#IMAGEKIT_DEFAULT_CACHEFILE_BACKEND = "imagekit.cachefiles.backends.Celery"
+# IMAGEKIT_DEFAULT_CACHEFILE_BACKEND = "imagekit.cachefiles.backends.Celery"
 IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = "bookwyrm.thumbnail_generation.Strategy"
 
 # Static files (CSS, JavaScript, Images)

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -190,6 +190,8 @@ USER_AGENT = f"{agent} (BookWyrm/{VERSION}; +https://{DOMAIN}/)"
 # Imagekit generated thumbnails
 ENABLE_THUMBNAIL_GENERATION = env.bool("ENABLE_THUMBNAIL_GENERATION", False)
 IMAGEKIT_CACHEFILE_DIR = "thumbnails"
+#IMAGEKIT_DEFAULT_CACHEFILE_BACKEND = "imagekit.cachefiles.backends.Celery"
+IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = "imagekit.cachefiles.strategies.Optimistic"
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -190,7 +190,6 @@ USER_AGENT = f"{agent} (BookWyrm/{VERSION}; +https://{DOMAIN}/)"
 # Imagekit generated thumbnails
 ENABLE_THUMBNAIL_GENERATION = env.bool("ENABLE_THUMBNAIL_GENERATION", False)
 IMAGEKIT_CACHEFILE_DIR = "thumbnails"
-# IMAGEKIT_DEFAULT_CACHEFILE_BACKEND = "imagekit.cachefiles.backends.Celery"
 IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = "bookwyrm.thumbnail_generation.Strategy"
 
 # Static files (CSS, JavaScript, Images)

--- a/bookwyrm/thumbnail_generation.py
+++ b/bookwyrm/thumbnail_generation.py
@@ -1,0 +1,14 @@
+class Strategy:
+    """
+    A strategy that generates the image on source saved (Optimistic),
+    but also on demand, for old images (JustInTime).
+    """
+
+    def on_source_saved(self, file):
+        file.generate()
+
+    def on_existence_required(self, file):
+        file.generate()
+
+    def on_content_required(self, file):
+        file.generate()

--- a/bookwyrm/thumbnail_generation.py
+++ b/bookwyrm/thumbnail_generation.py
@@ -1,14 +1,18 @@
+"""thumbnail generation strategy for django-imagekit"""
 class Strategy:
     """
     A strategy that generates the image on source saved (Optimistic),
     but also on demand, for old images (JustInTime).
     """
 
-    def on_source_saved(self, file):
+    def on_source_saved(self, file):  # pylint: disable=no-self-use
+        """What happens on source saved"""
         file.generate()
 
-    def on_existence_required(self, file):
+    def on_existence_required(self, file):  # pylint: disable=no-self-use
+        """What happens on existence required"""
         file.generate()
 
-    def on_content_required(self, file):
+    def on_content_required(self, file):  # pylint: disable=no-self-use
+        """What happens on content required"""
         file.generate()

--- a/bookwyrm/thumbnail_generation.py
+++ b/bookwyrm/thumbnail_generation.py
@@ -1,4 +1,6 @@
 """thumbnail generation strategy for django-imagekit"""
+
+
 class Strategy:
     """
     A strategy that generates the image on source saved (Optimistic),


### PR DESCRIPTION
I've looked at the thumbnail generation settings. Right now it's working with the default config:

```
IMAGEKIT_DEFAULT_CACHEFILE_BACKEND = 'imagekit.cachefiles.backends.Simple'
IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = 	'imagekit.cachefiles.strategies.JustInTime'
```

(from https://django-imagekit.readthedocs.io/en/latest/configuration.html)
- The `JustInTime` strategy generates the thumbnail file when it's existence is needed (if not already generated)
- The `Simple` backend uses the main process to generate the thumbnail files

So basically, if you have a page with loads of books with a thumbnail size that haven't been generated yet, the server will generate them on the fly—hence, the timeouts I experienced on my Annual Summary page

~This PR switches to a `Celery` backend, and an `Optimistic` strategy, where the thumbnails will be generated asynchronously (through Celery) when the cover image is uploaded/the book is imported~

~Because the `Optimistic` strategy disables the check to see if the image has been generated, if we change the strategy from `JustInTime` we'll have to generate all the images with `./bw-dev generate_thumbnails` (I think)~

This PR switches the default strategy to a custom strategy that will generate thumbnails on source creation (when the cover image is uploaded/book is imported), as well as when the thumb is required but didn't exist