### PR TITLE
Consistent positioning of success buttons

### DIFF
--- a/bookwyrm/templates/author/sync_modal.html
+++ b/bookwyrm/templates/author/sync_modal.html
@@ -19,8 +19,10 @@
 {% endblock %}
 
 {% block modal-footer %}
-<button class="button is-primary" type="submit">{% trans "Confirm" %}</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+<div class="buttons is-right is-flex-grow-1">
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <button class="button is-primary" type="submit">{% trans "Confirm" %}</button>
+</div>
 {% endblock %}
 
 {% block modal-form-close %}</form>{% endblock %}

--- a/bookwyrm/templates/book/cover_add_modal.html
+++ b/bookwyrm/templates/book/cover_add_modal.html
@@ -28,8 +28,10 @@
 {% endblock %}
 
 {% block modal-footer %}
-<button class="button is-primary" type="submit">{% trans "Add" %}</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+<div class="buttons is-right is-flex-grow-1">
+    <button class="button is-primary" type="submit">{% trans "Add" %}</button>
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+</div>
 {% endblock %}
 
 {% block modal-form-close %}</form>{% endblock %}

--- a/bookwyrm/templates/book/file_links/add_link_modal.html
+++ b/bookwyrm/templates/book/file_links/add_link_modal.html
@@ -55,8 +55,10 @@
 {% endblock %}
 
 {% block modal-footer %}
-<button class="button is-primary" type="submit">{% trans "Save" %}</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
-
+<div class="buttons is-right is-flex-grow-1">
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <button class="button is-primary" type="submit">{% trans "Save" %}</button>
+</div>
 {% endblock %}
+
 {% block modal-form-close %}</form>{% endblock %}

--- a/bookwyrm/templates/book/file_links/verification_modal.html
+++ b/bookwyrm/templates/book/file_links/verification_modal.html
@@ -17,13 +17,13 @@ Is that where you'd like to go?
 
 
 {% block modal-footer %}
-<a href="{{ link.url }}" target="_blank" rel="noopener noreferrer" class="button is-primary">{% trans "Continue" %}</a>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
-
 {% if request.user.is_authenticated %}
-<div class="has-text-right is-flex-grow-1">
+<div class="is-flex-grow-1">
     <a href="{% url 'report-link' link.added_by.id link.id %}">{% trans "Report spam" %}</a>
 </div>
+
+<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+<a href="{{ link.url }}" target="_blank" rel="noopener noreferrer" class="button is-primary">{% trans "Continue" %}</a>
 {% endif %}
 
 {% endblock %}

--- a/bookwyrm/templates/book/sync_modal.html
+++ b/bookwyrm/templates/book/sync_modal.html
@@ -19,8 +19,10 @@
 {% endblock %}
 
 {% block modal-footer %}
-<button class="button is-primary" type="submit">{% trans "Confirm" %}</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+<div class="buttons is-right is-flex-grow-1">
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <button class="button is-primary" type="submit">{% trans "Confirm" %}</button>
+</div>
 {% endblock %}
 
 {% block modal-form-close %}</form>{% endblock %}

--- a/bookwyrm/templates/groups/create_form.html
+++ b/bookwyrm/templates/groups/create_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block header %}
-{% trans "Create Group" %}
+{% trans "Create group" %}
 {% endblock %}
 
 {% block form %}

--- a/bookwyrm/templates/groups/delete_group_modal.html
+++ b/bookwyrm/templates/groups/delete_group_modal.html
@@ -8,13 +8,15 @@
 {% endblock %}
 
 {% block modal-footer %}
-<form name="delete-group-{{ group.id }}" action="{% url 'delete-group' group.id %}" method="POST">
+<form name="delete-group-{{ group.id }}" action="{% url 'delete-group' group.id %}" method="POST" class="is-flex-grow-1">
     {% csrf_token %}
     <input type="hidden" name="id" value="{{ group.id }}">
-    <button class="button is-danger" type="submit">
-        {% trans "Delete" %}
-    </button>
-    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <div class="buttons is-right is-flex-grow-1">
+        <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+        <button class="button is-danger" type="submit">
+            {% trans "Delete" %}
+        </button>
+    </div>
 </form>
 {% endblock %}
 

--- a/bookwyrm/templates/groups/form.html
+++ b/bookwyrm/templates/groups/form.html
@@ -16,18 +16,21 @@
 </div>
 <div class="is-flex">
     {% if group.id %}
