### PR TITLE
Make log level configurable, override default logging config

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -124,6 +124,10 @@ LOGGING = {
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
             'propagate': False,
         },
+        'bookwyrm': {
+            'handlers': ['console'],
+            'level': os.getenv('LOG_LEVEL', 'DEBUG' if DEBUG else 'INFO').upper(),
+        }
     },
 }
 

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -106,31 +106,31 @@ TEMPLATES = [
     },
 ]
 
-LOG_LEVEL = env('LOG_LEVEL', 'INFO').upper()
+LOG_LEVEL = env("LOG_LEVEL", "INFO").upper()
 # Override aspects of the default handler to our taste
 # See https://docs.djangoproject.com/en/3.2/topics/logging/#default-logging-configuration
 # for a reference to the defaults we're overriding
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
         # Overrides the default handler, which does not log in prod
-        'console': {
-            'level': LOG_LEVEL,
-            'class': 'logging.StreamHandler',
+        "console": {
+            "level": LOG_LEVEL,
+            "class": "logging.StreamHandler",
         },
     },
-    'loggers': {
+    "loggers": {
         # Override the log level for the default logger
-        'django': {
-            'handlers': ['console', 'mail_admins'],
-            'level': LOG_LEVEL,
+        "django": {
+            "handlers": ["console", "mail_admins"],
+            "level": LOG_LEVEL,
         },
         # Add a bookwyrm-specific logger
-        'bookwyrm': {
-            'handlers': ['console'],
-            'level': LOG_LEVEL,
-        }
+        "bookwyrm": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+        },
     },
 }
 

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -106,27 +106,30 @@ TEMPLATES = [
     },
 ]
 
+LOG_LEVEL = env('LOG_LEVEL', 'INFO').upper()
+# Override aspects of the default handler to our taste
+# See https://docs.djangoproject.com/en/3.2/topics/logging/#default-logging-configuration
+# for a reference to the defaults we're overriding
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'handlers': {
+        # Overrides the default handler, which does not log in prod
         'console': {
+            'level': LOG_LEVEL,
             'class': 'logging.StreamHandler',
         },
     },
-    'root': {
-        'handlers': ['console'],
-        'level': 'WARNING',
-    },
     'loggers': {
+        # Override the log level for the default logger
         'django': {
-            'handlers': ['console'],
-            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
-            'propagate': False,
+            'handlers': ['console', 'mail_admins'],
+            'level': LOG_LEVEL,
         },
+        # Add a bookwyrm-specific logger
         'bookwyrm': {
             'handlers': ['console'],
-            'level': os.getenv('LOG_LEVEL', 'DEBUG' if DEBUG else 'INFO').upper(),
+            'level': LOG_LEVEL,
         }
     },
 }

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -110,18 +110,42 @@ LOG_LEVEL = env("LOG_LEVEL", "INFO").upper()
 # Override aspects of the default handler to our taste
 # See https://docs.djangoproject.com/en/3.2/topics/logging/#default-logging-configuration
 # for a reference to the defaults we're overriding
+#
+# It seems that in order to override anything you have to include its
+# entire dependency tree (handlers and filters) which makes this a
+# bit verbose
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        # These are copied from the default configuration, required for
+        # implementing mail_admins below
+        "require_debug_false": {
+            "()": "django.utils.log.RequireDebugFalse",
+        },
+        "require_debug_true": {
+            "()": "django.utils.log.RequireDebugTrue",
+        },
+    },
     "handlers": {
-        # Overrides the default handler, which does not log in prod
+        # Overrides the default handler to make it log to console
+        # regardless of the DEBUG setting (default is to not log to
+        # console if DEBUG=False)
         "console": {
             "level": LOG_LEVEL,
             "class": "logging.StreamHandler",
         },
+        # This is copied as-is from the default logger, and is
+        # required for the django section below
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
+        },
     },
     "loggers": {
-        # Override the log level for the default logger
+        # Install our new console handler for Django's logger, and
+        # override the log level while we're at it
         "django": {
             "handlers": ["console", "mail_admins"],
             "level": LOG_LEVEL,

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -106,6 +106,27 @@ TEMPLATES = [
     },
 ]
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'WARNING',
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+            'propagate': False,
+        },
+    },
+}
+
 
 WSGI_APPLICATION = "bookwyrm.wsgi.application"
 

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -1,7 +1,10 @@
 """ incoming activities """
 import json
 import re
+import logging
+
 from urllib.parse import urldefrag
+import requests
 
 from django.http import HttpResponse, Http404
 from django.core.exceptions import BadRequest, PermissionDenied
@@ -9,8 +12,6 @@ from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
-import requests
-import logging
 
 from bookwyrm import activitypub, models
 from bookwyrm.tasks import app

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -74,7 +74,7 @@ def raise_is_blocked_user_agent(request):
         return
     url = url.group()
     if models.FederatedServer.is_blocked(url):
-        logger.debug(f"{url} is blocked, denying request based on user agent")
+        logger.debug("%s is blocked, denying request based on user agent", url)
         raise PermissionDenied()
 
 
@@ -89,11 +89,11 @@ def raise_is_blocked_activity(activity_json):
     # check if the user is banned/deleted
     existing = models.User.find_existing_by_remote_id(actor)
     if existing and existing.deleted:
-        logger.debug(f"{actor} is banned/deleted, denying request based on actor")
+        logger.debug("%s is banned/deleted, denying request based on actor", actor)
         raise PermissionDenied()
 
     if models.FederatedServer.is_blocked(actor):
-        logger.debug(f"{actor} is blocked, denying request based on actor")
+        logger.debug("%s is blocked, denying request based on actor", actor)
         raise PermissionDenied()
 
 

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -19,6 +19,7 @@ from bookwyrm.utils import regex
 
 logger = logging.getLogger(__name__)
 
+
 @method_decorator(csrf_exempt, name="dispatch")
 # pylint: disable=no-self-use
 class Inbox(View):


### PR DESCRIPTION
This should fix #1789 and #1787 - I have yet to actually test this, so don't merge right away, I couldn't figure out how to make it a draft.

The reason we aren't logging 500s in production is becuase Django [by default doesn't log _anything_ in production](https://docs.djangoproject.com/en/3.2/topics/logging/#default-logging-configuration), it just emails. This changes the default to log INFO messages and above regardless of the value of DEBUG - we could change that if we wanted, and, like, only log WARNING/ERROR (which is what it maps 400s and 500s to, respectively) by default in production, by changing what the default log level is depending on the value of DEBUG.