### PR TITLE
Use run --rm in `update` command

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -81,9 +81,9 @@ case "$CMD" in
     update)
         git pull
         docker-compose build --no-cache
-        docker-compose exec web python manage.py migrate
-        docker-compose exec web python manage.py collectstatic --no-input
-        docker-compose restart
+        runweb python manage.py migrate
+        runweb python manage.py collectstatic --no-input
+        docker-compose up -d
         ;;
     populate_streams)
         runweb python manage.py populate_streams "$@"

--- a/bw-dev
+++ b/bw-dev
@@ -80,7 +80,7 @@ case "$CMD" in
         ;;
     update)
         git pull
-        docker-compose build --no-cache
+        docker-compose build
         runweb python manage.py migrate
         runweb python manage.py collectstatic --no-input
         docker-compose up -d


### PR DESCRIPTION
Partial fix for #1785 - preivously we would run the migrate and collect
commands with exec, which would run them in the running (and thus old)
contianers, but with the new code. This caused issues when, for example,
new dependencies were introduced, which weren't built into the old
containers.

Instead, use run --rm to spin up temporary instances of the new
containers to do the commands.