### PR TITLE
Hotfix: Disable list suggestions

### DIFF
--- a/bookwyrm/views/list/list.py
+++ b/bookwyrm/views/list/list.py
@@ -71,7 +71,8 @@ class List(View):
             "add_succeeded": add_succeeded,
         }
 
-        if request.user.is_authenticated:
+        # Temporarily disable list suggestions, which seem to be causing 502s
+        if request.user.is_authenticated and False:
             data["suggested_books"] = get_list_suggestions(
                 book_list, request.user, query=query
             )


### PR DESCRIPTION
I did some process of elimination, and this seems to be behind #2433, causing 502s and using up a whole CPU core. Obviously this doesn't fix the underlying issue, but since list suggestions aren't a core functionality and are already conditionally rendered, disabling them seems like a good mitigation until the underlying issue can be fixed.