### PR TITLE
Remove dead URL

### DIFF
--- a/bookwyrm/templates/settings/federation/instance_blocklist.html
+++ b/bookwyrm/templates/settings/federation/instance_blocklist.html
@@ -60,7 +60,7 @@
         <label class="label" for="id_file">JSON data:</label>
         <aside class="help">
             {% blocktrans trimmed %}
-            Expects a json file in the format provided by <a href="https://fediblock.org/" target="_blank" rel="nofollow noopener noreferrer">FediBlock</a>, with a list of entries that have <code>instance</code> and <code>url</code> fields. For example:
+            Expects a json file in the format provided by FediBlock, with a list of entries that have <code>instance</code> and <code>url</code> fields. For example:
             {% endblocktrans %}
             <pre>
 [


### PR DESCRIPTION
https://fediblock.org delivers a 410 Gone as respone.