### PR TITLE
Don't add imported statuses to timeline

### DIFF
--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -303,6 +303,10 @@ def add_status_on_create_command(sender, instance, created):
     ) or instance.created_date < instance.published_date - timedelta(days=1):
         priority = LOW
 
+    # don't add imported statuses to feeds
+    if models.ImportItem.objects.exists(linked_review=instance):
+        return
+
     add_status_task.apply_async(
         args=(instance.id,),
         kwargs={"increment_unread": created},

--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -304,7 +304,7 @@ def add_status_on_create_command(sender, instance, created):
         priority = LOW
 
     # don't add imported statuses to feeds
-    if models.ImportItem.objects.exists(linked_review=instance):
+    if models.ImportItem.objects.filter(linked_review=instance).exists():
         return
 
     add_status_task.apply_async(


### PR DESCRIPTION
Imported items are creating a huge number of add_status_task tasks, and
really they don't need to go in to timelines at all.