### PR TITLE
Block some bw-dev commands from being run in prod

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -3,6 +3,17 @@
 # exit on errors
 set -e
 
+# check if we're in DEBUG mode
+DEBUG=$(sed <.env -ne 's/^DEBUG=//p')
+
+# disallow certain commands when debug is false
+function prod_error {
+    if [ "$DEBUG" != "true" ]; then
+        echo "This command is not safe to run in production environments"
+        exit 1
+    fi
+}
+
 # import our ENV variables
 # catch exits and give a friendly error message
 function showerr {
@@ -65,12 +76,14 @@ case "$CMD" in
         docker-compose up --build "$@"
         ;;
     service_ports_web)
+        prod_error
         docker-compose run --rm --service-ports web
         ;;
     initdb)
         initdb "@"
         ;;
     resetdb)
+        prod_error
         clean
         # Start just the DB so no one else is using it
         docker-compose up --build -d db
@@ -83,6 +96,7 @@ case "$CMD" in
         clean
         ;;
     makemigrations)
+        prod_error
         runweb python manage.py makemigrations "$@"
         ;;
     migrate)
@@ -101,21 +115,25 @@ case "$CMD" in
         docker-compose restart celery_worker
         ;;
     pytest)
+        prod_error
         runweb pytest --no-cov-on-fail "$@"
         ;;
     pytest_coverage_report)
+        prod_error
         runweb pytest -n 3 --cov-report term-missing "$@"
         ;;
     collectstatic)
         runweb python manage.py collectstatic --no-input
         ;;
     makemessages)
+        prod_error
         runweb django-admin makemessages --no-wrap --ignore=venv -l en_US $@
         ;;
     compilemessages)
         runweb django-admin compilemessages --ignore venv $@
         ;;
     update_locales)
+        prod_error
         git fetch origin l10n_main:l10n_main
         git checkout l10n_main locale/de_DE
         git checkout l10n_main locale/es_ES
@@ -138,24 +156,30 @@ case "$CMD" in
         docker-compose build
         ;;
     clean)
+        prod_error
         clean
         ;;
     black)
+        prod_error
         docker-compose run --rm dev-tools black celerywyrm bookwyrm
         ;;
     pylint)
+        prod_error
         # pylint depends on having the app dependencies in place, so we run it in the web container
         runweb pylint bookwyrm/
         ;;
     prettier)
+        prod_error
         docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
         ;;
     stylelint)
+        prod_error
         docker-compose run --rm dev-tools npx stylelint \
             bookwyrm/static/css/bookwyrm.scss bookwyrm/static/css/bookwyrm/**/*.scss --fix \
             --config dev-tools/.stylelintrc.js
         ;;
     formatters)
+        prod_error
         runweb pylint bookwyrm/
         docker-compose run --rm dev-tools black celerywyrm bookwyrm
         docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
@@ -168,6 +192,7 @@ case "$CMD" in
         runweb python manage.py collectstatic --no-input
         ;;
     collectstatic_watch)
+        prod_error
         npm run --prefix dev-tools watch:static
         ;;
     update)


### PR DESCRIPTION
Right now, commands that should not be run in production are removed
from the bw-dev file in the `production` branch. Since eventually I'd
like to get rid of that branch, this change would use the `DEBUG`
environment variable to determine if a command should be disabled,
rather than depending on the file available in the branch.

Works on #1858 