### PR TITLE
Don't add imported reviews to timelines

### DIFF
--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -318,6 +318,10 @@ def add_status_on_create_command(sender, instance, created):
     if instance.published_date < timezone.now() - timedelta(
         days=1
     ) or instance.created_date < instance.published_date - timedelta(days=1):
+        # a backdated status from a local user is an import, don't add it
+        if instance.user.local:
+            return
+        # an out of date remote status is a low priority but should be added
         priority = LOW
 
     add_status_task.apply_async(

--- a/bookwyrm/tests/views/inbox/test_inbox_create.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_create.py
@@ -63,7 +63,7 @@ class TransactionInboxCreate(TransactionTestCase):
 
         with patch("bookwyrm.activitystreams.add_status_task.apply_async") as mock:
             views.inbox.activity_task(activity)
-        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(mock.call_count, 0)
 
 
 @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")


### PR DESCRIPTION
Generally they're so backdated that they don't add meaningfully to the timelines, and they put too much load on the instance. They are still visible on the book pages.