### PR TITLE
Dependencies: support installation on macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ flower==1.2.0
 libsass==0.22.0
 Markdown==3.4.1
 Pillow==9.4.0
-psycopg2==2.9.5
+psycopg2==2.9.5; sys_platform != 'darwin'
+psycopg2-binary==2.9.5; sys_platform == 'darwin'
 pycryptodome==3.16.0
 python-dateutil==2.8.2
 redis==3.4.1


### PR DESCRIPTION
In order to allow VS Code to show autocompletion and not complain about dependency imports, I tried installing requirements on macOS. This did not work due to a pg dependency.
This PR should fix the installation being supported on macOS as well using conditional dependencies in the `requirements.txt`.