### PR TITLE
do not cache registration form

### DIFF
--- a/bookwyrm/templates/landing/landing.html
+++ b/bookwyrm/templates/landing/landing.html
@@ -1,11 +1,13 @@
 {% extends 'landing/layout.html' %}
 {% load i18n %}
+{% load cache %}
 {% block panel %}
 
 <div class="block is-hidden-tablet">
     <h2 class="title has-text-centered">{% trans "Recent Books" %}</h2>
 </div>
 
+{% cache 60 * 60 %}
 <section class="tile is-ancestor">
     <div class="tile is-vertical is-6">
         <div class="tile is-parent">
@@ -46,5 +48,5 @@
         </div>
     </div>
 </section>
-
+{% endcache %}
 {% endblock %}

--- a/bookwyrm/views/landing/landing.py
+++ b/bookwyrm/views/landing/landing.py
@@ -1,8 +1,6 @@
 """ non-interactive pages """
 from django.template.response import TemplateResponse
 from django.views import View
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 
 from bookwyrm import forms
 from bookwyrm.views import helpers

--- a/bookwyrm/views/landing/landing.py
+++ b/bookwyrm/views/landing/landing.py
@@ -33,7 +33,6 @@ class Home(View):
 class Landing(View):
     """preview of recently reviewed books"""
 
-    @method_decorator(cache_page(60 * 60), name="dispatch")
     def get(self, request):
         """tiled book activity page"""
         data = {


### PR DESCRIPTION
Fixes #1777

Caching the Landing view also caches the registration form, including the CSRF value.

This moves the caching into the recently reviewed books landing template which is presumably what we're trying to cache here, instead of caching the whole view.

NOTE: this fixes the problem with registration, I haven't done enough testing to be sure it actually still caches the recent reviews data.