### PR TITLE
Add end message for populate_list_streams command

### DIFF
--- a/bookwyrm/management/commands/populate_lists_streams.py
+++ b/bookwyrm/management/commands/populate_lists_streams.py
@@ -14,6 +14,7 @@ def populate_lists_streams():
     for user in users:
         print(".", end="")
         lists_stream.populate_lists_task.delay(user.id)
+    print("\nAll done, thank you for your patience!")
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
## Before

```
bookwyrm@scw-de86e3:~/bookwyrm$ ./bw-dev populate_lists_streams
+ CMD=populate_lists_streams
+ '[' -n populate_lists_streams ']'
+ shift
+ set -x
+ case "$CMD" in
+ runweb python manage.py populate_lists_streams
+ docker-compose run --rm web python manage.py populate_lists_streams
Creating bookwyrm_web_run ... done
Populating lists streams
This may take a long time! Please be patient.
......bookwyrm@scw-de86e3:~/bookwyrm$
```

## After

```
bookwyrm@scw-de86e3:~/bookwyrm$ ./bw-dev populate_lists_streams
+ case "$CMD" in
+ runweb python manage.py populate_lists_streams
+ docker-compose run --rm web python manage.py populate_lists_streams
Creating bookwyrm_web_run ... done
Populating lists streams
This may take a long time! Please be patient.
..
All done, thank you for your patience!

bookwyrm@scw-de86e3:~/bookwyrm$
```
