### PR TITLE
Support custom pg user/db names in DB backup script

### DIFF
--- a/postgres-docker/Dockerfile
+++ b/postgres-docker/Dockerfile
@@ -15,6 +15,6 @@ RUN touch /var/log/cron.log
 # We need to start the cron service the first time it runs, when it's still being run
 # as the root user. We're going to add a check that looks at the first argument and
 # if it's 'cron', starts the service and then removes that argument.
-RUN awk '$0 ~ /^\t_main "\$@"$/ { print "\tif [[ $1 == cron ]]; then\n\t\tservice cron start\n\t\tshift\n\tfi" }{ print }' docker-entrypoint.sh > bookwyrm-entrypoint.sh
+RUN awk '$0 ~ /^\t_main "\$@"$/ { print "\tif [[ $1 == cron ]]; then\n\t\techo \"POSTGRES_DB=${POSTGRES_DB}\" > /backups/.env\n\t\techo \"POSTGRES_USER=${POSTGRES_USER}\" >> /backups/.env\n\t\tservice cron start\n\t\tshift\n\tfi" }{ print }' docker-entrypoint.sh > bookwyrm-entrypoint.sh
 RUN chown postgres /bookwyrm-entrypoint.sh
 RUN chmod u=rwx,go=r /bookwyrm-entrypoint.sh

--- a/postgres-docker/Dockerfile
+++ b/postgres-docker/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:13.0
 
 # crontab
 RUN mkdir /backups
-COPY ./backup.sh /backups
-COPY ./weed.sh /backups
+COPY ./backup.sh /usr/local/bin/bookwyrm-backup.sh
+COPY ./weed.sh /usr/local/bin/bookwyrm-weed.sh
 COPY ./cronfile /etc/cron.d/cronfile
 RUN apt-get update && apt-get -y --no-install-recommends install cron
 RUN chmod 0644 /etc/cron.d/cronfile

--- a/postgres-docker/backup.sh
+++ b/postgres-docker/backup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+source /backups/.env
+
 if [ -z "$POSTGRES_DB" ]; then
     echo "Database not specified, defaulting to bookwyrm"
 fi
+if [ -z "$POSTGRES_USER" ]; then
+    echo "Database user not specified, defaulting to bookwyrm"
+fi
 BACKUP_DB=${POSTGRES_DB:-bookwyrm}
+BACKUP_USER=${POSTGRES_USER:-bookwyrm}
 filename=backup_${BACKUP_DB}_$(date +%F)
-pg_dump -U $BACKUP_DB > /backups/$filename.sql
+pg_dump -U $BACKUP_USER $BACKUP_DB > /backups/$filename.sql

--- a/postgres-docker/cronfile
+++ b/postgres-docker/cronfile
@@ -1,5 +1,5 @@
-0 0 * * * /backups/backup.sh
+0 0 * * * /usr/local/bin/bookwyrm-backup.sh
 # If uncommented, this script will weed the backups directory. It will keep the 14
 # most-recent backups, then one backup/week for the next four backups, then one
 # backup/month after that.
-# 0 1 * * * /backups/weed.sh -d 14 -w 4 -m -1 /backups
+# 0 1 * * * /usr/local/bin/bookwyrm-weed.sh -d 14 -w 4 -m -1 /backups


### PR DESCRIPTION
Fixes #2546

Here's a handy diff how this changes the `bookwyrm-entrypoint.sh`:

```diff
  if ! _is_sourced; then
  	if [[ $1 == cron ]]; then
+ 		echo "POSTGRES_DB=${POSTGRES_DB}" > /backups/.env
+ 		echo "POSTGRES_USER=${POSTGRES_USER}" >> /backups/.env
  		service cron start
  		shift
  	fi
```

The backup script then sources `/backups.env` before executing the rest.