### PR TITLE
Fix serialization of JSON-LD subarrays

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -194,6 +194,11 @@ class ActivityObject:
             try:
                 if issubclass(type(v), ActivityObject):
                     data[k] = v.serialize()
+                elif isinstance(v, list):
+                    data[k] = [
+                        e.serialize() if issubclass(type(e), ActivityObject) else e
+                        for e in v
+                    ]
             except TypeError:
                 pass
         data = {k: v for (k, v) in data.items() if v is not None and k not in omit}
@@ -306,7 +311,9 @@ class Link(ActivityObject):
 
     def serialize(self, **kwargs):
         """remove fields"""
-        omit = ("id", "type", "@context")
+        omit = ("id", "@context")
+        if self.type == "Link":
+            omit += ("type",)
         return super().serialize(omit=omit)
 
 

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -191,14 +191,14 @@ class Status(TestCase):
         self.assertEqual(activity["type"], "Note")
         self.assertEqual(activity["sensitive"], False)
         self.assertIsInstance(activity["attachment"], list)
-        self.assertEqual(activity["attachment"][0].type, "Document")
+        self.assertEqual(activity["attachment"][0]["type"], "Document")
         self.assertTrue(
             re.match(
                 r"https:\/\/your.domain.here\/images\/covers\/test_[A-z0-9]+.jpg",
-                activity["attachment"][0].url,
+                activity["attachment"][0]["url"],
             )
         )
-        self.assertEqual(activity["attachment"][0].name, "Test Edition")
+        self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
     def test_comment_to_activity(self, *_):
         """subclass of the base model version with a "pure" serializer"""
@@ -223,14 +223,14 @@ class Status(TestCase):
             activity["content"],
             f'test content<p>(comment on <a href="{self.book.remote_id}">"Test Edition"</a>)</p>',
         )
-        self.assertEqual(activity["attachment"][0].type, "Document")
+        self.assertEqual(activity["attachment"][0]["type"], "Document")
         # self.assertTrue(
         #    re.match(
         #        r"https:\/\/your.domain.here\/images\/covers\/test_[A-z0-9]+.jpg",
         #        activity["attachment"][0].url,
         #    )
         # )
-        self.assertEqual(activity["attachment"][0].name, "Test Edition")
+        self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
     def test_quotation_to_activity(self, *_):
         """subclass of the base model version with a "pure" serializer"""
@@ -262,14 +262,14 @@ class Status(TestCase):
             activity["content"],
             f'a sickening sense <p>-- <a href="{self.book.remote_id}">"Test Edition"</a></p>test content',
         )
-        self.assertEqual(activity["attachment"][0].type, "Document")
+        self.assertEqual(activity["attachment"][0]["type"], "Document")
         self.assertTrue(
             re.match(
                 r"https:\/\/your.domain.here\/images\/covers\/test_[A-z0-9]+.jpg",
-                activity["attachment"][0].url,
+                activity["attachment"][0]["url"],
             )
         )
-        self.assertEqual(activity["attachment"][0].name, "Test Edition")
+        self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
     def test_review_to_activity(self, *_):
         """subclass of the base model version with a "pure" serializer"""
@@ -305,14 +305,14 @@ class Status(TestCase):
             f'Review of "{self.book.title}" (3 stars): Review\'s name',
         )
         self.assertEqual(activity["content"], "test content")
-        self.assertEqual(activity["attachment"][0].type, "Document")
+        self.assertEqual(activity["attachment"][0]["type"], "Document")
         self.assertTrue(
             re.match(
                 r"https:\/\/your.domain.here\/images\/covers\/test_[A-z0-9]+.jpg",
-                activity["attachment"][0].url,
+                activity["attachment"][0]["url"],
             )
         )
-        self.assertEqual(activity["attachment"][0].name, "Test Edition")
+        self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
     def test_review_to_pure_activity_no_rating(self, *_):
         """subclass of the base model version with a "pure" serializer"""
@@ -330,14 +330,14 @@ class Status(TestCase):
             f'Review of "{self.book.title}": Review name',
         )
         self.assertEqual(activity["content"], "test content")
-        self.assertEqual(activity["attachment"][0].type, "Document")
+        self.assertEqual(activity["attachment"][0]["type"], "Document")
         self.assertTrue(
             re.match(
                 r"https:\/\/your.domain.here\/images\/covers\/test_[A-z0-9]+.jpg",
-                activity["attachment"][0].url,
+                activity["attachment"][0]["url"],
             )
         )
-        self.assertEqual(activity["attachment"][0].name, "Test Edition")
+        self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
     def test_reviewrating_to_pure_activity(self, *_):
         """subclass of the base model version with a "pure" serializer"""
@@ -353,14 +353,14 @@ class Status(TestCase):
             activity["content"],
             f'rated <em><a href="{self.book.remote_id}">{self.book.title}</a></em>: 3 stars',
         )
-        self.assertEqual(activity["attachment"][0].type, "Document")
+        self.assertEqual(activity["attachment"][0]["type"], "Document")
         self.assertTrue(
             re.match(
                 r"https:\/\/your.domain.here\/images\/covers\/test_[A-z0-9]+.jpg",
-                activity["attachment"][0].url,
+                activity["attachment"][0]["url"],
             )
         )
-        self.assertEqual(activity["attachment"][0].name, "Test Edition")
+        self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
     def test_favorite(self, *_):
         """fav a status"""


### PR DESCRIPTION
Properties like "tag" could be lists containing multiple subclasses of ActivityObject. Make sure to serialize them recursively instead of outputting them as they are, because otherwise we could get a bunch of nulls in the resulting JSON and that wouldn't necessarily be a valid JSON-LD object.

Fix: #2451