### PR TITLE
Fix barcode scanner

### DIFF
--- a/bookwyrm/templates/search/barcode_modal.html
+++ b/bookwyrm/templates/search/barcode_modal.html
@@ -29,7 +29,7 @@
     <template id="barcode-scanning">
         <span class="icon icon-barcode"></span>
         <span class="is-size-5">{% trans "Scanning..." context "barcode scanner" %}</span><br/>
-        <span>{% trans "Align your book's barcode with the camera." %}</span>
+        <span>{% trans "Align your book's barcode with the camera." %}</span><span class="isbn"></span>
     </template>
     <template id="barcode-found">
         <span class="icon icon-check"></span>


### PR DESCRIPTION
This quick fix adds the missing HTML element that causes the barcode scanner to crash