### PR TITLE
Ensure django tests pass in default Docker setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ SEARCH_TIMEOUT=5
 QUERY_TIMEOUT=5
 
 # Thumbnails Generation
-ENABLE_THUMBNAIL_GENERATION=false
+ENABLE_THUMBNAIL_GENERATION=true
 
 # S3 configuration
 USE_S3=false

--- a/bookwyrm/tests/models/test_book_model.py
+++ b/bookwyrm/tests/models/test_book_model.py
@@ -2,6 +2,8 @@
 from io import BytesIO
 import pathlib
 
+import pytest
+
 from dateutil.parser import parse
 from PIL import Image
 from django.core.files.base import ContentFile
@@ -10,7 +12,7 @@ from django.utils import timezone
 
 from bookwyrm import models, settings
 from bookwyrm.models.book import isbn_10_to_13, isbn_13_to_10
-
+from bookwyrm.settings import ENABLE_THUMBNAIL_GENERATION
 
 class Book(TestCase):
     """not too much going on in the books model but here we are"""
@@ -101,6 +103,10 @@ class Book(TestCase):
         self.first_edition.save()
         self.assertEqual(self.first_edition.edition_rank, 1)
 
+    @pytest.mark.skipif(
+        not ENABLE_THUMBNAIL_GENERATION,
+        reason="Thumbnail generation disabled in settings"
+    )
     def test_thumbnail_fields(self):
         """Just hit them"""
         image_file = pathlib.Path(__file__).parent.joinpath(

--- a/bookwyrm/tests/models/test_book_model.py
+++ b/bookwyrm/tests/models/test_book_model.py
@@ -14,6 +14,7 @@ from bookwyrm import models, settings
 from bookwyrm.models.book import isbn_10_to_13, isbn_13_to_10
 from bookwyrm.settings import ENABLE_THUMBNAIL_GENERATION
 
+
 class Book(TestCase):
     """not too much going on in the books model but here we are"""
 
@@ -105,7 +106,7 @@ class Book(TestCase):
 
     @pytest.mark.skipif(
         not ENABLE_THUMBNAIL_GENERATION,
-        reason="Thumbnail generation disabled in settings"
+        reason="Thumbnail generation disabled in settings",
     )
     def test_thumbnail_fields(self):
         """Just hit them"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - static_volume:/app/static
       - media_volume:/app/images
   db:
-    image: postgres
+    image: postgres:13
     env_file: .env
     volumes:
       - pgdata:/var/lib/postgresql/data


### PR DESCRIPTION
When running tests using `./bw-dev pytest` (nice script!), I encountered a few failures. This PR has some simple proposals to fix them, and make the docker tests run more similar to the `django-tests` GitHub action workflow.

First, the test `test_thumbnail_fields` will only pass if `ENABLE_THUMBNAIL_GENERATION` is set to true. However, in the `.env.example` it is set to false. Here are two fixes:

1. Set `ENABLE_THUMBNAIL_GENERATION` to true in `.env.example`
2. Skip `test_thumbnail_fields` unless `ENABLE_THUMBNAIL_GENERATION` is set to true.

Furthermore, the `docker-compose.yml` configuration uses `postgres` without version number. But some tests require postgres:13 or up. So I added this version tag (as it is in `.github/workflows/django-tests.yml`).

(Just using `postgres`  = `postgres:latest` resolved to a postgres:11 image I downloaded long ago when it actually was the latest).

Feel free to cherry-pick selected commits if you prefer not to adopt all changes.

An alternative could also be to bump to postgres 15 in both GitHub actions and Docker compose, but that is a different decision.