### PR TITLE
User menu mobile align right

### DIFF
--- a/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
+++ b/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
@@ -1,3 +1,7 @@
+.summary-on-open {
+    display: none;
+}
+
 @media only screen and (max-width: 768px) {
     .navbar-menu {
         text-align: right;
@@ -5,6 +9,38 @@
 
         .tags {
             justify-content: flex-end;
+        }
+
+        #navbar-dropdown {
+            &[open] {
+                .summary-on-open {
+                    display: initial;
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    right: 0;
+                    height: 3rem;
+                    z-index: 31;
+                    background-color: $dropdown-content-background-color;
+                    padding: 1rem 1.75rem;
+                    line-height: 1;
+                }
+            }
+            .dropdown-menu {
+                padding-top: 0;
+                top: 3rem;
+            }
+            .dropdown-content {
+                padding-top: 0;
+                box-shadow: none;
+                border-top-left-radius: 0;
+                border-top-right-radius: 0;
+            }
+            .navbar-item {
+                    // see ../components/_details.scss :: Navbar details
+                    padding-right: 1.75rem;
+                    font-size: 1rem;
+            }
         }
     }
 }

--- a/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
+++ b/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
@@ -26,20 +26,23 @@
                     line-height: 1;
                 }
             }
+
             .dropdown-menu {
                 padding-top: 0;
                 top: 3rem;
             }
+
             .dropdown-content {
                 padding-top: 0;
                 box-shadow: none;
                 border-top-left-radius: 0;
                 border-top-right-radius: 0;
             }
+
             .navbar-item {
-                    // see ../components/_details.scss :: Navbar details
-                    padding-right: 1.75rem;
-                    font-size: 1rem;
+                // see ../components/_details.scss :: Navbar details
+                padding-right: 1.75rem;
+                font-size: 1rem;
             }
         }
     }

--- a/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
+++ b/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
@@ -1,3 +1,14 @@
+@media only screen and (max-width: 768px) {
+    .navbar-menu {
+        text-align: right;
+        padding-right: 1rem;
+
+        .tags {
+            justify-content: flex-end;
+        }
+    }
+}
+
 .image {
     overflow: hidden;
 }

--- a/bookwyrm/templates/user_menu.html
+++ b/bookwyrm/templates/user_menu.html
@@ -13,6 +13,10 @@
             <span class="ml-2">{{ request.user.display_name }}</span>
         </span>
         <span class="icon icon-arrow-down is-hidden-mobile" aria-hidden="true"></span>
+        <span class="summary-on-open">
+            <span class="icon icon-arrow-left is-small" aria-hidden="true"></span>
+            {% trans "Back" %}
+        </span>
     </summary>
 
     <div class="dropdown-menu">


### PR DESCRIPTION
This PR:

- Aligns all texts and icons to the right (closes #2209)
- Adds a "Back" button at the top of the submenu
  (This implies a few overrides of Bulma, but especially of `bookwyrm/components/_details.scss`. More work will be needed in the future to untangle the navbar user menu from the regular dropdown menu)


<details>
<summary>Screenshots</summary>
<img alt="Capture d’écran 2022-12-23 à 20 13 07" src="https://user-images.githubusercontent.com/1781070/209396712-0fd349f1-0198-420f-8ae3-2e0f72699fed.png" width="320"/>
<img alt="Capture d’écran 2022-12-23 à 20 15 33" src="https://user-images.githubusercontent.com/1781070/209396714-0aa5df22-dc1e-4752-af36-a08f25cfc6ba.png" width="320"/>
</details>

