### PR TITLE
Added a class for fixing onboarding logo's size

### DIFF
--- a/bookwyrm/templates/get_started/layout.html
+++ b/bookwyrm/templates/get_started/layout.html
@@ -11,7 +11,7 @@
     <div class="modal-card is-fullwidth">
         <header class="modal-card-head">
             <img
-                class="image logo mr-2"
+                class="image logo mr-2 icon is-large"
                 src="{% if site.logo_small %}{% get_media_prefix %}{{ site.logo_small }}{% else %}{% static "images/logo-small.png" %}{% endif %}"
                 aria-hidden="true"
                 alt="{{ site.name }}"

--- a/bookwyrm/templates/get_started/layout.html
+++ b/bookwyrm/templates/get_started/layout.html
@@ -9,9 +9,9 @@
 <div class="modal is-active" role="dialog" aria-modal="true" aria-labelledby="get_started_header">
     <div class="modal-background"></div>
     <div class="modal-card is-fullwidth">
-        <header class="modal-card-head">
+        <header class="modal-card-head navbar">
             <img
-                class="image logo mr-2 icon is-large"
+                class="image logo mr-2"
                 src="{% if site.logo_small %}{% get_media_prefix %}{{ site.logo_small }}{% else %}{% static "images/logo-small.png" %}{% endif %}"
                 aria-hidden="true"
                 alt="{{ site.name }}"


### PR DESCRIPTION
This addresses #1839 by adding a CSS class to the onboarding logo's element and fixing the logo's size to a reasonable dimension of about 3rem. I was unable to test this on my local machine due to some bugs with running an instance, so further confirmations of this fix are appreciated.
