### PR TITLE
Added support for oauth 2 login and registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,11 @@ OTEL_SERVICE_NAME=
 # for your instance:
 # https://docs.djangoproject.com/en/3.2/ref/settings/#secure-proxy-ssl-header
 HTTP_X_FORWARDED_PROTO=false
+
+# Enable logging in and registration with OAuth 2
+OAUTH_ACTIVE=false
+#OAUTH_NAME="OAuth Provider" # Displayed on Login Button as "Login with OAUTH_NAME"
+#OAUTH_CLIENT_ID=""
+#OAUTH_CLIENT_SECRET=""
+#OAUTH_AUTHORIZE_URL="" # For mastodon use "https://<mastodon domain>/oauth/authorize"
+#OAUTH_ACCESS_TOKEN_URL="" # For mastodon use "https://<mastodon domain>/oauth/token"

--- a/bookwyrm/context_processors.py
+++ b/bookwyrm/context_processors.py
@@ -28,4 +28,6 @@ def site_settings(request):  # pylint: disable=unused-argument
         "preview_images_enabled": settings.ENABLE_PREVIEW_IMAGES,
         "request_protocol": request_protocol,
         "js_cache": settings.JS_CACHE,
+        "oauth_active": settings.OAUTH_ACTIVE,
+        "oauth_name": settings.OAUTH_NAME,
     }

--- a/bookwyrm/forms/landing.py
+++ b/bookwyrm/forms/landing.py
@@ -56,6 +56,20 @@ class RegisterForm(CustomForm):
             self.add_error("localname", _("User with this username already exists"))
 
 
+class OAuthRegisterForm(CustomForm):
+    class Meta:
+        model = models.User
+        fields = ["localname", "email"]
+        help_texts = {f: None for f in fields}
+
+    def clean(self):
+        """Check if the username is taken"""
+        cleaned_data = super().clean()
+        localname = cleaned_data.get("localname").strip()
+        if models.User.objects.filter(localname=localname).first():
+            self.add_error("localname", _("User with this username already exists"))
+
+
 class InviteRequestForm(CustomForm):
     def clean(self):
         """make sure the email isn't in use by a registered user"""

--- a/bookwyrm/oauth.py
+++ b/bookwyrm/oauth.py
@@ -1,0 +1,38 @@
+""" responds to various requests to oauth """
+from django.contrib.auth import login
+from django.core.exceptions import ObjectDoesNotExist
+from django.dispatch import receiver
+from django.urls import reverse
+from django.shortcuts import render, redirect
+from django.template.response import TemplateResponse
+from authlib.integrations.django_client import OAuth, OAuthError
+
+from bookwyrm import models
+from bookwyrm.settings import DOMAIN
+
+oauth = OAuth()
+oauth.register('oauth')
+oauth = oauth.oauth
+
+def auth(request):
+    try:
+        token = oauth.authorize_access_token(request)
+    except OAuthError:
+        data = {}
+        return TemplateResponse(request, "landing/login.html", data)
+    acct = oauth.get("https://raphus.social/api/v1/accounts/verify_credentials",token=token)
+    if (acct.status_code==200):
+        localname = dict(acct.json())['acct']
+        username = "{}@{}".format(localname,DOMAIN)
+        try:
+            user = models.User.objects.get(username=username)
+        except ObjectDoesNotExist:
+            request.session['oauth-newuser'] = localname
+            request.session["oauth-newuser-pfp"] = dict(acct.json())['avatar']
+            return redirect('oauth-register')
+        login(request,user)
+    return redirect('/')
+
+def request_login(request):
+    redirect_uri = request.build_absolute_uri(reverse('oauth'))
+    return oauth.authorize_redirect(request, redirect_uri, force_login=True )

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -388,3 +388,14 @@ if HTTP_X_FORWARDED_PROTO:
 # Do not change this setting unless you already have an existing
 # user with the same username - in which case you should change it!
 INSTANCE_ACTOR_USERNAME = "bookwyrm.instance.actor"
+OAUTH_ACTIVE = env("OAUTH_ACTIVE",False)
+if OAUTH_ACTIVE:
+    OAUTH_NAME=env("OAUTH_NAME","OAuth2")
+    AUTHLIB_OAUTH_CLIENTS = {
+        'oauth': {
+            'client_id': env("OAUTH_CLIENT_ID"),
+            'client_secret': env("OAUTH_CLIENT_SECRET"),
+            'authorize_url': env("OAUTH_AUTHORIZE_URL"),
+            'access_token_url': env("OAUTH_ACCESS_TOKEN_URL"),
+        }
+    }

--- a/bookwyrm/templates/landing/login.html
+++ b/bookwyrm/templates/landing/login.html
@@ -10,10 +10,15 @@
         {% if login_form.non_field_errors %}
         <p class="notification is-danger">{{ login_form.non_field_errors }}</p>
         {% endif %}
-
+	
         {% if show_confirmed_email %}
         <p class="notification is-success">{% trans "Success! Email address confirmed." %}</p>
         {% endif %}
+	{% if oauth_active %}
+	    <a href="{% url 'oauth-login' %}">
+		    <button class="button is-primary" type="submit">{% trans "Log in with " %}{{oauth_name}}</button>
+	    </a>
+	{% else %}
         <form name="login-confirm" method="post" action="{% url 'login' %}">
             {% csrf_token %}
             {% if show_confirmed_email %}<input type="hidden" name="first_login" value="true">{% endif %}
@@ -40,6 +45,7 @@
                 </div>
             </div>
         </form>
