### PR TITLE
Add config variable for additional CSP hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,8 @@ OTEL_SERVICE_NAME=
 # for your instance:
 # https://docs.djangoproject.com/en/3.2/ref/settings/#secure-proxy-ssl-header
 HTTP_X_FORWARDED_PROTO=false
+
+# Additional hosts to allow in the Content-Security-Policy, "self" (should be DOMAIN)
+# and AWS_S3_CUSTOM_DOMAIN (if used) are added by default.
+# Value should be a comma-separated list of host names.
+CSP_ADDITIONAL_HOSTS=

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -330,6 +330,7 @@ IMAGEKIT_DEFAULT_CACHEFILE_STRATEGY = "bookwyrm.thumbnail_generation.Strategy"
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+CSP_ADDITIONAL_HOSTS = env.list("CSP_ADDITIONAL_HOSTS", [])
 
 # Storage
 
@@ -361,15 +362,15 @@ if USE_S3:
     MEDIA_FULL_URL = MEDIA_URL
     STATIC_FULL_URL = STATIC_URL
     DEFAULT_FILE_STORAGE = "bookwyrm.storage_backends.ImagesStorage"
-    CSP_DEFAULT_SRC = ("'self'", AWS_S3_CUSTOM_DOMAIN)
-    CSP_SCRIPT_SRC = ("'self'", AWS_S3_CUSTOM_DOMAIN)
+    CSP_DEFAULT_SRC = ["'self'", AWS_S3_CUSTOM_DOMAIN] + CSP_ADDITIONAL_HOSTS
+    CSP_SCRIPT_SRC = ["'self'", AWS_S3_CUSTOM_DOMAIN] + CSP_ADDITIONAL_HOSTS
 else:
     STATIC_URL = "/static/"
     MEDIA_URL = "/images/"
     MEDIA_FULL_URL = f"{PROTOCOL}://{DOMAIN}{MEDIA_URL}"
     STATIC_FULL_URL = f"{PROTOCOL}://{DOMAIN}{STATIC_URL}"
-    CSP_DEFAULT_SRC = "'self'"
-    CSP_SCRIPT_SRC = "'self'"
+    CSP_DEFAULT_SRC = ["'self'"] + CSP_ADDITIONAL_HOSTS
+    CSP_SCRIPT_SRC = ["'self'"] + CSP_ADDITIONAL_HOSTS
 
 CSP_INCLUDE_NONCE_IN = ["script-src"]
 


### PR DESCRIPTION
This came up in the developer chat yesterday. One instance had their `AWS_S3_CUSTOM_DOMAIN` redirect to another domain which then served the static files. This didn't work with our content security policy that was introduced in #2644.

This change adds a new environment variable `CSP_ADDITIONAL_HOSTS` which allows configuring additional hosts that are added to the policy after `"self"` (basically `DOMAIN`), and `AWS_S3_CUSTOM_DOMAIN`.