### PR TITLE
Disable sass processer when not in debug mode

### DIFF
--- a/bookwyrm/management/commands/compile_themes.py
+++ b/bookwyrm/management/commands/compile_themes.py
@@ -1,0 +1,48 @@
+""" Our own command to all scss themes """
+import glob
+import os
+
+import sass
+
+from django.core.management.base import BaseCommand
+
+from sass_processor.apps import APPS_INCLUDE_DIRS
+from sass_processor.processor import SassProcessor
+from sass_processor.utils import get_custom_functions
+
+from bookwyrm import settings
+
+
+class Command(BaseCommand):
+    """command-line options"""
+
+    help = "SCSS compile all BookWyrm themes"
+
+    # pylint: disable=unused-argument
+    def handle(self, *args, **options):
+        """compile"""
+        themes_dir = os.path.join(
+            settings.BASE_DIR, "bookwyrm", "static", "css", "themes", "*.scss"
+        )
+        for theme_scss in glob.glob(themes_dir):
+            basename, _ = os.path.splitext(theme_scss)
+            theme_css = f"{basename}.css"
+            self.compile_sass(theme_scss, theme_css)
+
+    def compile_sass(self, sass_path, css_path):
+        compile_kwargs = {
+            "filename": sass_path,
+            "include_paths": SassProcessor.include_paths + APPS_INCLUDE_DIRS,
+            "custom_functions": get_custom_functions(),
+            "precision": getattr(settings, "SASS_PRECISION", 8),
+            "output_style": getattr(
+                settings,
+                "SASS_OUTPUT_STYLE",
+                "nested" if settings.DEBUG else "compressed",
+            ),
+        }
+
+        content = sass.compile(**compile_kwargs)
+        with open(css_path, "w") as f:
+            f.write(content)
+        self.stdout.write("Compiled SASS/SCSS file: '{0}'\n".format(sass_path))

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -193,7 +193,8 @@ STATICFILES_FINDERS = [
 ]
 
 SASS_PROCESSOR_INCLUDE_FILE_PATTERN = r"^.+\.[s]{0,1}(?:a|c)ss$"
-SASS_PROCESSOR_ENABLED = True
+# when debug is disabled, make sure to compile themes once with `./bw-dev compile_themes`
+SASS_PROCESSOR_ENABLED = DEBUG
 
 # minify css is production but not dev
 if not DEBUG:

--- a/bookwyrm/templates/settings/themes.html
+++ b/bookwyrm/templates/settings/themes.html
@@ -29,7 +29,7 @@
                 {% trans "Copy the theme file into the <code>bookwyrm/static/css/themes</code> directory on your server from the command line." %}
             </li>
             <li>
-                {% trans "Run <code>./bw-dev collectstatic</code>." %}
+                {% trans "Run <code>./bw-dev compile_themes</code> and <code>./bw-dev collectstatic</code>." %}
             </li>
             <li>
                 {% trans "Add the file name using the form below to make it available in the application interface." %}

--- a/bw-dev
+++ b/bw-dev
@@ -92,6 +92,7 @@ case "$CMD" in
         migrate
         migrate django_celery_beat
         initdb
+        runweb python manage.py compile_themes
         runweb python manage.py collectstatic --no-input
         admin_code
         ;;
@@ -121,6 +122,9 @@ case "$CMD" in
     pytest_coverage_report)
         prod_error
         runweb pytest -n 3 --cov-report term-missing "$@"
+        ;;
+    compile_themes)
+        runweb python manage.py compile_themes
         ;;
     collectstatic)
         runweb python manage.py collectstatic --no-input
@@ -203,6 +207,7 @@ case "$CMD" in
         docker-compose build
         # ./update.sh
         runweb python manage.py migrate
+        runweb python manage.py compile_themes
         runweb python manage.py collectstatic --no-input
         docker-compose up -d
         docker-compose restart web
@@ -256,6 +261,7 @@ case "$CMD" in
         migrate
         migrate django_celery_beat
         initdb
+        runweb python manage.py compile_themes
         runweb python manage.py collectstatic --no-input
         admin_code
         ;;
@@ -283,6 +289,7 @@ case "$CMD" in
         echo "    dbshell"
         echo "    restart_celery"
         echo "    pytest [path]"
+        echo "    compile_themes"
         echo "    collectstatic"
         echo "    makemessages"
         echo "    compilemessages [locale]"

--- a/complete_bwdev.fish
+++ b/complete_bwdev.fish
@@ -14,6 +14,7 @@ dbshell \
 restart_celery \
 pytest \
 pytest_coverage_report \
+compile_themes \
 collectstatic \
 makemessages \
 compilemessages \
@@ -54,6 +55,7 @@ __bw_complete "$commands" "shell"                   "open the Python shell withi
 __bw_complete "$commands" "dbshell"                 "open the database shell within the web container"
 __bw_complete "$commands" "restart_celery"          "restart the celery container"
 __bw_complete "$commands" "pytest"                  "run unit tests"
+__bw_complete "$commands" "compile_themes"          "compile themes css files"
 __bw_complete "$commands" "collectstatic"           "copy changed static files into the installation"
 __bw_complete "$commands" "makemessages"            "extract all localizable messages from the code"
 __bw_complete "$commands" "compilemessages"         "compile .po localization files to .mo"

--- a/complete_bwdev.sh
+++ b/complete_bwdev.sh
@@ -11,6 +11,7 @@ dbshell
 restart_celery
 pytest
 pytest_coverage_report
+compile_themes
 collectstatic
 makemessages
 compilemessages

--- a/complete_bwdev.zsh
+++ b/complete_bwdev.zsh
@@ -13,6 +13,7 @@ dbshell
 restart_celery
 pytest
 pytest_coverage_report
+compile_themes
 collectstatic
 makemessages
 compilemessages


### PR DESCRIPTION
As mentioned on the Matrix chat:
> I think the way django-sass-processor is currently configured means that every time an HTML layout is rendered, the sass processor does some work which in part results in it connecting to the static storage (in my case CloudFlare's R2, an S3-compatible storage service). Judging from an application monitoring software I'm running to try and find some performance issues, this adds a good 400ms on average to each request.
> 
> Now, I can turn this off by making the SASS_PROCESSOR_ENABLED configurable and I see those external requests Python makes to R2 disappear when turning that off.
However, the CSS files still need to be compiled (collectstatic doesn't do that), and the command it comes with (python manage.py compilescss) unfortunately fails to compile any file due to errors parsing all the the template files.
> 
> Just wanted to make sure I'm not missing something else, because my instance felt super fast after turning off the scss processing that happens on each request! I had the compiled files already stored, so it loaded alright on the client side.

This adds a new managment command `compile_themes` which lists all files in `bookwyrm/static/css/themes` and compiles them. This command should be run right before `collectstatic` is run when in a production environment.

The docs changes are in bookwyrm-social/documentation#87

TODO:
* [x] Changes to the documentation repo