### PR TITLE
Null state for review view during imports

### DIFF
--- a/bookwyrm/templates/import/import_status.html
+++ b/bookwyrm/templates/import/import_status.html
@@ -41,7 +41,7 @@
         </dl>
     </div>
 
-    {% if not job.complete %}
+    {% if not job.complete and show_progress %}
     <div class="box is-processing">
         <div class="block">
             <span class="icon icon-spinner is-pulled-left" aria-hidden="true"></span>
@@ -94,7 +94,7 @@
 <div class="block">
     {% block actions %}{% endblock %}
     <div class="table-container">
-        <table class="table is-striped">
+        <table class="table is-striped is-fullwidth">
             <tr>
                 <th>
                     {% trans "Row" %}
@@ -137,6 +137,13 @@
                 </td>
             </tr>
             {% else %}
+            {% if not items %}
+            <tr>
+                <td colspan="6">
+                    <em>{% trans "No items currently need review" %}</em>
+                </td>
+            </tr>
+            {% endif %}
             {% for item in items %}
             <tr>
                 {% block index_col %}

--- a/bookwyrm/views/imports/import_status.py
+++ b/bookwyrm/views/imports/import_status.py
@@ -47,6 +47,7 @@ class ImportStatus(View):
             "page_range": paginated.get_elided_page_range(
                 page.number, on_each_side=2, on_ends=1
             ),
+            "show_progress": True,
             "item_count": item_count,
             "complete_count": item_count - pending_item_count,
             "percent": math.floor(  # pylint: disable=c-extension-no-member


### PR DESCRIPTION
Without this, it will show an empty progress bar and no info about why the table is empty.