### PR TITLE
delete avatar when user is deleted

### DIFF
--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -373,6 +373,7 @@ class User(OrderedCollectionPageMixin, AbstractUser):
         """We don't actually delete the database entry"""
         # pylint: disable=attribute-defined-outside-init
         self.is_active = False
+        self.avatar = ""
         # skip the logic in this class's save()
         super().save(*args, **kwargs)
 

--- a/bookwyrm/templates/settings/users/delete_user_form.html
+++ b/bookwyrm/templates/settings/users/delete_user_form.html
@@ -10,7 +10,7 @@
     {% csrf_token %}
     <p>
         {% blocktrans trimmed with username=user.localname %}
-        Are you sure you want to delete <strong>{{ username}}</strong>'s account? This action cannot be undone. To proceed, please enter your password to confirm deletion.
+        Are you sure you want to delete <strong>{{username}}</strong>'s account? This action cannot be undone. To proceed, please enter your password to confirm deletion.
         {% endblocktrans %}
     </p>
     <div class="field">


### PR DESCRIPTION
To comply with GDPR, as always.