### PR TITLE
Enable nginx caching and optimizations.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,10 +86,8 @@ services:
     restart: on-failure
   flower:
     build: .
-    command: celery -A celerywyrm flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD}
+    command: celery -A celerywyrm flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD} --url_prefix=flower
     env_file: .env
-    ports:
-      - ${FLOWER_PORT}:${FLOWER_PORT}
     volumes:
       - .:/app
     networks:

--- a/nginx/development
+++ b/nginx/development
@@ -70,4 +70,10 @@ server {
         add_header X-Cache-Status STATIC;
         access_log off;
     }
+
+    # monitor the celery queues with flower, no caching enabled
+    location /flower/ {
+       proxy_pass http://flower:8888;
+       proxy_cache_bypass 1;
+    }
 }

--- a/nginx/development
+++ b/nginx/development
@@ -5,29 +5,69 @@ upstream web {
 }
 
 server {
+    access_log /var/log/nginx/access.log cache_log;
+
     listen 80;
 
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    #include /etc/nginx/mime.types;
+    #default_type application/octet-stream;
+
+    gzip on;
+    gzip_disable "msie6";
+
+    proxy_read_timeout 1800s;
+    chunked_transfer_encoding on;
+
+    # store responses to anonymous users for up to 1 minute
+    proxy_cache bookwyrm_cache;
+    proxy_cache_valid any 1m;
+    add_header X-Cache-Status $upstream_cache_status;
+
+    # ignore the set cookie header when deciding to
+    # store a response in the cache
+    proxy_ignore_headers Cache-Control Set-Cookie Expires;
+
+    # PUT requests always bypass the cache
+    # logged in sessions also do not populate the cache
+    # to avoid serving personal data to anonymous users
+    proxy_cache_methods GET HEAD;
+    proxy_no_cache      $cookie_sessionid;
+    proxy_cache_bypass  $cookie_sessionid;
+
+    # tell the web container the address of the outside client
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_redirect off;
+
+    # rate limit the login or password reset pages
     location ~ ^/(login[^-/]|password-reset|resend-link|2fa-check) {
         limit_req zone=loginlimit;
-
         proxy_pass http://web;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_redirect off;
     }
 
+    # do not log periodic polling requests from logged in users
+    location /api/updates/ {
+        access_log off;
+        proxy_pass http://web;
+    }
+
+    # forward any cache misses or bypass to the web container
     location / {
         proxy_pass http://web;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_redirect off;
     }
 
-    location /images/ {
-        alias /app/images/;
-    }
-
-    location /static/ {
-        alias /app/static/;
+    # directly serve images and static files from the
+    # bookwyrm filesystem using sendfile.
+    # make the logs quieter by not reporting these requests
+    location ~ ^/(images|static)/ {
+        root /app;
+        try_files $uri =404;
+        add_header X-Cache-Status STATIC;
+        access_log off;
     }
 }

--- a/nginx/server_config
+++ b/nginx/server_config
@@ -1,2 +1,22 @@
 client_max_body_size 10m;
 limit_req_zone $binary_remote_addr zone=loginlimit:10m rate=1r/s;
+
+# include the cache status in the log message
+log_format cache_log '$upstream_cache_status - '
+    '$remote_addr [$time_local] '
+    '"$request" $status $body_bytes_sent '
+    '"$http_referer" "$http_user_agent" '
+    '$upstream_response_time $request_time';
+
+# Create a cache for responses from the web app
+proxy_cache_path
+    /var/cache/nginx/bookwyrm_cache
+    keys_zone=bookwyrm_cache:20m
+    loader_threshold=400
+    loader_files=400
+    max_size=400m;
+
+# use the accept header as part of the cache key
+# since activitypub endpoints have both HTML and JSON
+# on the same URI.
+proxy_cache_key $scheme$proxy_host$uri$is_args$args$http_accept;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3068843/205066643-e5496023-fa12-4c60-97e2-77c4d436633b.png)

This patch enabled nginx caching of non-API calls so that a boost by a popular mastodon user doesn't DDOS the bookwyrm site.  It also silences some of the nginx access logs so that static images are not logged.  Note that I'm not an nginx expert; this was a quick hack to make it work better on my test bookwyrm instance, so if there are better ways to do it, please feel free to edit the request!

With this patch, the logs are a pleasing stream of `HIT` responses from nginx as it easily handles the herd of requests. Without this patch, a boost by a 2k follower mastodon user leads to endlessly scrolling error messages about database connection errors:

```
web_1             | "GET /user/hudson/review/11 HTTP/1.0" 301 0
db_1              | 2022-12-01 13:23:53.099 UTC [2103] FATAL:  sorry, too many clients already
nginx_1           | 192.168.160.1 - [01/Dec/2022:13:23:53 +0000] "GET /user/hudson/review/11 HTTP/1.0" 200 997 "-" "http.rb/5.1.0 (Mastodon/4.0.2; +https://ruby.social/)" ms=7.564
web_1             | Internal Server Error: /user/hudson/review/11
web_1             | Traceback (most recent call last):
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/base.py", line 219, in ensure_connection
web_1             |     self.connect()
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
web_1             |     return func(*args, **kwargs)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/base.py", line 200, in connect
web_1             |     self.connection = self.get_new_connection(conn_params)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
web_1             |     return func(*args, **kwargs)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/postgresql/base.py", line 187, in get_new_connection
web_1             |     connection = Database.connect(**conn_params)
web_1             |   File "/usr/local/lib/python3.9/site-packages/psycopg2/__init__.py", line 126, in connect
web_1             |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
web_1             | psycopg2.OperationalError: FATAL:  sorry, too many clients already
web_1             | 
web_1             | 
web_1             | The above exception was the direct cause of the following exception:
web_1             | 
web_1             | Traceback (most recent call last):
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
web_1             |     response = get_response(request)
web_1             |   File "/app/bookwyrm/middleware/ip_middleware.py", line 14, in __call__
web_1             |     if models.IPBlocklist.objects.filter(address=address).exists():
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/models/query.py", line 808, in exists
web_1             |     return self.query.has_results(using=self.db)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/models/sql/query.py", line 561, in has_results
web_1             |     return compiler.has_results()
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 1145, in has_results
web_1             |     return bool(self.execute_sql(SINGLE))
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 1173, in execute_sql
web_1             |     cursor = self.connection.cursor()
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
web_1             |     return func(*args, **kwargs)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/base.py", line 259, in cursor
web_1             |     return self._cursor()
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/base.py", line 235, in _cursor
web_1             |     self.ensure_connection()
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
web_1             |     return func(*args, **kwargs)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/base.py", line 219, in ensure_connection
web_1             |     self.connect()
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/utils.py", line 90, in __exit__
web_1             |     raise dj_exc_value.with_traceback(traceback) from exc_value
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/base.py", line 219, in ensure_connection
web_1             |     self.connect()
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
web_1             |     return func(*args, **kwargs)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/base.py", line 200, in connect
web_1             |     self.connection = self.get_new_connection(conn_params)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
web_1             |     return func(*args, **kwargs)
web_1             |   File "/usr/local/lib/python3.9/site-packages/django/db/backends/postgresql/base.py", line 187, in get_new_connection
web_1             |     connection = Database.connect(**conn_params)
web_1             |   File "/usr/local/lib/python3.9/site-packages/psycopg2/__init__.py", line 126, in connect
web_1             |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
web_1             | django.db.utils.OperationalError: FATAL:  sorry, too many clients already
web_1             | 
web_1             | "GET /user/hudson/review/11 HTTP/1.0" 200 997
```