### PR TITLE
Improve feed header for federated generated notes

### DIFF
--- a/bookwyrm/templates/snippets/status/headers/generatednote.html
+++ b/bookwyrm/templates/snippets/status/headers/generatednote.html
@@ -4,11 +4,11 @@
 {# Three day cache #}
 {% get_current_language as LANGUAGE_CODE %}
 {% cache 259200 generated_note_header LANGUAGE_CODE status.id %}
-{% if status.content == 'wants to read' %}
+{% if status.content == 'wants to read' or status.content == '<p>wants to read</p>' %}
     {% include 'snippets/status/headers/to_read.html' with book=status.mention_books.first %}
-{% elif status.content == 'finished reading' %}
+{% elif status.content == 'finished reading' or status.content == '<p>finished reading</p>' %}
     {% include 'snippets/status/headers/read.html' with book=status.mention_books.first %}
-{% elif status.content == 'started reading' %}
+{% elif status.content == 'started reading' or status.content == '<p>started reading</p>' %}
     {% include 'snippets/status/headers/reading.html' with book=status.mention_books.first %}
 {% else %}
     {{ status.content }}


### PR DESCRIPTION
Partially addresses #2531.

Roughly taking #2532 but applying it to the feed templates.

This works for wants/started/finished reading generated notes, but not yet for reading goal generated notes (i.e. `<p>set a goal to read 12 books in 2023</p>`).

This does feel fairly brittle though and I wonder if we should rethink how statuses are federated (#2398), maybe making a distinction between federating to BookWyrm instances vs other ActivityPub services?