### PR TITLE
Detect preferred timezone via JavaScript on register

### DIFF
--- a/bookwyrm/static/js/bookwyrm.js
+++ b/bookwyrm/static/js/bookwyrm.js
@@ -48,6 +48,12 @@ let BookWyrm = new (class {
         document
             .querySelector("#barcode-scanner-modal")
             .addEventListener("open", this.openBarcodeScanner.bind(this));
+
+        document
+            .querySelectorAll('form[name="register"]')
+            .forEach((form) =>
+                form.addEventListener("submit", (e) => this.setPreferredTimezone(e, form))
+            );
     }
 
     /**
@@ -784,5 +790,17 @@ let BookWyrm = new (class {
         event.target.addEventListener("close", cleanup, { once: true });
 
         initBarcodes();
+    }
+
+    /**
+     * Set preferred timezone in register form.
+     *
+     * @param  {Event} event - `submit` event fired by the register form.
+     * @return {undefined}
+     */
+    setPreferredTimezone(event, form) {
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        form.querySelector('input[name="preferred_timezone"]').value = tz;
     }
 })();

--- a/bookwyrm/templates/snippets/register_form.html
+++ b/bookwyrm/templates/snippets/register_form.html
@@ -58,6 +58,8 @@
     </div>
 </div>
 
+<input type="hidden" name="preferred_timezone" />
+
 <div class="field">
     <div class="control">
         <button class="button is-primary" type="submit">

--- a/bookwyrm/tests/views/landing/test_register.py
+++ b/bookwyrm/tests/views/landing/test_register.py
@@ -58,6 +58,7 @@ class RegisterViews(TestCase):
                 "localname": "nutria-user.user_nutria",
                 "password": "mouseword",
                 "email": "aa@bb.cccc",
+                "preferred_timezone": "Europe/Berlin",
             },
         )
         with patch("bookwyrm.views.landing.register.login"):
@@ -68,6 +69,7 @@ class RegisterViews(TestCase):
         self.assertEqual(nutria.username, f"nutria-user.user_nutria@{DOMAIN}")
         self.assertEqual(nutria.localname, "nutria-user.user_nutria")
         self.assertEqual(nutria.local, True)
+        self.assertEqual(nutria.preferred_timezone, "Europe/Berlin")
 
     @patch("bookwyrm.emailing.send_email.delay")
     def test_register_email_confirm(self, *_):
@@ -197,6 +199,58 @@ class RegisterViews(TestCase):
         response = view(request)
         self.assertEqual(models.User.objects.count(), 1)
         validate_html(response.render())
+
+    def test_register_default_preferred_timezone(self, *_):
+        """invalid preferred timezone strings should just default to UTC"""
+        view = views.Register.as_view()
+        self.assertEqual(models.User.objects.count(), 1)
+
+        request = self.factory.post(
+            "register/",
+            {
+                "localname": "nutria1",
+                "password": "mouseword",
+                "email": "aa1@bb.cccc",
+                "preferred_timezone": "invalid-tz",
+            },
+        )
+        with patch("bookwyrm.views.landing.register.login"):
+            response = view(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.User.objects.count(), 2)
+        nutria = models.User.objects.last()
+        self.assertEqual(nutria.preferred_timezone, "UTC")
+
+        request = self.factory.post(
+            "register/",
+            {
+                "localname": "nutria2",
+                "password": "mouseword",
+                "email": "aa2@bb.cccc",
+                "preferred_timezone": "",
+            },
+        )
+        with patch("bookwyrm.views.landing.register.login"):
+            response = view(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.User.objects.count(), 3)
+        nutria = models.User.objects.last()
+        self.assertEqual(nutria.preferred_timezone, "UTC")
+
+        request = self.factory.post(
+            "register/",
+            {
+                "localname": "nutria3",
+                "password": "mouseword",
+                "email": "aa3@bb.cccc",
+            },
+        )
+        with patch("bookwyrm.views.landing.register.login"):
+            response = view(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(models.User.objects.count(), 4)
+        nutria = models.User.objects.last()
+        self.assertEqual(nutria.preferred_timezone, "UTC")
 
     def test_register_closed_instance(self, *_):
         """you can't just register"""

--- a/bookwyrm/views/landing/register.py
+++ b/bookwyrm/views/landing/register.py
@@ -1,4 +1,5 @@
 """ class views for login/register views """
+import pytz
 from django.contrib.auth import login
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
@@ -55,6 +56,10 @@ class Register(View):
         localname = form.data["localname"].strip()
         email = form.data["email"]
         password = form.data["password"]
+        try:
+            preferred_timezone = pytz.timezone(form.data.get("preferred_timezone"))
+        except pytz.exceptions.UnknownTimeZoneError:
+            preferred_timezone = pytz.utc
 
         # make sure the email isn't blocked as spam
         email_domain = email.split("@")[-1]
@@ -71,6 +76,7 @@ class Register(View):
             local=True,
             deactivation_reason="pending" if settings.require_confirm_email else None,
             is_active=not settings.require_confirm_email,
+            preferred_timezone=preferred_timezone,
         )
         if invite:
             invite.times_used += 1


### PR DESCRIPTION
Fixes #2024

One solution for detecting and setting the user's `preferred_timezone`. Given browser don't send that information via headers, next best thing seems to be to use JavaScript's `Intl.DateTimeFormat()` API.
In case the browser sends rubbish data, the server side defaults to UTC.