### PR TITLE
Visually separate authors when creating book

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -25,7 +25,7 @@
 <div class="block" itemscope itemtype="https://schema.org/Book">
     <div class="columns is-mobile">
         <div class="column">
-            <h1 class="title" itemprop="name">
+            <h1 class="title" itemprop="name" dir="auto">
                 {{ book.title }}
             </h1>
 
@@ -37,7 +37,7 @@
                             content="{{ book.subtitle | escape }}"
                         >
 
-                        <span class="has-text-weight-bold">
+                        <span class="has-text-weight-bold" dir="auto">
                             {{ book.subtitle }}
                         </span>
                     {% endif %}
@@ -52,7 +52,7 @@
             {% endif %}
 
             {% if book.authors.exists %}
-                <div class="subtitle">
+                <div class="subtitle" dir="auto">
                     {% trans "by" %} {% include 'snippets/authors.html' with book=book %}
                 </div>
             {% endif %}

--- a/bookwyrm/templates/book/edit/edit_book.html
+++ b/bookwyrm/templates/book/edit/edit_book.html
@@ -98,7 +98,9 @@
                         </label>
                         {% endwith %}
                     </fieldset>
+                    {% if not forloop.last %}
                     <hr aria-hidden="true">
+                    {% endif %}
                     {% endfor %}
                 </div>
                 {% else %}

--- a/bookwyrm/templates/book/edit/edit_book.html
+++ b/bookwyrm/templates/book/edit/edit_book.html
@@ -65,17 +65,17 @@
                 <input type="hidden" name="author-match-count" value="{{ author_matches|length }}">
                 <div class="column is-half">
                     {% for author in author_matches %}
-                    <fieldset>
+                    <fieldset class="block">
                         <legend class="title is-5 mb-1">
                             {% blocktrans with name=author.name %}Is "{{ name }}" one of these authors?{% endblocktrans %}
                         </legend>
                         {% with forloop.counter0 as counter %}
                         {% for match in author.matches %}
-                        <label class="label">
+                        <label class="label mb-0">
                             <input type="radio" name="author_match-{{ counter }}" value="{{ match.id }}" required>
                             {{ match.name }}
                         </label>
-                        <p class="help ml-5 mb-2">
+                        <p class="help ml-5 mb-0 mt-0">
                             {% with book_title=match.book_set.first.title alt_title=match.bio %}
                             {% if book_title %}
                                 <a href="{{ match.local_path }}" target="_blank" rel="nofollow noopener noreferrer">{% blocktrans trimmed %}
@@ -98,6 +98,7 @@
                         </label>
                         {% endwith %}
                     </fieldset>
+                    <hr aria-hidden="true">
                     {% endfor %}
                 </div>
                 {% else %}


### PR DESCRIPTION
Before:
<img width="466" alt="Screen Shot 2022-12-05 at 5 38 02 PM" src="https://user-images.githubusercontent.com/1807695/205788098-7d918c8e-9c5b-406c-9998-3fea967a313e.png">

After:
<img width="473" alt="Screen Shot 2022-12-05 at 5 43 39 PM" src="https://user-images.githubusercontent.com/1807695/205788114-553da261-3291-479c-9222-0307eede1e51.png">

Fixes #2454 