+	{% endif %}
     </div>
 
     {% if site.allow_registration %}

--- a/bookwyrm/templates/landing/oauth_register.html
+++ b/bookwyrm/templates/landing/oauth_register.html
@@ -1,0 +1,75 @@
+{% extends 'layout.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Create an Account" %}{% endblock %}
+
+{% block content %}
+
+<h1 class="title">{% trans "Create an Account" %}</h1>
+<div class="columns">
+    <div class="column">
+        <div class="block">
+            {% if valid %}
+            <div>
+                <form name="register" method="post" action="/register">
+{% csrf_token %}
+			<div class="field">
+			    <label class="label" for="id_localname_register">{% trans "Username:" %}</label>
+			    <div class="control">
+				<input
+				    type="hidden"
+				    name="localname"
+				    value="{{ username }}"
+				    ><em>{{ username }}</em>
+				<div id="desc_localname_register_panel">
+				    <p class="help">
+					{% trans "Your username cannot be changed." %}
+				    </p>
+				</div>
+			    </div>
+			</div>
+                        <div class="field">
+                            <label class="label" for="id_email_register">{% trans "Email address:" %}</label>
+                            <div class="control">
+                                <input
+                                    type="email"
+                                    name="email"
+                                    maxlength="254"
+                                    class="input"
+                                    id="id_email_register"
+                                    value="{% if register_form.email.value %}{{ register_form.email.value }}{% endif %}"
+                                    required
+                                    aria-describedby="desc_email_register"
+                                >
+
+                                {% include 'snippets/form_errors.html' with errors_list=register_form.email.errors id="desc_email_register" %}
+                            </div>
+                        </div>
+
+			<input type="hidden" name="preferred_timezone" />
+
+			<div class="field">
+			    <div class="control">
+				<button class="button is-primary" type="submit">
+				    {% trans "Sign Up" %}
+				</button>
+			    </div>
+			</div>
+                </form>
+            </div>
+            {% else %}
+            <div class="content">
+                <h1 class="title">{% trans "Permission Denied" %}</h1>
+                <p>{% trans "Sorry!" %}</p>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    <div class="column">
+        <div class="box">
+            {% include 'snippets/about.html' %}
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -115,6 +115,12 @@
                         </span>
                     </a>
                 </div>
+		{% elif oauth_active %}
+                <div class="navbar-item pt-5 pb-0">
+	    		<a href="{% url 'oauth-login' %}">
+				<button class="button is-primary" type="submit">{% trans "Log in with " %}{{ oauth_name }}</button>
+			</a>
+		</div>
                 {% else %}
                 <div class="navbar-item pt-5 pb-0">
                     {% if request.path != '/login' and request.path != '/login/' %}

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.urls import path, re_path
 from django.views.generic.base import TemplateView
 
-from bookwyrm import settings, views
+from bookwyrm import settings, views, oauth
 from bookwyrm.utils import regex
 
 USER_PATH = rf"^user/(?P<username>{regex.USERNAME})"
@@ -81,6 +81,9 @@ urlpatterns = [
     re_path(
         r"^password-reset/(?P<code>[A-Za-z0-9]+)/?$", views.PasswordReset.as_view()
     ),
+    re_path(r"^oauth$",oauth.auth,name="oauth"),
+    re_path(r"^oauth/login$",oauth.request_login, name="oauth-login"),
+    re_path(r"^oauth/register$", views.OAuthRegister.as_view(), name="oauth-register"),
     # admin
     re_path(
         r"^settings/dashboard/?$", views.Dashboard.as_view(), name="settings-dashboard"

--- a/bookwyrm/views/__init__.py
+++ b/bookwyrm/views/__init__.py
@@ -164,3 +164,4 @@ from .annual_summary import (
     summary_add_key,
     summary_revoke_key,
 )
+from .oauth import OAuthRegister

--- a/bookwyrm/views/oauth.py
+++ b/bookwyrm/views/oauth.py
@@ -1,0 +1,35 @@
+""" invites when registration is closed """
+from functools import reduce
+import operator
+from urllib.parse import urlencode
+
+from django.contrib.auth.decorators import login_required, permission_required
+from django.core.paginator import Paginator
+from django.db.models import Q
+from django.http import HttpResponseBadRequest
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.http import require_POST
+
+from bookwyrm import emailing, forms, models
+from bookwyrm.settings import PAGE_LENGTH
+
+
+# pylint: disable= no-self-use
+class OAuthRegister(View):
+    """use an invite to register"""
+
+    def get(self, request):
+        if request.user.is_authenticated or 'oauth-newuser' not in request.session:
+            return redirect("/")
+        data = {
+            "register_form": forms.RegisterForm(),
+            "username": request.session['oauth-newuser'],
+            "valid": True,
+        }
+        return TemplateResponse(request, "landing/oauth_register.html", data)
+
+    # post handling is in views.register.Register

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.8.3
+oauthlib==3.2.2
 bleach==5.0.1
 celery==5.2.7
 colorthief==0.2.1


### PR DESCRIPTION
I've added support for OAuth 2 login and registration to my instance, so I can login with my mastodon credentials.
Enabling this disables password login.
If an account does not exist in bookwyrm, it will automatically register a new account with the same local part, and requires the user to enter their email address. This is not provided from Mastodon, and I am unable to set it to NULL via Django, so this step is unfortunately unavoidable.
I'm not sure if this is the best way to go about things, but it does work. I am submitting this as a draft pr to see if anyone has any other input or wants to test it out for themselves.