### PR TITLE
Fix permissions check for System admin navigation section

### DIFF
--- a/bookwyrm/templates/settings/layout.html
+++ b/bookwyrm/templates/settings/layout.html
@@ -74,7 +74,7 @@
             </li>
         </ul>
         {% endif %}
-        {% if perms.edit_instance_settings %}
+        {% if perms.bookwyrm.edit_instance_settings %}
         <h2 class="menu-label">{% trans "System" %}</h2>
         <ul class="menu-list">
             <li>


### PR DESCRIPTION
I recently realised that only my very first admin account was able to see the "System" navigation section in the admin interface. When I promoted another user to either Admin or Owner. Both of those groups should have the `edit_instance_settings` permission according to the `initdb` command [here](https://github.com/bookwyrm-social/bookwyrm/blob/5ea922a551e3e8173d3c91b40954d08208b7c3b4/bookwyrm/management/commands/initdb.py#L29-L33).

Looking at "Instance Settings" section I'm assuming the issue is that it was using `perms.edit_instance_settings` instead of `perms.bookwyrm.edit_instance_settings`.

This is the navigation section I meant:
<img width="205" alt="image" src="https://user-images.githubusercontent.com/112063/208772552-15e1dbcf-5fee-44b0-a677-7b2e67c1466a.png">
