### PR TITLE
Always expand content status on single status view

### DIFF
--- a/bookwyrm/templates/feed/status.html
+++ b/bookwyrm/templates/feed/status.html
@@ -30,7 +30,7 @@
         {% endif %}
         {% endfor %}
         <div class="is-main block">
-            {% include 'snippets/status/status.html' with status=status main=True %}
+            {% include 'snippets/status/status.html' with status=status main=True expand=True %}
         </div>
 
         {% for child in children %}

--- a/bookwyrm/templates/snippets/status/body.html
+++ b/bookwyrm/templates/snippets/status/body.html
@@ -6,9 +6,8 @@
 {% if status_type == 'GeneratedNote' or status_type == 'Rating' %}
     {% include 'snippets/status/generated_status.html' with status=status %}
 {% else %}
-    {% include 'snippets/status/content_status.html' with status=status %}
+    {% include 'snippets/status/content_status.html' with status=status expand=expand %}
 {% endif %}
 
 {% endwith %}
 {% endblock %}
-

--- a/bookwyrm/templates/snippets/status/content_status.html
+++ b/bookwyrm/templates/snippets/status/content_status.html
@@ -109,7 +109,7 @@
                 {% endif %}
 
                 {% if status.content and status_type != 'GeneratedNote' and status_type != 'Announce' %}
-                    {% with full=status.content|safe no_trim=status.content_warning itemprop="reviewBody" %}
+                    {% with full=status.content|safe no_trim=status.content_warning|default:expand itemprop="reviewBody" %}
                         {% include 'snippets/trimmed_text.html' %}
                     {% endwith %}
                 {% endif %}
@@ -155,4 +155,3 @@
 </div>
 
 {% endwith %}
-

--- a/bookwyrm/templates/snippets/status/status.html
+++ b/bookwyrm/templates/snippets/status/status.html
@@ -10,6 +10,6 @@
         {% trans "boosted" %}
         {% include 'snippets/status/body.html' with status=status|boosted_status %}
     {% else %}
-        {% include 'snippets/status/body.html' with status=status %}
+        {% include 'snippets/status/body.html' with status=status expand=expand %}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Fixes #2649

On the feed view along with other statuses, the body will be trimmed, but on the single view, there's no need to trim it. This preserves the logic for spoiler alerts.