### PR TITLE
Change log level to info for connector exceptions

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -271,7 +271,7 @@ def resolve_remote_id(
     try:
         data = get_data(remote_id)
     except ConnectorException:
-        logger.exception("Could not connect to host for remote_id: %s", remote_id)
+        logger.info("Could not connect to host for remote_id: %s", remote_id)
         return None
 
     # determine the model implicitly, if not provided

--- a/bookwyrm/connectors/abstract_connector.py
+++ b/bookwyrm/connectors/abstract_connector.py
@@ -222,7 +222,7 @@ def dict_from_mappings(data, mappings):
     return result
 
 
-def get_data(url, params=None, timeout=10):
+def get_data(url, params=None, timeout=settings.QUERY_TIMEOUT):
     """wrapper for request.get"""
     # check if the url is blocked
     raise_not_valid_url(url)


### PR DESCRIPTION
These errors in resolve_remote_id aren't really errors, they're routine problems that we can expect from dealing with the outside world, like a connection timeout, a server being down, a server being blocked, et cetera. It's cluttering up the logs and causing unnecessary worry.