### PR TITLE
strip spaces from user search

### DIFF
--- a/bookwyrm/views/search.py
+++ b/bookwyrm/views/search.py
@@ -90,6 +90,7 @@ def user_search(request):
     """cool kids members only user search"""
     viewer = request.user
     query = request.GET.get("q")
+    query = query.strip()
     data = {"type": "user", "query": query}
     # logged out viewers can't search users
     if not viewer.is_authenticated:


### PR DESCRIPTION
Strips leading and trailing spaces from user search to prevent errors when doing webfinger lookup.

Fixes #2205