### PR TITLE
Handles state in notifications where a list item was deleted

### DIFF
--- a/bookwyrm/templates/notifications/items/add.html
+++ b/bookwyrm/templates/notifications/items/add.html
@@ -61,7 +61,13 @@
 {% else %}
     {% with count=notification.related_list_items.count|add:"-2" %}
     {% with display_count=count|intcomma %}
-    {% if related_list.curation != "curated" %}
+    {% if count < 1 %}
+        {# This happens if the list item was deleted #}
+        {% blocktrans trimmed %}
+        <a href="{{ related_user_link }}">{{ related_user }}</a>
+        added added a book to one of your lists
+        {% endblocktrans %}
+    {% elif related_list.curation != "curated" %}
 
         {% blocktrans trimmed count counter=count %}
         <a href="{{ related_user_link }}">{{ related_user }}</a>


### PR DESCRIPTION
There might be a clearer way to phrase this, but it's better than before ™️
Before:
<img width="487" alt="Screen Shot 2022-11-25 at 8 57 35 AM" src="https://user-images.githubusercontent.com/1807695/204029524-d28e3b58-1f1d-4b60-95ff-63e0887fed8d.png">


After:
<img width="505" alt="Screen Shot 2022-11-25 at 8 56 34 AM" src="https://user-images.githubusercontent.com/1807695/204029481-73067e9c-044d-4684-b93c-60f58910906a.png">
