### PR TITLE
Fix typo from models refactor

### DIFF
--- a/bookwyrm/management/commands/initdb.py
+++ b/bookwyrm/management/commands/initdb.py
@@ -55,7 +55,7 @@ def init_permissions():
         },
     ]
 
-    content_type = models.ContentType.objects.get_for_model(User)
+    content_type = ContentType.objects.get_for_model(models.User)
     for permission in permissions:
         permission_obj = Permission.objects.create(
             codename=permission["codename"],


### PR DESCRIPTION
Looks like this got caught up when moving to importing `models`
instead of the individual models, and was throwing an error on
`./bw-dev initdb`

With this fix I was able to run a full `resetdb`/`initdb` 🥳 