### PR TITLE
Add eslint subcommand to bw-dev

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -174,6 +174,10 @@ case "$CMD" in
         prod_error
         docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
         ;;
+    eslint)
+        prod_error
+        docker-compose run --rm dev-tools npx eslint bookwyrm/static --ext .js
+        ;;
     stylelint)
         prod_error
         docker-compose run --rm dev-tools npx stylelint \
@@ -185,6 +189,7 @@ case "$CMD" in
         runweb pylint bookwyrm/
         docker-compose run --rm dev-tools black celerywyrm bookwyrm
         docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
+        docker-compose run --rm dev-tools npx eslint bookwyrm/static --ext .js
         docker-compose run --rm dev-tools npx stylelint \
             bookwyrm/static/css/bookwyrm.scss bookwyrm/static/css/bookwyrm/**/*.scss --fix \
             --config dev-tools/.stylelintrc.js
@@ -283,6 +288,7 @@ case "$CMD" in
         echo "    clean"
         echo "    black"
         echo "    prettier"
+        echo "    eslint"
         echo "    stylelint"
         echo "    formatters"
         echo "    collectstatic_watch"

--- a/complete_bwdev.fish
+++ b/complete_bwdev.fish
@@ -22,6 +22,7 @@ build \
 clean \
 black \
 prettier \
+eslint \
 stylelint \
 formatters \
 collectstatic_watch \
@@ -59,6 +60,7 @@ __bw_complete "$commands" "build"                   "build the containers"
 __bw_complete "$commands" "clean"                   "bring the cluster down and remove all containers"
 __bw_complete "$commands" "black"                   "run Python code formatting tool"
 __bw_complete "$commands" "prettier"                "run JavaScript code formatting tool"
+__bw_complete "$commands" "eslint"                  "run JavaScript linting tool"
 __bw_complete "$commands" "stylelint"               "run SCSS linting tool"
 __bw_complete "$commands" "formatters"              "run multiple formatter tools"
 __bw_complete "$commands" "populate_streams"        "populate the main streams"

--- a/complete_bwdev.sh
+++ b/complete_bwdev.sh
@@ -19,6 +19,7 @@ build
 clean
 black
 prettier
+eslint
 stylelint
 formatters
 collectstatic_watch

--- a/complete_bwdev.zsh
+++ b/complete_bwdev.zsh
@@ -21,6 +21,7 @@ build
 clean
 black
 prettier
+eslint
 stylelint
 formatters
 collectstatic_watch


### PR DESCRIPTION
I noticed when working on #2491 that `./bw-dev` doesn't have an easy way to run `eslint` even though there's a CI job that runs it.

This adds an `eslint` subcommand for running this locally.