### PR TITLE
Fix npm dev tools

### DIFF
--- a/bookwyrm/static/css/bookwyrm.scss
+++ b/bookwyrm/static/css/bookwyrm.scss
@@ -1,4 +1,3 @@
 @charset "utf-8";
-
 @import "vendor/bulma/bulma.sass";
-@import "bookwyrm/all.scss";
+@import "bookwyrm/all";

--- a/bookwyrm/static/css/bookwyrm/_all.scss
+++ b/bookwyrm/static/css/bookwyrm/_all.scss
@@ -16,9 +16,7 @@
 @import "components/status";
 @import "components/tabs";
 @import "components/toggle";
-
 @import "overrides/bulma_overrides";
-
 @import "utilities/a11y";
 @import "utilities/alignments";
 @import "utilities/colors";
@@ -40,10 +38,12 @@ body {
     width: 12px;
     height: 12px;
 }
+
 ::-webkit-scrollbar-thumb {
     background: $scrollbar-thumb;
     border-radius: 0.5em;
 }
+
 ::-webkit-scrollbar-track {
     background: $scrollbar-track;
 }
@@ -88,7 +88,6 @@ button::-moz-focus-inner {
 
 /** Utilities not covered by Bulma
  ******************************************************************************/
-
 
 .tag.is-small {
     height: auto;
@@ -140,7 +139,6 @@ button:focus-visible .button-invisible-overlay {
     opacity: 1;
 }
 
-
 /** States
  ******************************************************************************/
 
@@ -154,7 +152,6 @@ button:focus-visible .button-invisible-overlay {
     opacity: 0.5;
     cursor: not-allowed;
 }
-
 
 /* Notifications page
  ******************************************************************************/

--- a/bw-dev
+++ b/bw-dev
@@ -166,7 +166,8 @@ case "$CMD" in
     pylint)
         prod_error
         # pylint depends on having the app dependencies in place, so we run it in the web container
-        runweb pylint bookwyrm/
+        # no-deps doesn't spin up other containers, such as databases, cause we don't need them here
+        docker-compose run --no-deps --rm web pylint bookwyrm/
         ;;
     prettier)
         prod_error
@@ -181,7 +182,9 @@ case "$CMD" in
         ;;
     formatters)
         prod_error
-        runweb pylint bookwyrm/
+        # Make sure we're up to date
+        docker-compose build dev-tools
+        docker-compose run --no-deps --rm web pylint bookwyrm/
         docker-compose run --rm dev-tools black /app/celerywyrm /app/bookwyrm
         docker-compose run --rm dev-tools npx prettier --write /app/bookwyrm/static/js/*.js
         docker-compose run --rm dev-tools npx stylelint \

--- a/bw-dev
+++ b/bw-dev
@@ -161,7 +161,7 @@ case "$CMD" in
         ;;
     black)
         prod_error
-        docker-compose run --rm dev-tools black celerywyrm bookwyrm
+        docker-compose run --rm dev-tools black /app/celerywyrm /app/bookwyrm
         ;;
     pylint)
         prod_error
@@ -170,22 +170,24 @@ case "$CMD" in
         ;;
     prettier)
         prod_error
-        docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
+        docker-compose run --rm dev-tools npx prettier --write /app/bookwyrm/static/js/*.js
         ;;
     stylelint)
         prod_error
         docker-compose run --rm dev-tools npx stylelint \
-            bookwyrm/static/css/bookwyrm.scss bookwyrm/static/css/bookwyrm/**/*.scss --fix \
-            --config dev-tools/.stylelintrc.js
+            /app/bookwyrm/static/css/bookwyrm.scss \
+            /app/bookwyrm/static/css/bookwyrm/**/*.scss \
+            --fix --config .stylelintrc.js
         ;;
     formatters)
         prod_error
         runweb pylint bookwyrm/
-        docker-compose run --rm dev-tools black celerywyrm bookwyrm
-        docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
+        docker-compose run --rm dev-tools black /app/celerywyrm /app/bookwyrm
+        docker-compose run --rm dev-tools npx prettier --write /app/bookwyrm/static/js/*.js
         docker-compose run --rm dev-tools npx stylelint \
-            bookwyrm/static/css/bookwyrm.scss bookwyrm/static/css/bookwyrm/**/*.scss --fix \
-            --config dev-tools/.stylelintrc.js
+            /app/bookwyrm/static/css/bookwyrm.scss \
+            /app/bookwyrm/static/css/bookwyrm/**/*.scss \
+            --fix --config .stylelintrc.js
         ;;
     collectstatic_watch)
         prod_error

--- a/dev-tools/.dockerignore
+++ b/dev-tools/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.npm

--- a/dev-tools/.stylelintrc.js
+++ b/dev-tools/.stylelintrc.js
@@ -1,7 +1,7 @@
 /* global module */
 
 module.exports = {
-    "extends": "stylelint-config-standard",
+    "extends": "stylelint-config-standard-scss",
 
     "plugins": [
         "stylelint-order"

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,14 +1,20 @@
 FROM python:3.9
 
 ENV PYTHONUNBUFFERED 1
+ENV PIP_ROOT_USER_ACTION ignore
 
-RUN mkdir /app
 WORKDIR /app
-
-COPY package.json requirements.txt .stylelintrc.js .stylelintignore /app/
-RUN pip install -r requirements.txt
 
 RUN apt-get update && apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get install -y nodejs && apt-get clean
-RUN npm install .
+
+RUN python -m pip install --upgrade pip
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+WORKDIR /app/dev-tools
+ENV NO_UPDATE_NOTIFIER true
+COPY package.json .stylelintrc.js .stylelintignore ./
+RUN npm install

--- a/dev-tools/package.json
+++ b/dev-tools/package.json
@@ -9,7 +9,7 @@
     "prettier": "2.5.1",
     "stylelint": "^14.5.0",
     "stylelint-config-recommended": "^7.0.0",
-    "stylelint-config-standard": "^25.0.0",
+    "stylelint-config-standard-scss": "^6.1.0",
     "stylelint-order": "^5.0.0",
     "watch": "^0.13.0"
   },


### PR DESCRIPTION
The npm-based devtools weren't working (for me, at least) because they need to be run out of the `dev-tools` folder. This fixes that, and does some other dev-tools cleanup while I'm at it.