### PR TITLE
Ensure transient `cover_url` field value gets persisted across form renders

### DIFF
--- a/bookwyrm/tests/views/books/test_edit_book.py
+++ b/bookwyrm/tests/views/books/test_edit_book.py
@@ -82,6 +82,7 @@ class EditBookViews(TestCase):
         form = forms.EditionForm(instance=self.book)
         form.data["title"] = ""
         form.data["last_edited_by"] = self.local_user.id
+        form.data["cover-url"] = "http://local.host/cover.jpg"
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
@@ -91,6 +92,10 @@ class EditBookViews(TestCase):
         # Title is unchanged
         self.book.refresh_from_db()
         self.assertEqual(self.book.title, "Example Edition")
+        # transient field values are set correctly
+        self.assertEqual(
+            result.context_data["cover_url"], "http://local.host/cover.jpg"
+        )
 
     def test_edit_book_add_author(self):
         """lets a user edit a book with new authors"""
@@ -280,9 +285,14 @@ class EditBookViews(TestCase):
         form = forms.EditionForm(instance=self.book)
         form.data["title"] = ""
         form.data["last_edited_by"] = self.local_user.id
+        form.data["cover-url"] = "http://local.host/cover.jpg"
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
         result = view(request)
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
+        # transient field values are set correctly
+        self.assertEqual(
+            result.context_data["cover_url"], "http://local.host/cover.jpg"
+        )

--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -43,6 +43,7 @@ class EditBook(View):
         form = forms.EditionForm(request.POST, request.FILES, instance=book)
 
         data = {"book": book, "form": form}
+        ensure_transient_values_persist(request, data)
         if not form.is_valid():
             return TemplateResponse(request, "book/edit/edit_book.html", data)
 
@@ -101,6 +102,8 @@ class CreateBook(View):
                 "authors": authors,
             }
 
+        ensure_transient_values_persist(request, data)
+
         if not form.is_valid():
             return TemplateResponse(request, "book/edit/edit_book.html", data)
 
@@ -136,6 +139,11 @@ class CreateBook(View):
         return redirect(f"/book/{book.id}")
 
 
+def ensure_transient_values_persist(request, data):
+    """ensure that values of transient form fields persist when re-rendering the form"""
+    data["cover_url"] = request.POST.get("cover-url")
+
+
 def add_authors(request, data):
     """helper for adding authors"""
     add_author = [author for author in request.POST.getlist("add_author") if author]
@@ -150,7 +158,6 @@ def add_authors(request, data):
     data["confirm_mode"] = True
     # this isn't preserved because it isn't part of the form obj
     data["remove_authors"] = request.POST.getlist("remove_authors")
-    data["cover_url"] = request.POST.get("cover-url")
 
     for author in add_author:
         # filter out empty author fields


### PR DESCRIPTION
Given this field doesn't map to an `Edition` model field it lost its values when re-rendering the form. It worked only when the form was valid and rendered as part of the confirmation screen, which is due to the context data value being set in `add_authors` which was only getting called after the form validation.

I've opted to pull it out into a separate new function that gets called before form validation.

This addresses parts of:
* #2421
  * the same problem exists on the cover file selection field, but afaik there's no easy fix for file selection
* #2571
  * similar behaviour exists for the authors and subjects fields. but those fixes are slightly more involved, so will separate them into different PRs