-    <div class="is-flex-grow-1">
+    <div>
         <button type="button" data-modal-open="delete_group" class="button is-danger">
             {% trans "Delete group" %}
         </button>
     </div>
     {% endif %}
-    <div class="field has-addons">
-        <div class="control">
-            {% include 'snippets/privacy_select_no_followers.html' with current=group.privacy %}
-        </div>
-        <div class="control">
-            <button type="submit" class="button is-primary">{% trans "Save" %}</button>
+
+    <div class="is-flex is-flex-grow-1 is-justify-content-flex-end">
+        <div class="field has-addons">
+            <div class="control">
+                {% include 'snippets/privacy_select_no_followers.html' with current=group.privacy %}
+            </div>
+            <div class="control">
+                <button type="submit" class="button is-primary">{% trans "Save" %}</button>
+            </div>
         </div>
     </div>
 </div>

--- a/bookwyrm/templates/lists/add_item_modal.html
+++ b/bookwyrm/templates/lists/add_item_modal.html
@@ -32,14 +32,16 @@
 {% endblock %}
 
 {% block modal-footer %}
-<button type="submit" class="button is-link">
-    {% if list.curation == 'open' or request.user == list.user or list.group|is_member:request.user %}
-        {% trans "Add" %}
-    {% else %}
-        {% trans "Suggest" %}
-    {% endif %}
-</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+<div class="buttons is-right is-flex-grow-1">
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <button type="submit" class="button is-link">
+        {% if list.curation == 'open' or request.user == list.user or list.group|is_member:request.user %}
+            {% trans "Add" %}
+        {% else %}
+            {% trans "Suggest" %}
+        {% endif %}
+    </button>
+</div>
 {% endblock %}
 
 {% block modal-form-close %}</form>{% endblock %}

--- a/bookwyrm/templates/lists/delete_list_modal.html
+++ b/bookwyrm/templates/lists/delete_list_modal.html
@@ -8,15 +8,17 @@
 {% endblock %}
 
 {% block modal-footer %}
-<form name="delete-list-{{ list.id }}" action="{% url 'delete-list' list.id %}" method="POST">
+<form name="delete-list-{{ list.id }}" action="{% url 'delete-list' list.id %}" method="POST" class="is-flex-grow-1">
     {% csrf_token %}
     <input type="hidden" name="id" value="{{ list.id }}">
-    <button class="button is-danger" type="submit">
-        {% trans "Delete" %}
-    </button>
-    <button type="button" class="button" data-modal-close>
-        {% trans "Cancel" %}
-    </button>
+    <div class="buttons is-right is-flex-grow-1">
+        <button type="button" class="button" data-modal-close>
+            {% trans "Cancel" %}
+        </button>
+        <button class="button is-danger" type="submit">
+            {% trans "Delete" %}
+        </button>
+    </div>
 </form>
 {% endblock %}
 

--- a/bookwyrm/templates/lists/form.html
+++ b/bookwyrm/templates/lists/form.html
@@ -114,7 +114,7 @@
         </fieldset>
     </div>
 </div>
-<div class="is-flex">
+<div class="is-flex is-justify-content-end">
     {% if list.id %}
     <div class="is-flex-grow-1">
         <button type="button" data-modal-open="delete_list" class="button is-danger">

--- a/bookwyrm/templates/readthrough/delete_readthrough_modal.html
+++ b/bookwyrm/templates/readthrough/delete_readthrough_modal.html
@@ -14,12 +14,20 @@
 {% endblock %}
 
 {% block modal-footer %}
-<form name="delete-readthrough-{{ readthrough.id }}" action="/delete-readthrough" method="POST">
+<form
+    name="delete-readthrough-{{ readthrough.id }}"
+    action="/delete-readthrough"
+    method="POST"
+    class="is-flex-grow-1"
+>
     {% csrf_token %}
     <input type="hidden" name="id" value="{{ readthrough.id }}">
-    <button class="button is-danger" type="submit">
-        {% trans "Delete" %}
-    </button>
-    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+
+    <div class="buttons is-right">
+        <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+        <button class="button is-danger" type="submit">
+            {% trans "Delete" %}
+        </button>
+    </div>
 </form>
 {% endblock %}

