### PR TITLE
Use a separate queue for broadcasts

### DIFF
--- a/bookwyrm/tasks.py
+++ b/bookwyrm/tasks.py
@@ -16,3 +16,5 @@ MEDIUM = "medium_priority"
 HIGH = "high_priority"
 # import items get their own queue because they're such a pain in the ass
 IMPORTS = "imports"
+# I keep making more queues?? this one broadcasting out
+BROADCAST = "broadcast"

--- a/bookwyrm/templates/settings/celery.html
+++ b/bookwyrm/templates/settings/celery.html
@@ -20,29 +20,35 @@
 {% if queues %}
 <section class="block content">
     <h2>{% trans "Queues" %}</h2>
-    <div class="columns has-text-centered">
-        <div class="column is-3">
+    <div class="columns has-text-centered is-multiline">
+        <div class="column is-4">
             <div class="notification">
                 <p class="header">{% trans "Low priority" %}</p>
                 <p class="title is-5">{{ queues.low_priority|intcomma }}</p>
             </div>
         </div>
-        <div class="column is-3">
+        <div class="column is-4">
             <div class="notification">
                 <p class="header">{% trans "Medium priority" %}</p>
                 <p class="title is-5">{{ queues.medium_priority|intcomma }}</p>
             </div>
         </div>
-        <div class="column is-3">
+        <div class="column is-4">
             <div class="notification">
                 <p class="header">{% trans "High priority" %}</p>
                 <p class="title is-5">{{ queues.high_priority|intcomma }}</p>
             </div>
         </div>
-        <div class="column is-3">
+        <div class="column is-6">
             <div class="notification">
                 <p class="header">{% trans "Imports" %}</p>
                 <p class="title is-5">{{ queues.imports|intcomma }}</p>
+            </div>
+        </div>
+        <div class="column is-6">
+            <div class="notification">
+                <p class="header">{% trans "Broadcasts" %}</p>
+                <p class="title is-5">{{ queues.broadcast|intcomma }}</p>
             </div>
         </div>
     </div>

--- a/bookwyrm/views/admin/celery_status.py
+++ b/bookwyrm/views/admin/celery_status.py
@@ -8,7 +8,7 @@ from django.views.decorators.http import require_GET
 import redis
 
 from celerywyrm import settings
-from bookwyrm.tasks import app as celery
+from bookwyrm.tasks import app as celery, LOW, MEDIUM, HIGH, IMPORTS, BROADCAST
 
 r = redis.from_url(settings.REDIS_BROKER_URL)
 
@@ -35,10 +35,11 @@ class CeleryStatus(View):
 
         try:
             queues = {
-                "low_priority": r.llen("low_priority"),
-                "medium_priority": r.llen("medium_priority"),
-                "high_priority": r.llen("high_priority"),
-                "imports": r.llen("imports"),
+                LOW: r.llen(LOW),
+                MEDIUM: r.llen(MEDIUM),
+                HIGH: r.llen(HIGH),
+                IMPORTS: r.llen(IMPORTS),
+                BROADCAST: r.llen(BROADCAST),
             }
         # pylint: disable=broad-except
         except Exception as err:

--- a/contrib/systemd/bookwyrm-worker.service
+++ b/contrib/systemd/bookwyrm-worker.service
@@ -6,7 +6,7 @@ After=network.target postgresql.service redis.service
 User=bookwyrm
 Group=bookwyrm
 WorkingDirectory=/opt/bookwyrm/
-ExecStart=/opt/bookwyrm/venv/bin/celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority,import
+ExecStart=/opt/bookwyrm/venv/bin/celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority,import,broadcast
 StandardOutput=journal
 StandardError=inherit
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     build: .
     networks:
       - main
-    command: celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority,imports
+    command: celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority,imports,broadcast
     volumes:
       - .:/app
       - static_volume:/app/static


### PR DESCRIPTION
I think this will go a long way to solve the federation delay problems we're seeing on b.s. I'm not sure at what point adding more queues will create more problems than it solves, but I do think in this case the queues are out of balance and moving broadcasts (which are the most common type of `medium_priority` task at the moment) to their own queue will be an improvement.

Works on #2626
Works on #2614