### PR TITLE
Clip column in about page

### DIFF
--- a/bookwyrm/templates/about/layout.html
+++ b/bookwyrm/templates/about/layout.html
@@ -50,7 +50,7 @@
         </ul>
     </nav>
 
-    <div class="column">
+    <div class="column is-clipped">
         {% block about_content %}{% endblock %}
     </div>
 </div>


### PR DESCRIPTION
Text in the superlatives section can cause this column to expand outside
the container.