### PR TITLE
Fix pylint config for pylint 2.14.0

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,8 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint bookwyrm/ --ignore=migrations --disable=E1101,E1135,E1136,R0903,R0901,R0902,W0707,W0511,W0406,R0401,R0801
+        pylint bookwyrm/
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,6 @@
+[MAIN]
+ignore=migrations
+load-plugins=pylint.extensions.no_self_use
+
+[MESSAGES CONTROL]
+disable=E1101,E1135,E1136,R0903,R0901,R0902,W0707,W0511,W0406,R0401,R0801,C3001

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,3 @@ RUN apt-get update && apt-get install -y gettext libgettextpo-dev tidy && apt-ge
 
 COPY requirements.txt /app/
 RUN pip install -r requirements.txt --no-cache-dir
-
-COPY requirements.dev.txt /app/
-RUN pip install -r requirements.dev.txt --no-cache-dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN mkdir /app /app/static /app/images
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y gettext libgettextpo-dev tidy && apt-get clean
+
 COPY requirements.txt /app/
 RUN pip install -r requirements.txt --no-cache-dir
-RUN apt-get update && apt-get install -y gettext libgettextpo-dev tidy && apt-get clean
+
+COPY requirements.dev.txt /app/
+RUN pip install -r requirements.dev.txt --no-cache-dir

--- a/bookwyrm/tests/connectors/test_openlibrary_connector.py
+++ b/bookwyrm/tests/connectors/test_openlibrary_connector.py
@@ -229,7 +229,7 @@ class Openlibrary(TestCase):
             status=200,
         )
         with patch(
-            "bookwyrm.connectors.openlibrary.Connector." "get_authors_from_data"
+            "bookwyrm.connectors.openlibrary.Connector.get_authors_from_data"
         ) as mock:
             mock.return_value = []
             result = self.connector.create_edition_from_data(work, self.edition_data)

--- a/bookwyrm/tests/models/test_import_model.py
+++ b/bookwyrm/tests/models/test_import_model.py
@@ -195,7 +195,7 @@ class ImportJob(TestCase):
             ) as search:
                 search.return_value = result
                 with patch(
-                    "bookwyrm.connectors.openlibrary.Connector." "get_authors_from_data"
+                    "bookwyrm.connectors.openlibrary.Connector.get_authors_from_data"
                 ):
                     book = item.get_book_from_identifier()
 

--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -281,7 +281,7 @@ http://www.fish.com/"""
         result = views.status.to_markdown(text)
         self.assertEqual(
             result,
-            '<p><em>hi</em> and <a href="http://fish.com">fish.com</a> ' "is rad</p>",
+            '<p><em>hi</em> and <a href="http://fish.com">fish.com</a> is rad</p>',
         )
 
     def test_to_markdown_detect_url(self, *_):
@@ -297,7 +297,7 @@ http://www.fish.com/"""
         """this is mostly handled in other places, but nonetheless"""
         text = "[hi](http://fish.com) is <marquee>rad</marquee>"
         result = views.status.to_markdown(text)
-        self.assertEqual(result, '<p><a href="http://fish.com">hi</a> ' "is rad</p>")
+        self.assertEqual(result, '<p><a href="http://fish.com">hi</a> is rad</p>')
 
     def test_delete_status(self, mock, *_):
         """marks a status as deleted"""

--- a/bw-dev
+++ b/bw-dev
@@ -140,6 +140,10 @@ case "$CMD" in
     black)
         docker-compose run --rm dev-tools black celerywyrm bookwyrm
         ;;
+    pylint)
+        # pylint depends on having the app dependencies in place, so we run it in the web container
+        runweb pylint bookwyrm/
+        ;;
     prettier)
         docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
         ;;
@@ -149,6 +153,7 @@ case "$CMD" in
             --config dev-tools/.stylelintrc.js
         ;;
     formatters)
+        runweb pylint bookwyrm/
         docker-compose run --rm dev-tools black celerywyrm bookwyrm
         docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
         docker-compose run --rm dev-tools npx stylelint \

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,7 @@
+pytest-django==4.1.0
+pytest==6.1.2
+pytest-cov==2.10.1
+pytest-env==0.6.2
+pytest-xdist==2.3.0
+pytidylib==0.3.2
+pylint==2.14.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,0 @@
-pytest-django==4.1.0
-pytest==6.1.2
-pytest-cov==2.10.1
-pytest-env==0.6.2
-pytest-xdist==2.3.0
-pytidylib==0.3.2
-pylint==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,12 @@ opentelemetry-sdk==1.8.0
 opentelemetry-exporter-otlp-proto-grpc==1.8.0
 opentelemetry-instrumentation-django==0.27b0
 opentelemetry-instrumentation-celery==0.27b0
+
+# Dev
+pytest-django==4.1.0
+pytest==6.1.2
+pytest-cov==2.10.1
+pytest-env==0.6.2
+pytest-xdist==2.3.0
+pytidylib==0.3.2
+pylint==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,11 +26,3 @@ opentelemetry-sdk==1.8.0
 opentelemetry-exporter-otlp-proto-grpc==1.8.0
 opentelemetry-instrumentation-django==0.27b0
 opentelemetry-instrumentation-celery==0.27b0
-
-# Dev
-pytest-django==4.1.0
-pytest==6.1.2
-pytest-cov==2.10.1
-pytest-env==0.6.2
-pytest-xdist==2.3.0
-pytidylib==0.3.2


### PR DESCRIPTION
Pylint 2.14.0 was just released with new warnings and a deprecated one that broke the pipeline, since it uses the latest pylint.

I added a `.pylintrc` and comands to `bw-dev`, and added `pylint` to `requirements.txt`, so we can run pylint locally.

I also rearranged the dockerfile for optimal caching (assuming that system packages will change less often than the python requirements)

I also updated the GitHub workflow, with pylint in `requirements.txt` it doesn't need to install it any more (and now we're pinned to a version so it won't randomly break in the future), and it can use the `.pylintrc` instead of having the options inline.