### PR TITLE
docker: move initial setup into docker startup to simplify deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,7 @@ RUN apt-get update && apt-get install -y gettext libgettextpo-dev tidy && apt-ge
 
 COPY requirements.txt /app/
 RUN pip install -r requirements.txt --no-cache-dir
+ADD . /app
+
+
+ENTRYPOINT [ "/app/bookwyrm/setup.sh" ]

--- a/bookwyrm/setup.sh
+++ b/bookwyrm/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Perform initial setup so that the users don't have to
+# This should only be done in the web container;
+# the celery and flower containers should wait for the canary to exist
+
+CANARY=/app/static/.dbinit_done
+
+info() { echo >&2 "$*" ; }
+die() { echo >&2 "$*" ; exit 1 ; }
+
+if [ "$1" == "exit" ]; then
+	info "**** base container exiting"
+	exit 0
+fi
+
+if [ -z "$DB_INIT" ]; then
+	while [ ! -r "$CANARY" ]; do
+		info "**** Waiting for database and migrations to finish"
+		sleep 10
+	done
+elif [ ! -r "$CANARY" ]; then
+	info "**** Doing initial setup!"
+	python manage.py migrate || die "failed to migrate"
+	python manage.py migrate django_celery_beat || die "failed to migrate django"
+	python manage.py initdb || die "failed to initdb"
+	python manage.py collectstatic --no-input || die "failed to collect static"
+        python manage.py admin_code
+
+	info "**** Done with initial setup!"
+	touch "$CANARY"
+fi
+
+exec bash -c "$*"


### PR DESCRIPTION
This patch makes it easier to perform non-development installations with `docker-compose` by performing the initial setup in the `web` container on first startup (while the `celery` and `flower` containers wait for it to complete).

The production `docker-compose.yml` also needs an update to pull from an official image (I'm testing it with my OIDC patches in #2464 here):
```
version: '3'

services:
  nginx:
    image: nginx:latest
    restart: unless-stopped
    ports:
      - "1333:80"
    depends_on:
      - web
    networks:
      - main
    volumes:
      - ./nginx:/etc/nginx/conf.d:ro
      - ./data/static_volume:/app/static:ro
      - ./data/media_volume:/app/images:ro
      - ./data/cache:/cache

  db:
    image: postgres
    env_file: .env
    volumes:
      - ./data/pgdata:/var/lib/postgresql/data
    networks:
      - main

  redis_activity:
    image: redis
    command: redis-server --requirepass ${REDIS_ACTIVITY_PASSWORD} --appendonly yes --port ${REDIS_ACTIVITY_PORT}
    volumes:
      - ./redis.conf:/etc/redis/redis.conf
      - ./data/redis_activity_data:/data
    env_file: .env
    networks:
      - main
    restart: on-failure

  redis_broker:
    image: redis
    command: redis-server --requirepass ${REDIS_BROKER_PASSWORD} --appendonly yes --port ${REDIS_BROKER_PORT}
    volumes:
      - ./redis.conf:/etc/redis/redis.conf
      - ./data/redis_broker_data:/data
    env_file: .env
    networks:
      - main
    restart: on-failure

  web:
    image: osresearch/bookwyrm:oidc
    command: python manage.py runserver 0.0.0.0:8000
    env_file: .env
    volumes:
      - ./data/static_volume:/app/static
      - ./data/media_volume:/app/images
    environment:
      - DB_INIT=True
    depends_on:
      - db
      - celery_worker
      - redis_activity
    networks:
      - main
    ports:
      - "8000"

  celery_worker:
    image: osresearch/bookwyrm:oidc
    command: celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority
    env_file: .env
    volumes:
      - ./data/static_volume:/app/static
      - ./data/media_volume:/app/images
    depends_on:
      - db
      - redis_broker
    restart: on-failure
    networks:
      - main

  celery_beat:
    image: osresearch/bookwyrm:oidc
    command: celery -A celerywyrm beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
    env_file: .env
    volumes:
      - ./data/static_volume:/app/static
      - ./data/media_volume:/app/images
    depends_on:
      - celery_worker
    restart: on-failure
    networks:
      - main

  flower:
    image: osresearch/bookwyrm:oidc
    command: celery -A celerywyrm flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD}
    env_file: .env
    ports:
      - ${FLOWER_PORT}:${FLOWER_PORT}
    volumes:
      - ./data/static_volume:/app/static
      - ./data/media_volume:/app/images
    depends_on:
      - db
      - redis_broker
    restart: on-failure
    networks:
      - main

  dev-tools:
    build: dev-tools
    env_file: .env
    volumes:
      - .:/app

networks:
  main:
```