### PR TITLE
Uses custom date select widget for publication dates

### DIFF
--- a/bookwyrm/forms/books.py
+++ b/bookwyrm/forms/books.py
@@ -4,6 +4,7 @@ from django import forms
 from bookwyrm import models
 from bookwyrm.models.fields import ClearableFileInputWithWarning
 from .custom_form import CustomForm
+from .widgets import ArrayWidget, SelectDateWidget, Select
 
 
 # pylint: disable=missing-class-docstring
@@ -12,14 +13,6 @@ class CoverForm(CustomForm):
         model = models.Book
         fields = ["cover"]
         help_texts = {f: None for f in fields}
-
-
-class ArrayWidget(forms.widgets.TextInput):
-    # pylint: disable=unused-argument
-    # pylint: disable=no-self-use
-    def value_from_datadict(self, data, files, name):
-        """get all values for this name"""
-        return [i for i in data.getlist(name) if i]
 
 
 class EditionForm(CustomForm):
@@ -56,16 +49,16 @@ class EditionForm(CustomForm):
             "publishers": forms.TextInput(
                 attrs={"aria-describedby": "desc_publishers_help desc_publishers"}
             ),
-            "first_published_date": forms.SelectDateWidget(
+            "first_published_date": SelectDateWidget(
                 attrs={"aria-describedby": "desc_first_published_date"}
             ),
-            "published_date": forms.SelectDateWidget(
+            "published_date": SelectDateWidget(
                 attrs={"aria-describedby": "desc_published_date"}
             ),
             "cover": ClearableFileInputWithWarning(
                 attrs={"aria-describedby": "desc_cover"}
             ),
-            "physical_format": forms.Select(
+            "physical_format": Select(
                 attrs={"aria-describedby": "desc_physical_format"}
             ),
             "physical_format_detail": forms.TextInput(

--- a/bookwyrm/forms/widgets.py
+++ b/bookwyrm/forms/widgets.py
@@ -1,0 +1,70 @@
+""" using django model forms """
+from django import forms
+
+
+class ArrayWidget(forms.widgets.TextInput):
+    """Inputs for postgres array fields"""
+
+    # pylint: disable=unused-argument
+    # pylint: disable=no-self-use
+    def value_from_datadict(self, data, files, name):
+        """get all values for this name"""
+        return [i for i in data.getlist(name) if i]
+
+
+class Select(forms.Select):
+    """custom template for select widget"""
+
+    template_name = "widgets/select.html"
+
+
+class SelectDateWidget(forms.SelectDateWidget):
+    """
+    A widget that splits date input into two <select> boxes and a numerical year.
+    """
+
+    template_name = "widgets/addon_multiwidget.html"
+    select_widget = Select
+
+    def get_context(self, name, value, attrs):
+        """sets individual widgets"""
+        context = super().get_context(name, value, attrs)
+        date_context = {}
+        year_name = self.year_field % name
+        date_context["year"] = forms.NumberInput().get_context(
+            name=year_name,
+            value=context["widget"]["value"]["year"],
+            attrs={
+                **context["widget"]["attrs"],
+                "id": f"id_{year_name}",
+                "class": "input",
+            },
+        )
+        month_choices = list(self.months.items())
+        if not self.is_required:
+            month_choices.insert(0, self.month_none_value)
+        month_name = self.month_field % name
+        date_context["month"] = self.select_widget(
+            attrs, choices=month_choices
+        ).get_context(
+            name=month_name,
+            value=context["widget"]["value"]["month"],
+            attrs={**context["widget"]["attrs"], "id": f"id_{month_name}"},
+        )
+        day_choices = [(i, i) for i in range(1, 32)]
+        if not self.is_required:
+            day_choices.insert(0, self.day_none_value)
+        day_name = self.day_field % name
+        date_context["day"] = self.select_widget(
+            attrs,
+            choices=day_choices,
+        ).get_context(
+            name=day_name,
+            value=context["widget"]["value"]["day"],
+            attrs={**context["widget"]["attrs"], "id": f"id_{day_name}"},
+        )
+        subwidgets = []
+        for field in self._parse_date_fmt():
+            subwidgets.append(date_context[field]["widget"])
+        context["widget"]["subwidgets"] = subwidgets
+        return context

--- a/bookwyrm/templates/book/edit/edit_book_form.html
+++ b/bookwyrm/templates/book/edit/edit_book_form.html
@@ -155,8 +155,7 @@
                     <label class="label" for="id_first_published_date">
                         {% trans "First published date:" %}
                     </label>
-                    <input type="date" name="first_published_date" class="input" id="id_first_published_date"{% if form.first_published_date.value %} value="{{ form.first_published_date.value|date:'Y-m-d' }}"{% endif %} aria-describedby="desc_first_published_date">
-
+                    {{ form.first_published_date }}
                     {% include 'snippets/form_errors.html' with errors_list=form.first_published_date.errors id="desc_first_published_date" %}
                 </div>
 
@@ -164,7 +163,7 @@
                     <label class="label" for="id_published_date">
                         {% trans "Published date:" %}
                     </label>
-                    <input type="date" name="published_date" class="input" id="id_published_date"{% if form.published_date.value %} value="{{ form.published_date.value|date:'Y-m-d'}}"{% endif %} aria-describedby="desc_published_date">
+                    {{ form.published_date }}
 
                     {% include 'snippets/form_errors.html' with errors_list=form.published_date.errors id="desc_published_date" %}
                 </div>
@@ -259,9 +258,7 @@
                             <label class="label" for="id_physical_format">
                                 {% trans "Format:" %}
                             </label>
-                            <div class="select">
-                                {{ form.physical_format }}
-                            </div>
+                            {{ form.physical_format }}
 
                             {% include 'snippets/form_errors.html' with errors_list=form.physical_format.errors id="desc_physical_format" %}
                         </div>

--- a/bookwyrm/templates/widgets/addon_multiwidget.html
+++ b/bookwyrm/templates/widgets/addon_multiwidget.html
@@ -1,0 +1,9 @@
+{% spaceless %}
+<div class="field has-addons">
+{% for widget in widget.subwidgets %}
+<div class="control{% if forloop.last %} is-expanded{% endif %}">
+    {% include widget.template_name %}
+    </div>
+{% endfor %}
+</div>
+{% endspaceless %}

--- a/bookwyrm/templates/widgets/select.html
+++ b/bookwyrm/templates/widgets/select.html
@@ -1,0 +1,10 @@
+<div class="select">
+    <select
+        name="{{ widget.name }}"
+        {% include "django/forms/widgets/attrs.html" %}
+    >{% for group_name, group_choices, group_index in widget.optgroups %}{% if group_name %}
+        <optgroup label="{{ group_name }}">{% endif %}{% for option in group_choices %}
+        {% include option.template_name with widget=option %}{% endfor %}{% if group_name %}
+        </optgroup>{% endif %}{% endfor %}
+    </select>
+</div>

--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -1,13 +1,11 @@
 """ the good stuff! the books! """
 from re import sub, findall
-from dateutil.parser import parse as dateparse
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.postgres.search import SearchRank, SearchVector
 from django.db import transaction
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
-from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_POST
 from django.views import View
@@ -52,7 +50,6 @@ class EditBook(View):
 
         # either of the above cases requires additional confirmation
         if data.get("add_author"):
-            data = copy_form(data)
             return TemplateResponse(request, "book/edit/edit_book.html", data)
 
         remove_authors = request.POST.getlist("remove_authors")
@@ -118,7 +115,6 @@ class CreateBook(View):
 
         # go to confirm mode
         if not parent_work_id or data.get("add_author"):
-            data = copy_form(data)
             return TemplateResponse(request, "book/edit/edit_book.html", data)
 
         with transaction.atomic():
@@ -137,21 +133,6 @@ class CreateBook(View):
 
             book.save()
         return redirect(f"/book/{book.id}")
-
-
-def copy_form(data):
-    """helper to re-create the date fields in the form"""
-    formcopy = data["form"].data.copy()
-    try:
-        formcopy["first_published_date"] = dateparse(formcopy["first_published_date"])
-    except (MultiValueDictKeyError, ValueError):
-        pass
-    try:
-        formcopy["published_date"] = dateparse(formcopy["published_date"])
-    except (MultiValueDictKeyError, ValueError):
-        pass
-    data["form"].data = formcopy
-    return data
 
 
 def add_authors(request, data):


### PR DESCRIPTION
This PR adds a new custom date widget based on [Django's built-in `SelectDate` widget](https://docs.djangoproject.com/en/4.0/ref/forms/widgets/#selectdatewidget), but with the year as a `number` field instead of another `select` field. I think this makes much more sense than a datepicker for publication dates, since they're often far in the past.

<img width="500" alt="Screen Shot 2022-03-19 at 8 36 50 AM" src="https://user-images.githubusercontent.com/1807695/159127728-93e12155-35d2-4d8d-b695-ffafa742dbc7.png">


Fixes #1979 and works on #743