### PR TITLE
Fixes weird display of author page

### DIFF
--- a/bookwyrm/templates/author/author.html
+++ b/bookwyrm/templates/author/author.html
@@ -23,18 +23,13 @@
     </div>
 </div>
 
-<div class="block columns is-flex-direction-row-reverse" itemscope itemtype="https://schema.org/Person">
+<div class="block columns" itemscope itemtype="https://schema.org/Person">
     <meta itemprop="name" content="{{ author.name }}">
-    {% if author.bio %}
-    <div class="column">
-        {% include "snippets/trimmed_text.html" with full=author.bio trim_length=200 %}
-    </div>
-    {% endif %}
 
     {% firstof author.aliases author.born author.died as details %}
     {% firstof author.wikipedia_link author.openlibrary_key author.inventaire_id author.isni as links %}
     {% if details or links %}
-    <div class="column is-two-fifths">
+    <div class="column is-3">
         {% if details %}
         <section class="block content">
             <h2 class="title is-4">{% trans "Author details" %}</h2>
@@ -137,26 +132,28 @@
         {% endif %}
     </div>
     {% endif %}
-</div>
 
-<hr aria-hidden="true">
+    <div class="column">
+        {% if author.bio %}
+        {% include "snippets/trimmed_text.html" with full=author.bio trim_length=200 %}
+        {% endif %}
 
-<div class="block">
-    <h2 class="title is-4">{% blocktrans with name=author.name %}Books by {{ name }}{% endblocktrans %}</h2>
-    <div class="columns is-multiline is-mobile">
-    {% for book in books %}
-        <div class="column is-one-fifth-tablet is-half-mobile is-flex is-flex-direction-column">
-            <div class="is-flex-grow-1">
-                {% include 'landing/small-book.html' with book=book %}
+        <h2 class="title is-4">{% blocktrans with name=author.name %}Books by {{ name }}{% endblocktrans %}</h2>
+        <div class="columns is-multiline is-mobile">
+        {% for book in books %}
+            <div class="column is-one-fifth-tablet is-half-mobile is-flex is-flex-direction-column">
+                <div class="is-flex-grow-1">
+                    {% include 'landing/small-book.html' with book=book %}
+                </div>
+                {% include 'snippets/shelve_button/shelve_button.html' with book=book %}
             </div>
-            {% include 'snippets/shelve_button/shelve_button.html' with book=book %}
+        {% endfor %}
         </div>
-    {% endfor %}
-    </div>
-</div>
 
-<div>
-    {% include 'snippets/pagination.html' with page=books %}
+        <div>
+            {% include 'snippets/pagination.html' with page=books %}
+        </div>
+    </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #1814 

Authors with lots of metadata:
<img width="1407" alt="Screen Shot 2022-01-16 at 7 37 58 PM" src="https://user-images.githubusercontent.com/1807695/149704476-3e3613e8-497d-4f6c-bb63-611a543f133c.png">

And authors with less:
<img width="1385" alt="Screen Shot 2022-01-16 at 7 38 06 PM" src="https://user-images.githubusercontent.com/1807695/149704485-aafe5833-5ab8-4dd9-b09e-9dfd2434e80e.png">

