### PR TITLE
Update password reset copy so as not to reveal whether the email exists

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 env = Env()
 env.read_env()
 DOMAIN = env("DOMAIN")
-VERSION = "0.4.1"
+VERSION = "0.4.2"
 
 RELEASE_API = env(
     "RELEASE_API",

--- a/bookwyrm/templates/landing/password_reset_request.html
+++ b/bookwyrm/templates/landing/password_reset_request.html
@@ -9,7 +9,13 @@
         <div class="block">
             <h1 class="title">{% trans "Reset Password" %}</h1>
 
-            {% if message %}<p class="notification is-primary">{{ message }}</p>{% endif %}
+            {% if sent_message %}
+            <p class="notification is-primary">
+            {% blocktrans trimmed %}
+            A password reset link will be sent to <strong>{{ email }}</strong> if there is an account using that email address.
+            {% endblocktrans %}
+            </p>
+            {% endif %}
 
             <p>{% trans "A link to reset your password will be sent to your email address" %}</p>
             <form name="password-reset" method="post" action="/password-reset">

--- a/bookwyrm/views/landing/password.py
+++ b/bookwyrm/views/landing/password.py
@@ -3,7 +3,6 @@ from django.contrib.auth import login
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.utils.translation import gettext_lazy as _
 from django.views import View
 
 from bookwyrm import models
@@ -24,12 +23,13 @@ class PasswordResetRequest(View):
     def post(self, request):
         """create a password reset token"""
         email = request.POST.get("email")
+        data = {"sent_message": True, "email": email}
         try:
             user = models.User.viewer_aware_objects(request.user).get(
                 email=email, email__isnull=False
             )
         except models.User.DoesNotExist:
-            data = {"error": _("No user with that email address was found.")}
+            # Showing an error message would leak whether or not this email is in use
             return TemplateResponse(
                 request, "landing/password_reset_request.html", data
             )
@@ -40,7 +40,6 @@ class PasswordResetRequest(View):
         # create a new reset code
         code = models.PasswordReset.objects.create(user=user)
         password_reset_email(code)
-        data = {"message": _(f"A password reset link was sent to {email}")}
         return TemplateResponse(request, "landing/password_reset_request.html", data)
 
 


### PR DESCRIPTION
If, as it does now, the app reports whether or not the email exists, that could be used to test which email addresses are in the user database.

New copy:
<img width="594" alt="Screen Shot 2022-07-06 at 7 52 30 PM" src="https://user-images.githubusercontent.com/1807695/177680683-e2d28eaf-3ce1-4acb-83d5-8a8a5877ff0e.png">

