### PR TITLE
Fix `SiteSettings.default_user_auth_group` FK on_delete value

### DIFF
--- a/bookwyrm/models/site.py
+++ b/bookwyrm/models/site.py
@@ -72,7 +72,7 @@ class SiteSettings(SiteModel):
     invite_request_question = models.BooleanField(default=False)
     require_confirm_email = models.BooleanField(default=True)
     default_user_auth_group = models.ForeignKey(
-        auth_models.Group, null=True, blank=True, on_delete=models.PROTECT
+        auth_models.Group, null=True, blank=True, on_delete=models.RESTRICT
     )
 
     invite_question_text = models.CharField(


### PR DESCRIPTION
This is a bug I introduced in #2554. The `on_delete` value in the model didn't match the one in the migration.

The migration uses `RESTRICT` instead of `PROTECT`, which is both more correct, but also those values need to be identical, otherwise Django thinks that there's a migration missing and will refuse to apply any new migrations.