### PR TITLE
Makes default language configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ USE_HTTPS=true
 DOMAIN=your.domain.here
 EMAIL=your@email.here
 
+# Instance defualt language (see options at bookwyrm/settings.py "LANGUAGES"
+LANGUAGE_CODE="en-us"
 # Used for deciding which editions to prefer
 DEFAULT_LANGUAGE="English"
 

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -243,7 +243,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = env("LANGUAGE_CODE", "en-us")
 LANGUAGES = [
     ("en-us", _("English")),
     ("de-de", _("Deutsch (German)")),


### PR DESCRIPTION
Fixes #1791 - if the browser sends a request for a language that is available, that will still be preferred to the provided `LANGUAGE_CODE`, but if no available language is requested, whatever is set in the env will be used.