--- a/bookwyrm/templates/readthrough/readthrough_modal.html
+++ b/bookwyrm/templates/readthrough/readthrough_modal.html
@@ -69,8 +69,10 @@
 {% endblock %}
 
 {% block modal-footer %}
-<button class="button is-primary" type="submit">{% trans "Save" %}</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+<div class="buttons is-right is-flex-grow-1">
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <button class="button is-primary" type="submit">{% trans "Save" %}</button>
+</div>
 {% endblock %}
 
 {% block modal-form-close %}

--- a/bookwyrm/templates/settings/link_domains/edit_domain_modal.html
+++ b/bookwyrm/templates/settings/link_domains/edit_domain_modal.html
@@ -18,8 +18,10 @@
 {% endblock %}
 
 {% block modal-footer %}
-<button type="submit" class="button is-primary">{% trans "Set" %}</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+<div class="buttons is-right is-flex-grow-1">
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <button type="submit" class="button is-primary">{% trans "Set" %}</button>
+</div>
 {% endblock %}
 
 {% block modal-form-close %}</form>{% endblock %}

--- a/bookwyrm/templates/shelf/create_shelf_form.html
+++ b/bookwyrm/templates/shelf/create_shelf_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block header %}
-{% trans "Create Shelf" %}
+{% trans "Create shelf" %}
 {% endblock %}
 
 {% block form %}

--- a/bookwyrm/templates/shelf/form.html
+++ b/bookwyrm/templates/shelf/form.html
@@ -17,7 +17,7 @@
     <label class="label" for="id_description_{{ uuid }}">{% trans "Description:" %}</label>
     <textarea name="description" cols="40" rows="5" maxlength="500" class="textarea" id="id_description_{{ uuid }}">{{ form.description.value|default:'' }}</textarea>
 </div>
-<div class="field has-addons">
+<div class="field has-addons is-justify-content-end">
     <div class="control">
         {% include 'snippets/privacy_select.html' with current=privacy %}
     </div>

--- a/bookwyrm/templates/snippets/register_form.html
+++ b/bookwyrm/templates/snippets/register_form.html
@@ -53,12 +53,12 @@
             id="id_password_register"
             aria-describedby="desc_password_register"
         >
-        
+
         {% include 'snippets/form_errors.html' with errors_list=register_form.password.errors id="desc_password_register" %}
     </div>
 </div>
 
-<div class="field is-grouped">
+<div class="field">
     <div class="control">
         <button class="button is-primary" type="submit">
             {% trans "Sign Up" %}

--- a/bookwyrm/templates/snippets/report_modal.html
+++ b/bookwyrm/templates/snippets/report_modal.html
@@ -48,10 +48,10 @@
 
 
 {% block modal-footer %}
-
-<button class="button is-success" type="submit">{% trans "Submit" %}</button>
-<button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
-
+<div class="buttons is-right is-flex-grow-1">
+    <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+    <button class="button is-success" type="submit">{% trans "Submit" %}</button>
+</div>
 {% endblock %}
 
 {% block modal-form-close %}</form>{% endblock %}

--- a/bookwyrm/views/books/editions.py
+++ b/bookwyrm/views/books/editions.py
@@ -58,8 +58,12 @@ class Editions(View):
             )
 
         paginated = Paginator(editions, PAGE_LENGTH)
+        page = paginated.get_page(request.GET.get("page"))
         data = {
-            "editions": paginated.get_page(request.GET.get("page")),
+            "editions": page,
+            "page_range": paginated.get_elided_page_range(
+                page.number, on_each_side=2, on_ends=1
+            ),
             "work": work,
             "languages": languages,
             "formats": set(


### PR DESCRIPTION
Currently, the "success" button for anything from posting a status to following a link can be either on the right or left, after or before the close or cancel options. This PR just puts the success button on the right and the cancel (or whatever) button the left.

For example, before:
<img width="652" alt="Screen Shot 2022-03-10 at 9 34 53 AM" src="https://user-images.githubusercontent.com/1807695/157722320-c8baab4a-7d98-48c0-9e11-09ee2ecb18d1.png">


And after:
<img width="661" alt="Screen Shot 2022-03-10 at 9 34 38 AM" src="https://user-images.githubusercontent.com/1807695/157722293-e6626814-b4d0-453d-93b7-c655db5b8ebc.png">

