### PR TITLE
Improve search results

### DIFF
--- a/bookwyrm/connectors/abstract_connector.py
+++ b/bookwyrm/connectors/abstract_connector.py
@@ -1,5 +1,6 @@
 """ functionality outline for a book data connector """
 from abc import ABC, abstractmethod
+from urllib.parse import quote_plus
 import imghdr
 import logging
 import re
@@ -48,7 +49,7 @@ class AbstractMinimalConnector(ABC):
             return f"{self.isbn_search_url}{normalized_query}"
         # NOTE: previously, we tried searching isbn and if that produces no results,
         # searched as free text. This, instead, only searches isbn if it's isbn-y
-        return f"{self.search_url}{query}"
+        return f"{self.search_url}{quote_plus(query)}"
 
     def process_search_response(self, query, data, min_confidence):
         """Format the search results based on the formt of the query"""


### PR DESCRIPTION
Search query has to be encoded. Otherwise, a query like this:
```
https://openlibrary.org/search.json?q=Rang%20&%20Dale%27s%20Pharmacology=&limit=10
```
Is equivalent to this:
```
https://openlibrary.org/search.json?q=Rang%20
```
Because the ampersand isn't encoded.

Consider search results for `Rang & Dale's Pharmacology` query without this fix:

![image](https://user-images.githubusercontent.com/18251194/216438518-63bf7497-66be-4352-adeb-947f5f527298.png)

And with the fix:

![image](https://user-images.githubusercontent.com/18251194/216438867-d419f52e-218d-453d-a863-10144ef73ab8.png)

You can see that Inventaire returned more accurate results. Also, OpenLibrary returned relevant results.