### PR TITLE
Removed incorrect and duplicate page indicator from content status

### DIFF
--- a/bookwyrm/templates/snippets/status/content_status.html
+++ b/bookwyrm/templates/snippets/status/content_status.html
@@ -112,9 +112,6 @@
                     {% with full=status.content|safe no_trim=status.content_warning itemprop="reviewBody" %}
                         {% include 'snippets/trimmed_text.html' %}
                     {% endwith %}
-                    {% if status.progress %}
-                    <div class="is-small is-italic has-text-right mr-3">{% trans "page" %} {{ status.progress }}</div>
-                    {% endif %}
                 {% endif %}
 
                 {% if status.attachments.exists %}


### PR DESCRIPTION
I overlooked this when reviewing #2148 -- the progress is already marked in the status header, so it isn't needed here. It's also not correct when the status should be by percent.

<img width="777" alt="Screen Shot 2022-07-06 at 3 28 05 PM" src="https://user-images.githubusercontent.com/1807695/177654112-720bee78-e362-46d5-9b21-a8f5ff69e113.png">

