### PR TITLE
New and improved warnings on the admin dashboard

### DIFF
--- a/bookwyrm/templates/settings/dashboard/dashboard.html
+++ b/bookwyrm/templates/settings/dashboard/dashboard.html
@@ -38,60 +38,23 @@
 
 <div class="columns block is-multiline">
     {% if email_config_error %}
-    <div class="column is-flex">
-        <span class="notification is-warning is-block is-flex-grow-1">
-            {% blocktrans trimmed %}
-            Your outgoing email address, <code>{{ email_sender }}</code>, may be misconfigured.
-            {% endblocktrans %}
-            {% trans "Check the <code>EMAIL_SENDER_NAME</code> and <code>EMAIL_SENDER_DOMAIN</code> in your <code>.env</code>." %}
-        </span>
-    </div>
-    {% endif %}
-
-    {% if reports %}
-    <div class="column is-flex">
-        <a href="{% url 'settings-reports' %}" class="notification is-warning is-block is-flex-grow-1">
-            {% blocktrans trimmed count counter=reports with display_count=reports|intcomma %}
-            {{ display_count }} open report
-            {% plural %}
-            {{ display_count }} open reports
-            {% endblocktrans %}
-        </a>
-    </div>
-    {% endif %}
-
-    {% if pending_domains %}
-    <div class="column is-flex">
-        <a href="{% url 'settings-link-domain' %}" class="notification is-primary is-block is-flex-grow-1">
-            {% blocktrans trimmed count counter=pending_domains with display_count=pending_domains|intcomma %}
-            {{ display_count }} domain needs review
-            {% plural %}
-            {{ display_count }} domains need review
-            {% endblocktrans %}
-        </a>
-    </div>
-    {% endif %}
-
-    {% if not site.allow_registration and site.allow_invite_requests and invite_requests %}
-    <div class="column is-flex">
-        <a href="{% url 'settings-invite-requests' %}" class="notification is-block is-success is-flex-grow-1">
-            {% blocktrans trimmed count counter=invite_requests with display_count=invite_requests|intcomma %}
-            {{ display_count }} invite request
-            {% plural %}
-            {{ display_count }} invite requests
-            {% endblocktrans %}
-        </a>
-    </div>
+    {% include 'settings/dashboard/warnings/email_config.html' with warning_level="danger" fullwidth=True %}
     {% endif %}
 
     {% if current_version %}
-    <div class="column is-flex">
-        <a href="https://docs.joinbookwyrm.com/updating.html" class="notification is-block is-warning is-flex-grow-1" target="_blank">
-            {% blocktrans trimmed with current=current_version available=available_version %}
-            An update is available! You're running v{{ current }} and the latest release is {{ available }}.
-            {% endblocktrans %}
-        </a>
-    </div>
+    {% include 'settings/dashboard/warnings/update_version.html' with warning_level="warning" fullwidth=True %}
+    {% endif %}
+
+    {% if reports %}
+    {% include 'settings/dashboard/warnings/reports.html' with warning_level="warning" %}
+    {% endif %}
+
+    {% if pending_domains %}
+    {% include 'settings/dashboard/warnings/domain_review.html' with warning_level="primary" %}
+    {% endif %}
+
+    {% if not site.allow_registration and site.allow_invite_requests and invite_requests %}
+    {% include 'settings/dashboard/warnings/invites.html' with warning_level="success" %}
     {% endif %}
 </div>
 

--- a/bookwyrm/templates/settings/dashboard/dashboard.html
+++ b/bookwyrm/templates/settings/dashboard/dashboard.html
@@ -45,6 +45,22 @@
     {% include 'settings/dashboard/warnings/update_version.html' with warning_level="warning" fullwidth=True %}
     {% endif %}
 
+    {% if missing_privacy or missing_conduct %}
+    <div class="column is-12 columns m-0 p-0">
+        {% if missing_privacy %}
+        {% include 'settings/dashboard/warnings/missing_privacy.html' with warning_level="danger" %}
+        {% endif %}
+
+        {% if missing_conduct %}
+        {% include 'settings/dashboard/warnings/missing_conduct.html' with warning_level="warning" %}
+        {% endif %}
+    </div>
+    {% endif %}
+
+    {% if current_version %}
+    {% include 'settings/dashboard/warnings/update_version.html' with warning_level="warning" fullwidth=True %}
+    {% endif %}
+
     {% if reports %}
     {% include 'settings/dashboard/warnings/reports.html' with warning_level="warning" %}
     {% endif %}

--- a/bookwyrm/templates/settings/dashboard/warnings/domain_review.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/domain_review.html
@@ -2,9 +2,7 @@
 {% load i18n %}
 {% load humanize %}
 
