### PR TITLE
Send confirmation emails directly, rather than with celery

### DIFF
--- a/bookwyrm/emailing.py
+++ b/bookwyrm/emailing.py
@@ -23,7 +23,7 @@ def email_confirmation_email(user):
     data = email_data()
     data["confirmation_code"] = user.confirmation_code
     data["confirmation_link"] = user.confirmation_link
-    send_email.delay(user.email, *format_email("confirm", data))
+    send_email(user.email, *format_email("confirm", data))
 
 
 def invite_email(invite_request):

--- a/bookwyrm/tests/views/landing/test_register.py
+++ b/bookwyrm/tests/views/landing/test_register.py
@@ -20,6 +20,7 @@ from bookwyrm.tests.validate_html import validate_html
 class RegisterViews(TestCase):
     """login and password management"""
 
+    # pylint: disable=invalid-name
     def setUp(self):
         """we need basic test data and mocks"""
         self.factory = RequestFactory()
@@ -382,6 +383,6 @@ class RegisterViews(TestCase):
         """try again"""
         request = self.factory.post("", {"email": "mouse@mouse.com"})
         request.user = self.anonymous_user
-        with patch("bookwyrm.emailing.send_email.delay") as mock:
+        with patch("bookwyrm.emailing.send_email") as mock:
             views.ResendConfirmEmail.as_view()(request)
         self.assertEqual(mock.call_count, 1)

--- a/nginx/development
+++ b/nginx/development
@@ -7,7 +7,7 @@ upstream web {
 server {
     listen 80;
 
-    location ~ ^/(login[^-]|password-reset|resend-link|2fa-check) {
+    location ~ ^/(login[^-/]|password-reset|resend-link|2fa-check) {
         limit_req zone=loginlimit;
 
         proxy_pass http://web;

--- a/nginx/production
+++ b/nginx/production
@@ -41,7 +41,7 @@ server {
 #         root /var/www/certbot;
 #     }
 #
-#     location ~ ^/(login[^-]|password-reset|resend-link|2fa-check) {
+#     location ~ ^/(login[^-/]|password-reset|resend-link|2fa-check) {
 #         limit_req zone=loginlimit;
 #
 #         proxy_pass http://web;


### PR DESCRIPTION
Whenver bookwyrm has an influx of new users, celery gets delayed and the emails don't get sent out promptly, which causes people to first resend the email multiple times, and then to email me, both of which just create more work and confusion for everyone involved.