### PR TITLE
Closes #2194 Normalize stored ISNI

### DIFF
--- a/bookwyrm/models/author.py
+++ b/bookwyrm/models/author.py
@@ -42,6 +42,11 @@ class Author(BookDataModel):
                 for book in self.book_set.values_list("id", flat=True)
             ]
             cache.delete_many(cache_keys)
+        
+        # normalize isni format
+        if self.isni:
+            self.isni = re.sub(r"\s", "", self.isni)
+
         return super().save(*args, **kwargs)
 
     @property


### PR DESCRIPTION
The Author.isni_link property has sample code to remove spaces, I just copied that up to the Author.save() function.  I left Author.isni_link as is to preserve existing functionality for isni values stored in the DB where the Author.save() function has not been run.