### PR TITLE
Log failing to connect as info instead of exception

### DIFF
--- a/bookwyrm/connectors/connector_manager.py
+++ b/bookwyrm/connectors/connector_manager.py
@@ -53,7 +53,7 @@ async def get_results(session, url, min_confidence, query, connector):
     except asyncio.TimeoutError:
         logger.info("Connection timed out for url: %s", url)
     except aiohttp.ClientError as err:
-        logger.exception(err)
+        logger.info(err)
 
 
 async def async_connector_search(query, items, min_confidence):


### PR DESCRIPTION
These are normal, expected errors, and while we should probably
re-evaluate the connectors in some way, pending that, there's no need to
log these as unepected errors, which causes confusion and clutters my
error logging.