### PR TITLE
goodreads_key for books editable

### DIFF
--- a/bookwyrm/forms/books.py
+++ b/bookwyrm/forms/books.py
@@ -73,6 +73,9 @@ class EditionForm(CustomForm):
             "inventaire_id": forms.TextInput(
                 attrs={"aria-describedby": "desc_inventaire_id"}
             ),
+            "goodreads_key": forms.TextInput(
+                attrs={"aria-describedby": "desc_goodreads_key"}
+            ),
             "oclc_number": forms.TextInput(
                 attrs={"aria-describedby": "desc_oclc_number"}
             ),

--- a/bookwyrm/templates/book/book_identifiers.html
+++ b/bookwyrm/templates/book/book_identifiers.html
@@ -23,6 +23,12 @@
             <dd>{{ book.asin }}</dd>
         </div>
     {% endif %}
+    {% if book.goodreads_key %}
+        <div class="is-flex">
+            <dt class="mr-1">{% trans "Goodreads:" %}</dt>
+            <dd>{{ book.goodreads_key }}</dd>
+        </div>
+    {% endif %}
 </dl>
 {% endif %}
 {% endspaceless %}

--- a/bookwyrm/templates/book/edit/edit_book_form.html
+++ b/bookwyrm/templates/book/edit/edit_book_form.html
@@ -328,6 +328,15 @@
                 </div>
 
                 <div class="field">
+                    <label class="label" for="id_goodreads_key">
+                        {% trans "Goodreads key:" %}
+                    </label>
+                    {{ form.goodreads_key }}
+
+                    {% include 'snippets/form_errors.html' with errors_list=form.goodreads_key.errors id="desc_goodreads_key" %}
+                </div>
+
+                <div class="field">
                     <label class="label" for="id_oclc_number">
                         {% trans "OCLC Number:" %}
                     </label>


### PR DESCRIPTION
The field goodreads_key is now editable.
ID is shown in ID section of book:

<img width="238" alt="Bildschirm­foto 2022-12-10 um 10 49 07" src="https://user-images.githubusercontent.com/2017105/206846827-924e3f38-cd97-460f-aea6-4677ce43361e.png">

This solves #2487 