### PR TITLE
Fix titleby cache fragment clearing

### DIFF
--- a/bookwyrm/models/author.py
+++ b/bookwyrm/models/author.py
@@ -1,8 +1,6 @@
 """ database schema for info about authors """
 import re
 from django.contrib.postgres.indexes import GinIndex
-from django.core.cache import cache
-from django.core.cache.utils import make_template_fragment_key
 from django.db import models
 
 from bookwyrm import activitypub
@@ -37,16 +35,7 @@ class Author(BookDataModel):
     bio = fields.HtmlField(null=True, blank=True)
 
     def save(self, *args, **kwargs):
-        """clear related template caches"""
-        # clear template caches
-        if self.id:
-            cache_keys = [
-                make_template_fragment_key("titleby", [book])
-                for book in self.book_set.values_list("id", flat=True)
-            ]
-            cache.delete_many(cache_keys)
-
-        # normalize isni format
+        """normalize isni format"""
         if self.isni:
             self.isni = re.sub(r"\s", "", self.isni)
 

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -4,7 +4,6 @@ import re
 from django.contrib.postgres.search import SearchVectorField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.cache import cache
-from django.core.cache.utils import make_template_fragment_key
 from django.db import models, transaction
 from django.db.models import Prefetch
 from django.dispatch import receiver
@@ -207,10 +206,6 @@ class Book(BookDataModel):
         """can't be abstract for query reasons, but you shouldn't USE it"""
         if not isinstance(self, Edition) and not isinstance(self, Work):
             raise ValueError("Books should be added as Editions or Works")
-
-        # clear template caches
-        cache_key = make_template_fragment_key("titleby", [self.id])
-        cache.delete(cache_key)
 
         return super().save(*args, **kwargs)
 

--- a/bookwyrm/templates/snippets/book_titleby.html
+++ b/bookwyrm/templates/snippets/book_titleby.html
@@ -5,7 +5,7 @@
 
 {% get_current_language as LANGUAGE_CODE %}
 {# 6 month cache #}
-{% cache 15552000 titleby LANGUAGE_CODE book.id %}
+{% cache 10 titleby LANGUAGE_CODE book.id %}
 
 {% if book.authors.exists %}
 {% blocktrans trimmed with path=book.local_path title=book|book_title %}


### PR DESCRIPTION
The cache key in the snippet uses the language code: https://github.com/bookwyrm-social/bookwyrm/blob/5ea922a551e3e8173d3c91b40954d08208b7c3b4/bookwyrm/templates/snippets/book_titleby.html#L8

I'm guessing we should just clear all languages caches when updating a book or an author.