### PR TITLE
Remove redundant DB queries

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -215,10 +215,10 @@
                 {% endif %}
 
 
-                {% with work=book.parent_work %}
+                {% with work=book.parent_work editions_count=book.parent_work.editions.count %}
                 <p>
                     <a href="{{ work.local_path }}/editions" id="tour-other-editions-link">
-                        {% blocktrans trimmed count counter=work.editions.count with count=work.editions.count|intcomma %}
+                        {% blocktrans trimmed count counter=editions_count with count=editions_count|intcomma %}
                             {{ count }} edition
                             {% plural %}
                             {{ count }} editions

--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -25,6 +25,7 @@
 {% block body %}
 <nav class="navbar" aria-label="main navigation">
     <div class="container">
+        {% with request.user.unread_notification_count as notification_count %}
         <div class="navbar-brand">
             <a class="navbar-item" href="/">
                 <img class="image logo" src="{% if site.logo_small %}{% get_media_prefix %}{{ site.logo_small }}{% else %}{% static "images/logo-small.png" %}{% endif %}" alt="{% blocktrans with site_name=site.name %}{{ site_name }} home page{% endblocktrans %}">
@@ -67,7 +68,6 @@
             >
                 <i class="icon-dots-three-vertical" aria-hidden="true"></i>
 
-                {% with request.user.unread_notification_count as notification_count %}
                 <strong
                     class="{% if not notification_count %}is-hidden {% elif request.user.has_unread_mentions %}is-danger {% else %}is-primary {% endif %} tag is-small px-1"
                     data-poll-wrapper
@@ -77,7 +77,6 @@
                         {{ notification_count }}
                     </strong>
                 </strong>
-                {% endwith %}
             </button>
         </div>
 
@@ -108,14 +107,12 @@
                                 <span class="is-sr-only">{% trans "Notifications" %}</span>
                             </span>
                         </span>
-                        {% with request.user.unread_notification_count as notification_count %}
                         <span
                             class="{% if not notification_count %}is-hidden {% elif request.user.has_unread_mentions %}is-danger {% endif %}tag is-medium transition-x"
                             data-poll-wrapper
                         >
                             <span data-poll="notifications">{{ notification_count }}</span>
                         </span>
-                        {% endwith %}
                     </a>
                 </div>
                 {% else %}
@@ -154,6 +151,7 @@
                 {% endif %}
             </div>
         </div>
+        {% endwith %}
     </div>
 </nav>
 

--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -25,7 +25,7 @@
 {% block body %}
 <nav class="navbar" aria-label="main navigation">
     <div class="container">
-        {% with request.user.unread_notification_count as notification_count %}
+        {% with notification_count=request.user.unread_notification_count has_unread_mentions=request.user.has_unread_mentions %}
         <div class="navbar-brand">
             <a class="navbar-item" href="/">
                 <img class="image logo" src="{% if site.logo_small %}{% get_media_prefix %}{{ site.logo_small }}{% else %}{% static "images/logo-small.png" %}{% endif %}" alt="{% blocktrans with site_name=site.name %}{{ site_name }} home page{% endblocktrans %}">
@@ -69,7 +69,7 @@
                 <i class="icon-dots-three-vertical" aria-hidden="true"></i>
 
                 <strong
-                    class="{% if not notification_count %}is-hidden {% elif request.user.has_unread_mentions %}is-danger {% else %}is-primary {% endif %} tag is-small px-1"
+                    class="{% if not notification_count %}is-hidden {% elif has_unread_mentions %}is-danger {% else %}is-primary {% endif %} tag is-small px-1"
                     data-poll-wrapper
                 >
                     <span class="is-sr-only">{% trans "Notifications" %}</span>
@@ -108,7 +108,7 @@
                             </span>
                         </span>
                         <span
-                            class="{% if not notification_count %}is-hidden {% elif request.user.has_unread_mentions %}is-danger {% endif %}tag is-medium transition-x"
+                            class="{% if not notification_count %}is-hidden {% elif has_unread_mentions %}is-danger {% endif %}tag is-medium transition-x"
                             data-poll-wrapper
                         >
                             <span data-poll="notifications">{{ notification_count }}</span>

--- a/bookwyrm/templates/snippets/create_status/comment.html
+++ b/bookwyrm/templates/snippets/create_status/comment.html
@@ -19,9 +19,9 @@ uuid: a unique identifier used to make html "id" attributes unique and clarify j
     {# Supplemental fields #}
     <div>
         {% active_shelf book as active_shelf %}
-        {% if active_shelf.shelf.identifier == 'reading' and book.latest_readthrough %}
-
+        {% if active_shelf.shelf.identifier == 'reading' %}
         {% with readthrough=book.latest_readthrough %}
+        {% if readthrough %}
         <div class="field">
             <input type="hidden" name="id" value="{{ readthrough.id }}"/>
             <label class="label" for="progress_{{ uuid }}">{% trans "Progress:" %}</label>
@@ -66,6 +66,7 @@ uuid: a unique identifier used to make html "id" attributes unique and clarify j
             <p class="help">{% blocktrans with pages=book.pages %}of {{ pages }} pages{% endblocktrans %}</p>
             {% endif %}
         </div>
+        {% endif %}
         {% endwith %}
         {% endif %}
     </div>

--- a/bookwyrm/views/feed.py
+++ b/bookwyrm/views/feed.py
@@ -237,16 +237,24 @@ def feed_page_data(user):
 def get_suggested_books(user, max_books=5):
     """helper to get a user's recent books"""
     book_count = 0
-    preset_shelves = [("reading", max_books), ("read", 2), ("to-read", max_books)]
+    preset_shelves = {"reading": max_books, "read": 2, "to-read": max_books}
     suggested_books = []
-    for (preset, shelf_max) in preset_shelves:
+
+    user_shelves = {
+        shelf.identifier: shelf
+        for shelf in user.shelf_set.filter(
+            identifier__in=preset_shelves.keys()
+        ).exclude(books__isnull=True)
+    }
+
+    for preset, shelf_max in preset_shelves.items():
         limit = (
             shelf_max
             if shelf_max < (max_books - book_count)
             else max_books - book_count
         )
-        shelf = user.shelf_set.get(identifier=preset)
-        if not shelf.books.exists():
+        shelf = user_shelves.get(preset, None)
+        if not shelf:
             continue
 
         shelf_preview = {


### PR DESCRIPTION
This PR downs the number of DB requests from 46 to 38 for the feed page, assuming you have 3 books added to each shelf (`to-read`, `reading`, `read`). Also, it fixes one duplicated request from the book page.

Testing steps:
1. Switch to the `main` branch.
2. Cherry-pick ee3c29f9a269b8aa7dbd218be895e59b1fad3270 and fd98aa34a6ff2ae7325bea64af2463db5d5b09eb
3. Add three test books, each to it's own shelf.
4. Note the number of DB requests.
5. Rebase on `redundant-db-queries`.
6. There should be 8 less DB requests now.
7. Test that book suggestions block works well.
8. Test that book page works well too.