### PR TITLE
Show deleted users as red in the user list

### DIFF
--- a/bookwyrm/templates/settings/users/user_admin.html
+++ b/bookwyrm/templates/settings/users/user_admin.html
@@ -72,6 +72,12 @@
                         <span class="icon icon-check"></span>
                     </span>
                     {% trans "Active" %}
+                {% elif user.deactivation_reason == "moderator_deletion" or user.deactivation_reason == "self_deletion" %}
+                    <span class="tag is-danger" aria-hidden="true">
+                        <span class="icon icon-x"></span>
+                    </span>
+                    {% trans "Deleted" %}
+                    <span class="help">({{ user.get_deactivation_reason_display }})</span>
                 {% else %}
                     <span class="tag is-warning" aria-hidden="true">
                         <span class="icon icon-x"></span>


### PR DESCRIPTION
It can be hard to differentiate at a glance if a user is deleted or
suspended -- without this, you would have to read the deactivation
reason. By making deletions (moderator and self deletions) red, it's
clear at a glance if an account has been permanently deleted or just
temporarily suspended.

Works on #2088