### PR TITLE
Fix generated note content checks in card header template

### DIFF
--- a/bookwyrm/templates/discover/card-header.html
+++ b/bookwyrm/templates/discover/card-header.html
@@ -9,12 +9,12 @@
         <a href="{{ user_path}}">{{ username }}</a> wants to read <a href="{{ book_path }}">{{ book_title }}</a>
         {% endblocktrans %}
     {% endif %}
-    {% if finished reading or status.content == '<p>finished reading</p>' %}
+    {% if status.content == 'finished reading' or status.content == '<p>finished reading</p>' %}
         {% blocktrans trimmed %}
         <a href="{{ user_path}}">{{ username }}</a> finished reading <a href="{{ book_path }}">{{ book_title }}</a>
         {% endblocktrans %}
     {% endif %}
-    {% if started reading or status.content == '<p>started reading</p>' %}
+    {% if status.content == 'started reading' or status.content == '<p>started reading</p>' %}
         {% blocktrans trimmed %}
         <a href="{{ user_path}}">{{ username }}</a> started reading <a href="{{ book_path }}">{{ book_title }}</a>
         {% endblocktrans %}


### PR DESCRIPTION
#2532 unfortunately introduced a bug with invalid Python in the card-header template 😬 