### PR TITLE
Email Config View Has a Typo

### DIFF
--- a/bookwyrm/views/admin/email_config.py
+++ b/bookwyrm/views/admin/email_config.py
@@ -39,7 +39,7 @@ def view_data():
         "email_backend": settings.EMAIL_BACKEND,
         "email_host": settings.EMAIL_HOST,
         "email_port": settings.EMAIL_PORT,
-        "Email_host_user": settings.EMAIL_HOST_USER,
+        "email_host_user": settings.EMAIL_HOST_USER,
         "email_use_tls": settings.EMAIL_USE_TLS,
         "email_use_ssl": settings.EMAIL_USE_SSL,
         "email_sender": settings.EMAIL_SENDER,


### PR DESCRIPTION
There's an errant capital "E" preventing the SMTP user from appearing on the settings page. This just corrects the typo.