### PR TITLE
add "import" to celery worker

### DIFF
--- a/contrib/systemd/bookwyrm-worker.service
+++ b/contrib/systemd/bookwyrm-worker.service
@@ -6,7 +6,7 @@ After=network.target postgresql.service redis.service
 User=bookwyrm
 Group=bookwyrm
 WorkingDirectory=/opt/bookwyrm/
-ExecStart=/opt/bookwyrm/venv/bin/celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority
+ExecStart=/opt/bookwyrm/venv/bin/celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority,import
 StandardOutput=journal
 StandardError=inherit
 


### PR DESCRIPTION
import was missing in ExecStart for celery