### PR TITLE
Use general ratings rather than privacy filtered

### DIFF
--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -374,7 +374,7 @@ class Review(BookStatus):
     def save(self, *args, **kwargs):
         """clear rating caches"""
         if self.book.parent_work:
-            cache.delete(f"book-rating-{self.book.parent_work.id}-*")
+            cache.delete(f"book-rating-{self.book.parent_work.id}")
         super().save(*args, **kwargs)
 
 

--- a/bookwyrm/templatetags/rating_tags.py
+++ b/bookwyrm/templatetags/rating_tags.py
@@ -13,10 +13,10 @@ register = template.Library()
 def get_rating(book, user):
     """get the overall rating of a book"""
     return cache.get_or_set(
-        f"book-rating-{book.parent_work.id}-{user.id}",
-        lambda u, b: models.Review.privacy_filter(u)
-        .filter(book__parent_work__editions=b, rating__gt=0)
-        .aggregate(Avg("rating"))["rating__avg"]
+        f"book-rating-{book.parent_work.id}",
+        lambda u, b: models.Review.objects.filter(
+            book__parent_work__editions=b, rating__gt=0
+        ).aggregate(Avg("rating"))["rating__avg"]
         or 0,
         user,
         book,

--- a/bookwyrm/tests/templatetags/test_rating_tags.py
+++ b/bookwyrm/tests/templatetags/test_rating_tags.py
@@ -40,7 +40,8 @@ class RatingTags(TestCase):
 
     @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
     def test_get_rating(self, *_):
-        """privacy filtered rating"""
+        """privacy filtered rating. Commented versions are how it ought to work with
+        subjective ratings, which are currenly not used for performance reasons."""
         # follows-only: not included
         models.ReviewRating.objects.create(
             user=self.remote_user,
@@ -48,7 +49,8 @@ class RatingTags(TestCase):
             book=self.book,
             privacy="followers",
         )
-        self.assertEqual(rating_tags.get_rating(self.book, self.local_user), 0)
+        # self.assertEqual(rating_tags.get_rating(self.book, self.local_user), 0)
+        self.assertEqual(rating_tags.get_rating(self.book, self.local_user), 5)
 
         # public: included
         models.ReviewRating.objects.create(


### PR DESCRIPTION
Works on #2117 (hopefully this fixes it but I'm not able to replicate the error so I want to get confirmation from the people who reported it).


The original system customized how a rating is displayed to every user
based on the privacy settings of the reviews and, relatedly, who the
user follows. This is cool, but the query is too complicated to load in
sessions, and the initial load, which isn't mitigated by caching, is too
much and causes timeouts for many users. Also the cache clearing wasn't
working correctly because I put in a wildcard, which does not work.