### PR TITLE
Fix Half Stars for Rating books

### DIFF
--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -37,7 +37,7 @@
             type="radio"
             name="rating"
             value="{{ forloop.counter0 }}.5"
-            {% if default_rating > 0 and default_rating >= forloop.counter0 %}checked{% endif %}
+            {% if default_rating > 0 and default_rating > forloop.counter0 %}checked{% endif %}
         />
         <input
             id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}"


### PR DESCRIPTION
Fixes #2568

A small error in the inequality has led to the fact that a half star was added to the actual rating