### PR TITLE
Close dropdown menu when opening one of its modal

### DIFF
--- a/bookwyrm/static/css/bookwyrm/components/_details.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_details.scss
@@ -67,7 +67,7 @@ details.dropdown .dropdown-menu a:focus-visible {
         align-items: center;
         justify-content: center;
         pointer-events: none;
-        z-index: 100;
+        z-index: 35;
     }
 
     details .dropdown-menu > * {

--- a/bookwyrm/static/js/bookwyrm.js
+++ b/bookwyrm/static/js/bookwyrm.js
@@ -38,11 +38,12 @@ let BookWyrm = new (class {
             .querySelectorAll("[data-modal-open]")
             .forEach((node) => node.addEventListener("click", this.handleModalButton.bind(this)));
 
-        document
-            .querySelectorAll("details.dropdown")
-            .forEach((node) =>
-                node.addEventListener("toggle", this.handleDetailsDropdown.bind(this))
+        document.querySelectorAll("details.dropdown").forEach((node) => {
+            node.addEventListener("toggle", this.handleDetailsDropdown.bind(this));
+            node.querySelectorAll("[data-modal-open]").forEach((modal_node) =>
+                modal_node.addEventListener("click", () => (node.open = false))
             );
+        });
 
         document
             .querySelector("#barcode-scanner-modal")


### PR DESCRIPTION
This PR resolves dropdown menus staying above opened modals on mobile.
work:
- [X] close a dropdown menus after one of its item opening a modal is clicked
- [X] set dropdown menu z-index below that of modals on mobile (35 vs 40)

resolves #2178 