-{% block warning_link %}
-{% url 'settings-link-domain' %}
-{% endblock %}
+{% block warning_link %}{% url 'settings-link-domain' %}{% endblock %}
 
 {% block warning_text %}
 

--- a/bookwyrm/templates/settings/dashboard/warnings/domain_review.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/domain_review.html
@@ -1,0 +1,17 @@
+{% extends 'settings/dashboard/warnings/layout.html' %}
+{% load i18n %}
+{% load humanize %}
+
+{% block warning_link %}
+{% url 'settings-link-domain' %}
+{% endblock %}
+
+{% block warning_text %}
+
+{% blocktrans trimmed count counter=pending_domains with display_count=pending_domains|intcomma %}
+{{ display_count }} domain needs review
+{% plural %}
+{{ display_count }} domains need review
+{% endblocktrans %}
+
+{% endblock %}

--- a/bookwyrm/templates/settings/dashboard/warnings/email_config.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/email_config.html
@@ -1,0 +1,15 @@
+{% extends 'settings/dashboard/warnings/layout.html' %}
+{% load i18n %}
+
+{% block warning_link %}
+https://docs.joinbookwyrm.com/install-prod.html
+{% endblock %}
+
+{% block warning_text %}
+
+{% blocktrans trimmed %}
+Your outgoing email address, <code>{{ email_sender }}</code>, may be misconfigured.
+{% endblocktrans %}
+{% trans "Check the <code>EMAIL_SENDER_NAME</code> and <code>EMAIL_SENDER_DOMAIN</code> in your <code>.env</code> file." %}
+
+{% endblock %}

--- a/bookwyrm/templates/settings/dashboard/warnings/email_config.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/email_config.html
@@ -1,9 +1,7 @@
 {% extends 'settings/dashboard/warnings/layout.html' %}
 {% load i18n %}
 
-{% block warning_link %}
-https://docs.joinbookwyrm.com/install-prod.html
-{% endblock %}
+{% block warning_link %}https://docs.joinbookwyrm.com/install-prod.html{% endblock %}
 
 {% block warning_text %}
 

--- a/bookwyrm/templates/settings/dashboard/warnings/invites.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/invites.html
@@ -1,0 +1,17 @@
+{% extends 'settings/dashboard/warnings/layout.html' %}
+{% load i18n %}
+{% load humanize %}
+
+{% block warning_link %}
+{% url 'settings-invite-requests' %}
+{% endblock %}
+
+{% block warning_text %}
+
+{% blocktrans trimmed count counter=invite_requests with display_count=invite_requests|intcomma %}
+{{ display_count }} invite request
+{% plural %}
+{{ display_count }} invite requests
+{% endblocktrans %}
+
+{% endblock %}

--- a/bookwyrm/templates/settings/dashboard/warnings/invites.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/invites.html
@@ -2,9 +2,7 @@
 {% load i18n %}
 {% load humanize %}
 
-{% block warning_link %}
-{% url 'settings-invite-requests' %}
-{% endblock %}
+{% block warning_link %}{% url 'settings-invite-requests' %}{% endblock %}
 
 {% block warning_text %}
 

--- a/bookwyrm/templates/settings/dashboard/warnings/layout.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/layout.html
@@ -3,4 +3,3 @@
         {% block warning_text %}{% endblock %}
     </a>
 </div>
-

--- a/bookwyrm/templates/settings/dashboard/warnings/layout.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/layout.html
@@ -1,0 +1,6 @@
+<div class="column is-flex{% if fullwidth %} is-12{% endif %}">
+    <a href="{% block warning_link %}{% endblock %}" class="notification is-{{ warning_level }} is-block is-flex-grow-1">
+        {% block warning_text %}{% endblock %}
+    </a>
+</div>
+

--- a/bookwyrm/templates/settings/dashboard/warnings/missing_conduct.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/missing_conduct.html
@@ -1,9 +1,7 @@
 {% extends 'settings/dashboard/warnings/layout.html' %}
 {% load i18n %}
 
-{% block warning_link %}
-{% url 'settings-site' %}#instance-info
-{% endblock %}
+{% block warning_link %}{% url 'settings-site' %}#instance-info{% endblock %}
 
 {% block warning_text %}
 

--- a/bookwyrm/templates/settings/dashboard/warnings/missing_conduct.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/missing_conduct.html
@@ -1,0 +1,12 @@
+{% extends 'settings/dashboard/warnings/layout.html' %}
+{% load i18n %}
+
+{% block warning_link %}
+{% url 'settings-site' %}#instance-info
+{% endblock %}
+
+{% block warning_text %}
+
+{% trans "Your instance is missing a code of conduct." %}
+
+{% endblock %}

--- a/bookwyrm/templates/settings/dashboard/warnings/missing_privacy.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/missing_privacy.html
@@ -1,9 +1,7 @@
 {% extends 'settings/dashboard/warnings/layout.html' %}
 {% load i18n %}
 
