### PR TITLE
Make follow activities a high priority

### DIFF
--- a/bookwyrm/tests/test_signing.py
+++ b/bookwyrm/tests/test_signing.py
@@ -35,6 +35,7 @@ Sender = namedtuple("Sender", ("remote_id", "key_pair"))
 class Signature(TestCase):
     """signature test"""
 
+    # pylint: disable=invalid-name
     def setUp(self):
         """create users and test data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
@@ -86,7 +87,7 @@ class Signature(TestCase):
         data = json.dumps(get_follow_activity(sender, self.rat))
         digest = digest or make_digest(data)
         signature = make_signature(signer or sender, self.rat.inbox, now, digest)
-        with patch("bookwyrm.views.inbox.activity_task.delay"):
+        with patch("bookwyrm.views.inbox.activity_task.apply_async"):
             with patch("bookwyrm.models.user.set_remote_server.delay"):
                 return self.send(signature, now, send_data or data, digest)
 

--- a/bookwyrm/tests/views/inbox/test_inbox.py
+++ b/bookwyrm/tests/views/inbox/test_inbox.py
@@ -15,6 +15,7 @@ from bookwyrm import models, views
 class Inbox(TestCase):
     """readthrough tests"""
 
+    # pylint: disable=invalid-name
     def setUp(self):
         """basic user and book data"""
         self.client = Client()
@@ -119,7 +120,7 @@ class Inbox(TestCase):
         with patch("bookwyrm.views.inbox.has_valid_signature") as mock_valid:
             mock_valid.return_value = True
 
-            with patch("bookwyrm.views.inbox.activity_task.delay"):
+            with patch("bookwyrm.views.inbox.activity_task.apply_async"):
                 result = self.client.post(
                     "/inbox", json.dumps(activity), content_type="application/json"
                 )

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -64,7 +64,7 @@ class Inbox(View):
         high = ["Follow", "Accept", "Reject", "Block", "Unblock", "Undo"]
 
         priority = HIGH if activity_json["type"] in high else MEDIUM
-        activity_task.apply_async(args=(activity_json), queue=priority)
+        activity_task.apply_async(args=(activity_json,), queue=priority)
         return HttpResponse()
 
 

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -14,7 +14,7 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from bookwyrm import activitypub, models
-from bookwyrm.tasks import app, MEDIUM
+from bookwyrm.tasks import app, MEDIUM, HIGH
 from bookwyrm.signatures import Signature
 from bookwyrm.utils import regex
 
@@ -60,7 +60,11 @@ class Inbox(View):
                 return HttpResponse()
             return HttpResponse(status=401)
 
-        activity_task.delay(activity_json)
+        # Make activities relating to follow/unfollow a high priority
+        high = ["Follow", "Accept", "Reject", "Block", "Unblock", "Undo"]
+
+        priority = HIGH if activity_json["type"] in high else MEDIUM
+        activity_task.apply_async(args=(activity_json), queue=priority)
         return HttpResponse()
 
 


### PR DESCRIPTION
This should go a long way towards fixing the problems with follows not going through to remote servers. All it does is move relationship related activities from the medium priority queue, which gets backlogged easily, to the high priority queue, which is less backlogged.

The risk here is that the high priority queue could end up getting backlogged, so this isn't the last word on fixing this, but I think the volume of activities that this will add to it will be manageable.

Works on #2614 #2545 