### PR TITLE
Add REDIS_BROKER_HOST to example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ REDIS_ACTIVITY_PASSWORD=redispassword345
 # REDIS_ACTIVITY_DB_INDEX=0
 
 # Redis as celery broker
+REDIS_BROKER_HOST=redis_broker
 REDIS_BROKER_PORT=6379
 REDIS_BROKER_PASSWORD=redispassword123
 # Optional, use a different redis database (defaults to 0)


### PR DESCRIPTION
This might avoid future confusion when somebody wants to run this dockerless for example, given that in the settings module this gets the default value of `redis_broker` when not set.