### PR TITLE
Use the .url method on the avatar object

### DIFF
--- a/bookwyrm/templates/snippets/avatar.html
+++ b/bookwyrm/templates/snippets/avatar.html
@@ -2,7 +2,7 @@
 
 <img
     class="avatar image {% if large %}is-96x96{% elif medium %}is-48x48{% else %}is-32x32{% endif %}"
-    src="{% if user.avatar %}{% get_media_prefix %}{{ user.avatar }}{% else %}{% static "images/default_avi.jpg" %}{% endif %}"
+    src="{% if user.avatar %}{{ user.avatar.url }}{% else %}{% static "images/default_avi.jpg" %}{% endif %}"
     {% if ariaHide %}aria-hidden="true"{% endif %}
     alt="{{ user.alt_text }}"
 >


### PR DESCRIPTION
The current method of constructing an avatar by URL does not work in my CDN (Azure BlobStorage) setup. Asking Django to build the URL instead of contstructing it with string building seems like the correct way anyways, hopefully this is backwards compatible.