### PR TITLE
fix visibility of stars when editing a review

### DIFF
--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -37,7 +37,7 @@
             type="radio"
             name="rating"
             value="{{ forloop.counter0 }}.5"
-            {% if default_rating == forloop.counter %}checked{% endif %}
+            {% if default_rating >= forloop.counter0 %}checked{% endif %}
         />
         <input
             id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}"
@@ -45,7 +45,7 @@
             type="radio"
             name="rating"
             value="{{ forloop.counter }}"
-            {% if default_rating == forloop.counter %}checked{% endif %}
+            {% if default_rating >= forloop.counter %}checked{% endif %}
         />
 
         <label


### PR DESCRIPTION
Previously the star rating appeared to be five stars when editing a review, regardless of what value was actually stored.
Now it will show the actual rating, including half stars.

Fixes #2213