### PR TITLE
Add contrib directory with systemd service files for front, worker and scheduler

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,5 @@
+# Contrib
+
+This directory contain some scripts, configuration files and other useful tools around BookWyrm.
+
+These tools are not necessary for the proper functioning of BookWyrm but provide a helpful leg-up for integration with some third-party or to nicely fit BookWyrm into other environments.

--- a/contrib/systemd/bookwyrm-scheduler.service
+++ b/contrib/systemd/bookwyrm-scheduler.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=BookWyrm scheduler
-After=network.target postgresql.service
+After=network.target postgresql.service redis.service
 
 [Service]
 User=bookwyrm

--- a/contrib/systemd/bookwyrm-scheduler.service
+++ b/contrib/systemd/bookwyrm-scheduler.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=BookWyrm scheduler
+After=network.target postgresql.service
+
+[Service]
+User=bookwyrm
+Group=bookwyrm
+WorkingDirectory=/opt/bookwyrm/
+ExecStart=/opt/bookwyrm/venv/bin/celery -A celerywyrm beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
+StandardOutput=journal
+StandardError=inherit
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/bookwyrm-worker.service
+++ b/contrib/systemd/bookwyrm-worker.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=BookWyrm worker
+After=network.target postgresql.service redis.service
+
+[Service]
+User=bookwyrm
+Group=bookwyrm
+WorkingDirectory=/opt/bookwyrm/
+ExecStart=/opt/bookwyrm/venv/bin/celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority
+StandardOutput=journal
+StandardError=inherit
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/bookwyrm.service
+++ b/contrib/systemd/bookwyrm.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=BookWyrm
-After=network.target postgresql.service
+After=network.target postgresql.service redis.service
 
 [Service]
 User=bookwyrm

--- a/contrib/systemd/bookwyrm.service
+++ b/contrib/systemd/bookwyrm.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=BookWyrm
+After=network.target postgresql.service
+
+[Service]
+User=bookwyrm
+Group=bookwyrm
+WorkingDirectory=/opt/bookwyrm/
+ExecStart=/opt/bookwyrm/venv/bin/gunicorn bookwyrm.wsgi:application --bind 0.0.0.0:8000
+StandardOutput=journal
+StandardError=inherit
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Goal

- Create a `contrib` directory
- Create `bookwyrm`, `bookwyrm-worker` and `bookwyrm-scheduler` systemd services

# Information

Naming a directory `contrib` for scripts and configuration files providing a helpful leg-up for integration of a project into other environments is a long established convention.

If this PR is accepted I will also propose a change in the `install-prod-dockerless` documentation to use this systemd service files instead of the current `dockerless-run.sh` script.