### PR TITLE
Enable RSS autodiscovery on user profile

### DIFF
--- a/bookwyrm/templates/user/user.html
+++ b/bookwyrm/templates/user/user.html
@@ -5,7 +5,7 @@
 {% block title %}{{ user.display_name }}{% endblock %}
 
 {% block head_links %}
-    <link rel="alternate" type="application/rss+xml" href="{{ user.local_path }}/rss" title="{{ user.display_name }}" />
+    <link rel="alternate" type="application/rss+xml" href="{{ user.local_path }}/rss" title="{{ user.display_name }} - {{ site.name }}" />
 {% endblock %}
 
 {% block header %}

--- a/bookwyrm/templates/user/user.html
+++ b/bookwyrm/templates/user/user.html
@@ -4,6 +4,10 @@
 
 {% block title %}{{ user.display_name }}{% endblock %}
 
+{% block head_links %}
+    <link rel="alternate" type="application/xml+rss" href="{{ user.local_path }}/rss" />
+{% endblock %}
+
 {% block header %}
 <div class="columns is-mobile">
     <div class="column">

--- a/bookwyrm/templates/user/user.html
+++ b/bookwyrm/templates/user/user.html
@@ -5,7 +5,7 @@
 {% block title %}{{ user.display_name }}{% endblock %}
 
 {% block head_links %}
-    <link rel="alternate" type="application/xml+rss" href="{{ user.local_path }}/rss" />
+    <link rel="alternate" type="application/rss+xml" href="{{ user.local_path }}/rss" title="{{ user.display_name }}" />
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
This is a simple change that adds a <link> tag to the header of the user profile so that browsers and feed readers can auto-detect the feed location, making it easier to follow a user by RSS.