### PR TITLE
Fix follow recommendation modal failing on signup

### DIFF
--- a/bookwyrm/views/get_started.py
+++ b/bookwyrm/views/get_started.py
@@ -118,8 +118,8 @@ class GetStartedUsers(View):
         data = {"no_results": not user_results}
 
         if user_results.count() < 5:
-            user_results = list(user_results) + suggested_users.get_suggestions(
-                request.user
+            user_results = list(user_results) + list(suggested_users.get_suggestions(
+                request.user)
             )
 
         data["suggested_users"] = user_results

--- a/bookwyrm/views/get_started.py
+++ b/bookwyrm/views/get_started.py
@@ -118,8 +118,8 @@ class GetStartedUsers(View):
         data = {"no_results": not user_results}
 
         if user_results.count() < 5:
-            user_results = list(user_results) + list(suggested_users.get_suggestions(
-                request.user)
+            user_results = list(user_results) + list(
+                suggested_users.get_suggestions(request.user)
             )
 
         data["suggested_users"] = user_results


### PR DESCRIPTION
You can't concatenate a list with a queryset, nor two querysets, apparently.