-{% block warning_link %}
-{% url 'settings-site' %}#instance-info
-{% endblock %}
+{% block warning_link %}{% url 'settings-site' %}#instance-info{% endblock %}
 
 {% block warning_text %}
 

--- a/bookwyrm/templates/settings/dashboard/warnings/missing_privacy.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/missing_privacy.html
@@ -1,0 +1,12 @@
+{% extends 'settings/dashboard/warnings/layout.html' %}
+{% load i18n %}
+
+{% block warning_link %}
+{% url 'settings-site' %}#instance-info
+{% endblock %}
+
+{% block warning_text %}
+
+{% trans "Your instance is missing a privacy policy." %}
+
+{% endblock %}

--- a/bookwyrm/templates/settings/dashboard/warnings/reports.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/reports.html
@@ -1,0 +1,17 @@
+{% extends 'settings/dashboard/warnings/layout.html' %}
+{% load i18n %}
+{% load humanize %}
+
+{% block warning_link %}
+{% url 'settings-reports' %}
+{% endblock %}
+
+{% block warning_text %}
+
+{% blocktrans trimmed count counter=reports with display_count=reports|intcomma %}
+{{ display_count }} open report
+{% plural %}
+{{ display_count }} open reports
+{% endblocktrans %}
+
+{% endblock %}

--- a/bookwyrm/templates/settings/dashboard/warnings/reports.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/reports.html
@@ -2,9 +2,7 @@
 {% load i18n %}
 {% load humanize %}
 
-{% block warning_link %}
-{% url 'settings-reports' %}
-{% endblock %}
+{% block warning_link %}{% url 'settings-reports' %}{% endblock %}
 
 {% block warning_text %}
 

--- a/bookwyrm/templates/settings/dashboard/warnings/update_version.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/update_version.html
@@ -1,9 +1,7 @@
 {% extends 'settings/dashboard/warnings/layout.html' %}
 {% load i18n %}
 
-{% block warning_link %}
-https://docs.joinbookwyrm.com/updating.html
-{% endblock %}
+{% block warning_link %}https://docs.joinbookwyrm.com/updating.html{% endblock %}
 
 {% block warning_text %}
 

--- a/bookwyrm/templates/settings/dashboard/warnings/update_version.html
+++ b/bookwyrm/templates/settings/dashboard/warnings/update_version.html
@@ -1,0 +1,14 @@
+{% extends 'settings/dashboard/warnings/layout.html' %}
+{% load i18n %}
+
+{% block warning_link %}
+https://docs.joinbookwyrm.com/updating.html
+{% endblock %}
+
+{% block warning_text %}
+
+{% blocktrans trimmed with current=current_version available=available_version %}
+An update is available! You're running v{{ current }} and the latest release is {{ available }}.
+{% endblocktrans %}
+
+{% endblock %}

--- a/bookwyrm/views/admin/dashboard.py
+++ b/bookwyrm/views/admin/dashboard.py
@@ -43,7 +43,7 @@ class Dashboard(View):
         ] = f"{settings.EMAIL_SENDER_NAME}@{settings.EMAIL_SENDER_DOMAIN}"
 
         site = models.SiteSettings.objects.get()
-        # other warnings
+        # pylint: disable=protected-access
         data["missing_conduct"] = (
             not site.code_of_conduct
             or site.code_of_conduct

--- a/bookwyrm/views/admin/dashboard.py
+++ b/bookwyrm/views/admin/dashboard.py
@@ -42,6 +42,19 @@ class Dashboard(View):
             "email_sender"
         ] = f"{settings.EMAIL_SENDER_NAME}@{settings.EMAIL_SENDER_DOMAIN}"
 
+        site = models.SiteSettings.objects.get()
+        # other warnings
+        data["missing_conduct"] = (
+            not site.code_of_conduct
+            or site.code_of_conduct
+            == site._meta.get_field("code_of_conduct").get_default()
+        )
+        data["missing_privacy"] = (
+            not site.privacy_policy
+            or site.privacy_policy
+            == site._meta.get_field("privacy_policy").get_default()
+        )
+
         # check version
         try:
             release = get_data(settings.RELEASE_API, timeout=3)


### PR DESCRIPTION
Before, with all warnings active (don't mind the nonsense content):
<img width="887" alt="Screen Shot 2022-07-08 at 11 17 37 AM" src="https://user-images.githubusercontent.com/1807695/178054328-d1ede2a7-a68d-4d85-b56a-39106a5201ff.png">

After:
<img width="892" alt="Screen Shot 2022-07-08 at 11 47 42 AM" src="https://user-images.githubusercontent.com/1807695/178054392-93fcf1f0-351b-4438-b40f-2177f49ff80a.png">

