### PR TITLE
{list} Fix duplicate suggestions in Add Books section

### DIFF
--- a/bookwyrm/book_search.py
+++ b/bookwyrm/book_search.py
@@ -20,7 +20,7 @@ def search(query, min_confidence=0, filters=None, return_first=False):
     query = query.strip()
 
     results = None
-    # first, try searching unqiue identifiers
+    # first, try searching unique identifiers
     # unique identifiers never have spaces, title/author usually do
     if not " " in query:
         results = search_identifiers(query, *filters, return_first=return_first)

--- a/bookwyrm/views/list/list.py
+++ b/bookwyrm/views/list/list.py
@@ -94,7 +94,7 @@ class List(View):
         return redirect(book_list.local_path)
 
 
-def get_list_suggestions(book_list, user, query=None):
+def get_list_suggestions(book_list, user, query=None, num_suggestions=5):
     """What books might a user want to add to a list"""
     if query:
         # search for books
@@ -103,15 +103,21 @@ def get_list_suggestions(book_list, user, query=None):
             filters=[~Q(parent_work__editions__in=book_list.books.all())],
         )
     # just suggest whatever books are nearby
-    suggestions = user.shelfbook_set.filter(~Q(book__in=book_list.books.all()))
-    suggestions = [s.book for s in suggestions[:5]]
-    if len(suggestions) < 5:
-        suggestions += [
+    suggestions = user.shelfbook_set.filter(
+        ~Q(book__in=book_list.books.all())
+    ).distinct()[:num_suggestions]
+    suggestions = [s.book for s in suggestions[:num_suggestions]]
+    if len(suggestions) < num_suggestions:
+        others = [
             s.default_edition
             for s in models.Work.objects.filter(
                 ~Q(editions__in=book_list.books.all()),
-            ).order_by("-updated_date")[: 5 - len(suggestions)]
+            )
+            .distinct()
+            .order_by("-updated_date")[:num_suggestions]
         ]
+        # get 'num_suggestions' unique items
+        suggestions = list(set(suggestions + others))[:num_suggestions]
     return suggestions
 
 


### PR DESCRIPTION
(Also fix a spelling mistake in a comment in book_search.py)

Fixes #2584

Note that I'm not a Python person, so please tell me if any of this is non-Python-y.

- made the number of suggestions a parameter instead of a magic number
- I'm not sure if the `distinct()`s on queries are strictly necessary? But it does make it clearer.
- instead of appending to the suggestion list directly I create a second list
- I combine them to make them unique and limit the number of items to `num_suggestions`

**Edit:** I'm sure there's a fancy way to do this all in one query using a join, but handling it in Python seems fine given the size of the things we're dealing with.