### PR TITLE
Revert logging changes that seem to be breaking things

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -106,59 +106,6 @@ TEMPLATES = [
     },
 ]
 
-LOG_LEVEL = env("LOG_LEVEL", "INFO").upper()
-# Override aspects of the default handler to our taste
-# See https://docs.djangoproject.com/en/3.2/topics/logging/#default-logging-configuration
-# for a reference to the defaults we're overriding
-#
-# It seems that in order to override anything you have to include its
-# entire dependency tree (handlers and filters) which makes this a
-# bit verbose
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "filters": {
-        # These are copied from the default configuration, required for
-        # implementing mail_admins below
-        "require_debug_false": {
-            "()": "django.utils.log.RequireDebugFalse",
-        },
-        "require_debug_true": {
-            "()": "django.utils.log.RequireDebugTrue",
-        },
-    },
-    "handlers": {
-        # Overrides the default handler to make it log to console
-        # regardless of the DEBUG setting (default is to not log to
-        # console if DEBUG=False)
-        "console": {
-            "level": LOG_LEVEL,
-            "class": "logging.StreamHandler",
-        },
-        # This is copied as-is from the default logger, and is
-        # required for the django section below
-        "mail_admins": {
-            "level": "ERROR",
-            "filters": ["require_debug_false"],
-            "class": "django.utils.log.AdminEmailHandler",
-        },
-    },
-    "loggers": {
-        # Install our new console handler for Django's logger, and
-        # override the log level while we're at it
-        "django": {
-            "handlers": ["console", "mail_admins"],
-            "level": LOG_LEVEL,
-        },
-        # Add a bookwyrm-specific logger
-        "bookwyrm": {
-            "handlers": ["console"],
-            "level": LOG_LEVEL,
-        },
-    },
-}
-
-
 WSGI_APPLICATION = "bookwyrm.wsgi.application"
 
 # redis/activity streams settings


### PR DESCRIPTION
I really don't understand how, but after bisecting, this logging configuration seems to be what is causing #1906 - if I remove it, the resolution errors go away, if I reintroduce it, they show up again.

Very strange, but since configurable logging (and 500 errors) are only nice-to-have, I think we should remove the logging configuration