### PR TITLE
fix sass compound selector extensions

### DIFF
--- a/bookwyrm/static/css/vendor/shepherd.scss
+++ b/bookwyrm/static/css/vendor/shepherd.scss
@@ -6,16 +6,16 @@
 @use 'bulma/bulma.sass';
 
 .shepherd-button {
-    @extend .button.mr-2;
+    @extend .button, .mr-2;
 }
 
 .shepherd-button.shepherd-button-secondary {
-    @extend .button.is-light;
+    @extend .button, .is-light;
 }
 
 .shepherd-footer {
     @extend .message-body;
-    @extend .is-info.is-light;
+    @extend .is-info, .is-light;
     border-color: $info-light;
     border-radius: 0 0 4px 4px;
 }
@@ -29,7 +29,7 @@
 
 .shepherd-text {
     @extend .message-body;
-    @extend .is-info.is-light;
+    @extend .is-info, .is-light;
     border-radius: 0;
 }
 


### PR DESCRIPTION
Sass changed the way compound selectors can be extended, as outlined here: https://sass-lang.com/documentation/breaking-changes/extend-compound

This PR aligns the styles in `shepherd.scss` to the new compound selector extension format. There should be no change noticed by end users, but sass errors will no longer be reported when running `collectstatic`.

Resolved #2615 