### PR TITLE
Button in admin view to manually activate pending user

### DIFF
--- a/bookwyrm/templates/settings/users/user_moderation_actions.html
+++ b/bookwyrm/templates/settings/users/user_moderation_actions.html
@@ -15,6 +15,12 @@
             </p>
             {% endif %}
 
+            {% if not user.is_active and user.deactivation_reason == "pending" %}
+            <form name="suspend" method="post" action="{% url 'settings-activate-user' user.id  %}" class="mr-1">
+                {% csrf_token %}
+                <button type="submit" class="button is-success is-light">{% trans "Activate user" %}</button>
+            </form>
+            {% endif %}
             {% if user.is_active or user.deactivation_reason == "pending" %}
             <form name="suspend" method="post" action="{% url 'settings-report-suspend' user.id  %}" class="mr-1">
                 {% csrf_token %}

--- a/bookwyrm/templates/settings/users/user_moderation_actions.html
+++ b/bookwyrm/templates/settings/users/user_moderation_actions.html
@@ -16,7 +16,7 @@
             {% endif %}
 
             {% if not user.is_active and user.deactivation_reason == "pending" %}
-            <form name="suspend" method="post" action="{% url 'settings-activate-user' user.id  %}" class="mr-1">
+            <form name="activate" method="post" action="{% url 'settings-activate-user' user.id  %}" class="mr-1">
                 {% csrf_token %}
                 <button type="submit" class="button is-success is-light">{% trans "Activate user" %}</button>
             </form>

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -146,6 +146,11 @@ urlpatterns = [
         name="settings-user",
     ),
     re_path(
+        r"^settings/users/(?P<user>\d+)/activate/?$",
+        views.ActivateUserAdmin.as_view(),
+        name="settings-activate-user",
+    ),
+    re_path(
         r"^settings/federation/(?P<status>(federated|blocked))?/?$",
         views.Federation.as_view(),
         name="settings-federation",

--- a/bookwyrm/utils/regex.py
+++ b/bookwyrm/utils/regex.py
@@ -1,6 +1,6 @@
 """ defining regexes for regularly used concepts """
 
-DOMAIN = r"[\w_\-\.]+\.[a-z\-]{2,}"
+DOMAIN = r"(?:localhost:[0-9]{4,}|[\w_\-\.]+\.[a-z\-]{2,})"
 LOCALNAME = r"@?[a-zA-Z_\-\.0-9]+"
 STRICT_LOCALNAME = r"@[a-zA-Z_\-\.0-9]+"
 USERNAME = rf"{LOCALNAME}(@{DOMAIN})?"

--- a/bookwyrm/utils/regex.py
+++ b/bookwyrm/utils/regex.py
@@ -1,6 +1,6 @@
 """ defining regexes for regularly used concepts """
 
-DOMAIN = r"(?:localhost:[0-9]{4,}|[\w_\-\.]+\.[a-z\-]{2,})"
+DOMAIN = r"[\w_\-\.]+\.[a-z\-]{2,}"
 LOCALNAME = r"@?[a-zA-Z_\-\.0-9]+"
 STRICT_LOCALNAME = r"@[a-zA-Z_\-\.0-9]+"
 USERNAME = rf"{LOCALNAME}(@{DOMAIN})?"

--- a/bookwyrm/views/__init__.py
+++ b/bookwyrm/views/__init__.py
@@ -31,7 +31,7 @@ from .admin.reports import (
 )
 from .admin.site import Site, Registration, RegistrationLimited
 from .admin.themes import Themes, delete_theme
-from .admin.user_admin import UserAdmin, UserAdminList
+from .admin.user_admin import UserAdmin, UserAdminList, ActivateUserAdmin
 
 # user preferences
 from .preferences.change_password import ChangePassword

--- a/bookwyrm/views/admin/user_admin.py
+++ b/bookwyrm/views/admin/user_admin.py
@@ -96,6 +96,7 @@ class UserAdmin(View):
         data = {"user": user, "group_form": form}
         return TemplateResponse(request, "settings/users/user.html", data)
 
+
 @method_decorator(login_required, name="dispatch")
 @method_decorator(
     permission_required("bookwyrm.moderate_user", raise_exception=True),

--- a/bookwyrm/views/admin/user_admin.py
+++ b/bookwyrm/views/admin/user_admin.py
@@ -105,6 +105,7 @@ class UserAdmin(View):
 class ActivateUserAdmin(View):
     """activate a user manually"""
 
+    # pylint: disable=unused-argument
     def post(self, request, user):
         """activate user"""
         user = get_object_or_404(models.User, id=user)

--- a/bookwyrm/views/admin/user_admin.py
+++ b/bookwyrm/views/admin/user_admin.py
@@ -1,7 +1,7 @@
 """ manage user """
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views import View
@@ -95,3 +95,17 @@ class UserAdmin(View):
                 form.save(request)
         data = {"user": user, "group_form": form}
         return TemplateResponse(request, "settings/users/user.html", data)
+
+@method_decorator(login_required, name="dispatch")
+@method_decorator(
+    permission_required("bookwyrm.moderate_user", raise_exception=True),
+    name="dispatch",
+)
+class ActivateUserAdmin(View):
+    """activate a user manually"""
+
+    def post(self, request, user):
+        """activate user"""
+        user = get_object_or_404(models.User, id=user)
+        user.reactivate()
+        return redirect("settings-user", user.id)

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-26 16:43+0000\n"
+"POT-Creation-Date: 2023-01-30 08:21+0000\n"
 "PO-Revision-Date: 2021-02-28 17:19-0800\n"
 "Last-Translator: Mouse Reeve <mousereeve@riseup.net>\n"
 "Language-Team: English <LL@li.org>\n"
@@ -851,7 +851,7 @@ msgstr ""
 #: bookwyrm/templates/settings/registration.html:96
 #: bookwyrm/templates/settings/registration_limited.html:76
 #: bookwyrm/templates/settings/site.html:144
-#: bookwyrm/templates/settings/users/user_moderation_actions.html:69
+#: bookwyrm/templates/settings/users/user_moderation_actions.html:75
 #: bookwyrm/templates/shelf/form.html:25
 #: bookwyrm/templates/snippets/reading_modals/layout.html:18
 msgid "Save"
@@ -5448,7 +5448,7 @@ msgid "Remove theme"
 msgstr ""
 
 #: bookwyrm/templates/settings/users/delete_user_form.html:5
-#: bookwyrm/templates/settings/users/user_moderation_actions.html:32
+#: bookwyrm/templates/settings/users/user_moderation_actions.html:38
 msgid "Permanently delete user"
 msgstr ""
 
@@ -5570,14 +5570,18 @@ msgid "User Actions"
 msgstr ""
 
 #: bookwyrm/templates/settings/users/user_moderation_actions.html:21
+msgid "Activate user"
+msgstr ""
+
+#: bookwyrm/templates/settings/users/user_moderation_actions.html:27
 msgid "Suspend user"
 msgstr ""
 
-#: bookwyrm/templates/settings/users/user_moderation_actions.html:26
+#: bookwyrm/templates/settings/users/user_moderation_actions.html:32
 msgid "Un-suspend user"
 msgstr ""
 
-#: bookwyrm/templates/settings/users/user_moderation_actions.html:48
+#: bookwyrm/templates/settings/users/user_moderation_actions.html:54
 msgid "Access level:"
 msgstr ""
 


### PR DESCRIPTION
Resolves https://github.com/bookwyrm-social/bookwyrm/issues/2493

This PR adds a simple button to the admin user interface that allows quickly activating a pending user when they have not confirmed their email address yet.
No need to use the CLI anymore.