### PR TITLE
Fix for TypeError/no focus when clicking on a reply

### DIFF
--- a/bookwyrm/templates/snippets/status/layout.html
+++ b/bookwyrm/templates/snippets/status/layout.html
@@ -69,7 +69,6 @@
 
 {% block card-bonus %}
 {% if request.user.is_authenticated and not moderation_mode and not no_interact %}
-{% with status.id|uuid as uuid %}
 <section class="reply-panel is-hidden" id="show_comment_{{ status.id }}">
     <div class="card-footer">
         <div class="card-footer-item">
@@ -77,6 +76,5 @@
         </div>
     </div>
 </section>
-{% endwith %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Remove uuid for status reply panel
- The focus target did not include this uuid, so was throwing `Uncaught TypeError: node is null` when clicking on Reply button.
- I wasn't able to figure out how to share the uuid between blocks but it doesn't seem like the uuid is really needed -- the same block has other ids that do not have the uuid in them. So if the uuid is needed for uniqueness the other ones should be changed too.