### PR TITLE
Add apple-touch-icon to global layout

### DIFF
--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -13,6 +13,7 @@
     <link rel="search" type="application/opensearchdescription+xml" href="{% url 'opensearch' %}" title="{% blocktrans with site_name=site.name %}{{ site_name }} search{% endblocktrans %}" />
 
     <link rel="shortcut icon" type="image/x-icon" href="{% if site.favicon %}{% get_media_prefix %}{{ site.favicon }}{% else %}{% static "images/favicon.ico" %}{% endif %}">
+    <link rel="apple-touch-icon" href="{% if site.logo %}{{ media_full_url }}{{ site.logo }}{% else %}{% static "images/logo.png" %}{% endif %}">
 
     {% if preview_images_enabled is True %}
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Fixes #2084

Adding the `apple-touch-icon` to the `head` of the global layout. Taking the biggest available logo, iOS should be able to downsample the image. Looking at the default logo, it could maybe get a bit more of a white border so that it looks less cramped as the touch icon.

With the default logo:
![IMG_0907](https://user-images.githubusercontent.com/112063/206866680-48701d72-0c44-4a31-8f33-ab43a62fed4d.png)


With a custom logo:
![IMG_0906](https://user-images.githubusercontent.com/112063/206866441-0c1814e5-c3d8-4ba3-8da7-4092db297e05.png)
