### PR TITLE
Only use chronological pagination sometimes

### DIFF
--- a/bookwyrm/templates/feed/layout.html
+++ b/bookwyrm/templates/feed/layout.html
@@ -23,7 +23,7 @@
         {% block panel %}{% endblock %}
 
         {% if activities %}
-        {% include 'snippets/pagination.html' with page=activities path=path anchor="#feed" %}
+        {% include 'snippets/pagination.html' with page=activities path=path anchor="#feed" mode="chronological" %}
         {% endif %}
     </div>
 </div>

--- a/bookwyrm/templates/snippets/pagination.html
+++ b/bookwyrm/templates/snippets/pagination.html
@@ -9,7 +9,11 @@
         {% endif %}>
 
         <span class="icon icon-arrow-left" aria-hidden="true"></span>
-        {% trans "Older" %}
+        {% if mode == "chronological" %}
+        {% trans "Newer" %}
+        {% else %}
+        {% trans "Previous" %}
+        {% endif %}
     </a>
 
     <a
@@ -20,7 +24,11 @@
         aria-hidden="true"
         {% endif %}>
 
-        {% trans "Newer" %}
+        {% if mode == "chronological" %}
+        {% trans "Older" %}
+        {% else %}
+        {% trans "Next" %}
+        {% endif %}
         <span class="icon icon-arrow-right" aria-hidden="true"></span>
     </a>
 


### PR DESCRIPTION
The timeline uses chronological buttons, but other paginated pages do not (by default). This also reversed the chronology.