### PR TITLE
Fix: Slice queryset in list suggestions before we resolve it

### DIFF
--- a/bookwyrm/views/list/list.py
+++ b/bookwyrm/views/list/list.py
@@ -110,8 +110,8 @@ def get_list_suggestions(book_list, user, query=None):
             s.default_edition
             for s in models.Work.objects.filter(
                 ~Q(editions__in=book_list.books.all()),
-            ).order_by("-updated_date")
-        ][: 5 - len(suggestions)]
+            ).order_by("-updated_date")[: 5 - len(suggestions)]
+        ]
     return suggestions
 
 


### PR DESCRIPTION
What happened here is due to the fact that slicing querysets is somewhat magical, in that it's not actually operating on a list at all, it's really a LIMIT/OFFSET to the query.

Since this code was doing a list comprehension with the queryset and _then_ slicing, that magic didn't happen, since the list comprehension "resolved" the queryset by iterating over it _before_ we sliced it, which meant the query that got kicked off went and fetched basically every book in database, pulled the `default_edition` off of it, and _then_ chose the first five books from that list.

For instances that had any number of books, this of course, broke some stuff, causing #2433.

The fix is to slice the queryset before iterating over it, so that the slice is correctly applied as a LIMIT parameter.