### PR TITLE
Fix spelling in author form

### DIFF
--- a/bookwyrm/forms/author.py
+++ b/bookwyrm/forms/author.py
@@ -35,8 +35,8 @@ class AuthorForm(CustomForm):
             "website": forms.TextInput(attrs={"aria-describedby": "desc_website"}),
             "born": forms.SelectDateWidget(attrs={"aria-describedby": "desc_born"}),
             "died": forms.SelectDateWidget(attrs={"aria-describedby": "desc_died"}),
-            "oepnlibrary_key": forms.TextInput(
-                attrs={"aria-describedby": "desc_oepnlibrary_key"}
+            "openlibrary_key": forms.TextInput(
+                attrs={"aria-describedby": "desc_openlibrary_key"}
             ),
             "inventaire_id": forms.TextInput(
                 attrs={"aria-describedby": "desc_inventaire_id"}

--- a/bookwyrm/templates/author/edit_author.html
+++ b/bookwyrm/templates/author/edit_author.html
@@ -81,7 +81,7 @@
                 <label class="label" for="id_openlibrary_key">{% trans "Openlibrary key:" %}</label>
                 {{ form.openlibrary_key }}
 
-                {% include 'snippets/form_errors.html' with errors_list=form.oepnlibrary_key.errors id="desc_oepnlibrary_key" %}
+                {% include 'snippets/form_errors.html' with errors_list=form.openlibrary_key.errors id="desc_openlibrary_key" %}
             </div>
 
             <div class="field">


### PR DESCRIPTION
"oepnlibrary" ➡️ "openlibrary"

I think this would have prevented form errors from being shown for OpenLibrary on the author edit page.