### PR TITLE
Uses details instead of javascript for inline forms

### DIFF
--- a/bookwyrm/templates/components/inline_form.html
+++ b/bookwyrm/templates/components/inline_form.html
@@ -1,15 +1,15 @@
 {% load i18n %}
-<section class="card {% if not visible %}is-hidden {% endif %}{{ class }}" id="{{ controls_text }}{% if controls_uid %}-{{ controls_uid }}{% endif %}">
-    <header class="card-header has-background-secondary">
-        <h2 class="card-header-title" tabindex="0" id="{{ controls_text }}{% if controls_uid %}-{{ controls_uid }}{% endif %}_header">
-            {% block header %}{% endblock %}
-        </h2>
-        <span class="card-header-icon">
-            {% trans "Close" as button_text %}
-            {% include 'snippets/toggle/toggle_button.html' with label=button_text class="delete" nonbutton=True controls_text=controls_text %}
-        </span>
-    </header>
-    <section class="card-content content">
+<details
+    class="details-panel box"
+    {% if visible %}open{% endif %}
+    open
+>
+    <summary role="heading" aria-level="2">
+        <span class="title is-5">{% block header %}{% endblock %}</span>
+        <span class="details-close icon icon-x" aria-hidden="true"></span>
+    </summary>
+
+    <section class="{{ class }} mt-2">
         {% block form %}{% endblock %}
     </section>
-</section>
+</details>

--- a/bookwyrm/templates/components/inline_form.html
+++ b/bookwyrm/templates/components/inline_form.html
@@ -2,7 +2,6 @@
 <details
     class="details-panel box"
     {% if visible %}open{% endif %}
-    open
 >
     <summary role="heading" aria-level="2">
         <span class="title is-5">{% block header %}{% endblock %}</span>

--- a/bookwyrm/templates/lists/form.html
+++ b/bookwyrm/templates/lists/form.html
@@ -7,11 +7,15 @@
     <div class="column is-two-thirds">
         <div class="field">
             <label class="label" for="id_name">{% trans "Name:" %}</label>
-            {{ list_form.name }}
+            <div class="control">
+                {{ list_form.name }}
+            </div>
         </div>
         <div class="field">
             <label class="label" for="id_description">{% trans "Description:" %}</label>
-            {{ list_form.description }}
+            <div class="control">
+                {{ list_form.description }}
+            </div>
         </div>
     </div>
     <div class="column">

--- a/bookwyrm/templates/lists/lists.html
+++ b/bookwyrm/templates/lists/lists.html
@@ -6,21 +6,13 @@
 
 {% block content %}
 
-<header class="block columns is-mobile">
-    <div class="column">
-        <h1 class="title">
-            {% trans "Lists" %}
-            {% if request.user.is_authenticated %}
-            <a class="help has-text-weight-normal" href="{% url 'user-lists' request.user|username %}">{% trans "Your Lists" %}</a>
-            {% endif %}
-        </h1>
-    </div>
-    {% if request.user.is_authenticated %}
-    <div class="column is-narrow">
-        {% trans "Create List" as button_text %}
-        {% include 'snippets/toggle/open_button.html' with controls_text="create_list" icon_with_text="plus" text=button_text focus="create_list_header" %}
-    </div>
-    {% endif %}
+<header class="block">
+    <h1 class="title">
+        {% trans "Lists" %}
+        {% if request.user.is_authenticated %}
+        <a class="help has-text-weight-normal" href="{% url 'user-lists' request.user|username %}">{% trans "Your Lists" %}</a>
+        {% endif %}
+    </h1>
 </header>
 {% if request.user.is_authenticated %}
 <div class="block">


### PR DESCRIPTION
I'd like to get rid of the javascript "toggle button" component entirely and use noscript-friendly modals and details instead. This replaces the "Create"/"Edit" buttons next to headers with details panels. The main downside is that the button next to the header was more compact and I liked how it looked, but I think it's a worthwhile tradeoff.

Before
-------
Closed:
<img width="1203" alt="Screen Shot 2022-03-10 at 11 14 51 AM" src="https://user-images.githubusercontent.com/1807695/157737941-6be76712-261f-4189-80c7-75e3032eb001.png">

Open:
<img width="1191" alt="Screen Shot 2022-03-10 at 11 14 55 AM" src="https://user-images.githubusercontent.com/1807695/157737957-d12b9e86-9139-4f8d-a6ca-493bf631ab9c.png">


After
-----

Closed:
<img width="1195" alt="Screen Shot 2022-03-10 at 11 06 12 AM" src="https://user-images.githubusercontent.com/1807695/157737670-333f5263-5b67-4f19-9ed1-6236a31fe377.png">

Open:
<img width="1189" alt="Screen Shot 2022-03-10 at 11 06 21 AM" src="https://user-images.githubusercontent.com/1807695/157737680-abd365dc-1865-4be4-aec9-3dd70ae4e258.png">

