### PR TITLE
Improve `HomeStream.get_audience` performance

### DIFF
--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -160,14 +160,15 @@ class HomeStream(ActivityStream):
 
     key = "home"
 
-    def _get_audience(self, status):
+    def get_audience(self, status):
         audience = super()._get_audience(status)
         if not audience:
             return []
-        return audience.filter(
-            Q(id=status.user.id)  # if the user is the post's author
-            | Q(following=status.user)  # if the user is following the author
-        ).distinct()
+        # if the user is the post's author
+        ids_self = [user.id for user in audience.filter(Q(id=status.user.id))]
+        # if the user is following the author
+        ids_following = [user.id for user in audience.filter(Q(following=status.user))]
+        return ids_self + ids_following
 
     def get_statuses_for_user(self, user):
         return models.Status.privacy_filter(

--- a/bookwyrm/tests/activitystreams/test_abstractstream.py
+++ b/bookwyrm/tests/activitystreams/test_abstractstream.py
@@ -53,7 +53,7 @@ class Activitystreams(TestCase):
     def test_activitystream_class_ids(self, *_):
         """the abstract base class for stream objects"""
         self.assertEqual(
-            self.test_stream.stream_id(self.local_user),
+            self.test_stream.stream_id(self.local_user.id),
             f"{self.local_user.id}-test",
         )
         self.assertEqual(

--- a/bookwyrm/tests/activitystreams/test_abstractstream.py
+++ b/bookwyrm/tests/activitystreams/test_abstractstream.py
@@ -118,9 +118,9 @@ class Activitystreams(TestCase):
         )
         users = self.test_stream.get_audience(status)
         # remote users don't have feeds
-        self.assertFalse(self.remote_user in users)
-        self.assertTrue(self.local_user in users)
-        self.assertTrue(self.another_user in users)
+        self.assertFalse(self.remote_user.id in users)
+        self.assertTrue(self.local_user.id in users)
+        self.assertTrue(self.another_user.id in users)
 
     def test_abstractstream_get_audience_direct(self, *_):
         """get a list of users that should see a status"""
@@ -141,9 +141,9 @@ class Activitystreams(TestCase):
         )
         status.mention_users.add(self.local_user)
         users = self.test_stream.get_audience(status)
-        self.assertTrue(self.local_user in users)
-        self.assertFalse(self.another_user in users)
-        self.assertFalse(self.remote_user in users)
+        self.assertTrue(self.local_user.id in users)
+        self.assertFalse(self.another_user.id in users)
+        self.assertFalse(self.remote_user.id in users)
 
     def test_abstractstream_get_audience_followers_remote_user(self, *_):
         """get a list of users that should see a status"""
@@ -153,7 +153,7 @@ class Activitystreams(TestCase):
             privacy="followers",
         )
         users = self.test_stream.get_audience(status)
-        self.assertFalse(users.exists())
+        self.assertEqual(users, [])
 
     def test_abstractstream_get_audience_followers_self(self, *_):
         """get a list of users that should see a status"""
@@ -164,9 +164,9 @@ class Activitystreams(TestCase):
             book=self.book,
         )
         users = self.test_stream.get_audience(status)
-        self.assertTrue(self.local_user in users)
-        self.assertFalse(self.another_user in users)
-        self.assertFalse(self.remote_user in users)
+        self.assertTrue(self.local_user.id in users)
+        self.assertFalse(self.another_user.id in users)
+        self.assertFalse(self.remote_user.id in users)
 
     def test_abstractstream_get_audience_followers_with_mention(self, *_):
         """get a list of users that should see a status"""
@@ -179,9 +179,9 @@ class Activitystreams(TestCase):
         status.mention_users.add(self.local_user)
 
         users = self.test_stream.get_audience(status)
-        self.assertTrue(self.local_user in users)
-        self.assertFalse(self.another_user in users)
-        self.assertFalse(self.remote_user in users)
+        self.assertTrue(self.local_user.id in users)
+        self.assertFalse(self.another_user.id in users)
+        self.assertFalse(self.remote_user.id in users)
 
     def test_abstractstream_get_audience_followers_with_relationship(self, *_):
         """get a list of users that should see a status"""
@@ -193,6 +193,6 @@ class Activitystreams(TestCase):
             book=self.book,
         )
         users = self.test_stream.get_audience(status)
-        self.assertFalse(self.local_user in users)
-        self.assertFalse(self.another_user in users)
-        self.assertFalse(self.remote_user in users)
+        self.assertFalse(self.local_user.id in users)
+        self.assertFalse(self.another_user.id in users)
+        self.assertFalse(self.remote_user.id in users)

--- a/bookwyrm/tests/activitystreams/test_abstractstream.py
+++ b/bookwyrm/tests/activitystreams/test_abstractstream.py
@@ -57,7 +57,7 @@ class Activitystreams(TestCase):
             f"{self.local_user.id}-test",
         )
         self.assertEqual(
-            self.test_stream.unread_id(self.local_user),
+            self.test_stream.unread_id(self.local_user.id),
             f"{self.local_user.id}-test-unread",
         )
 

--- a/bookwyrm/tests/activitystreams/test_abstractstream.py
+++ b/bookwyrm/tests/activitystreams/test_abstractstream.py
@@ -64,7 +64,7 @@ class Activitystreams(TestCase):
     def test_unread_by_status_type_id(self, *_):
         """stream for status type"""
         self.assertEqual(
-            self.test_stream.unread_by_status_type_id(self.local_user),
+            self.test_stream.unread_by_status_type_id(self.local_user.id),
             f"{self.local_user.id}-test-unread-by-type",
         )
 

--- a/bookwyrm/tests/activitystreams/test_homestream.py
+++ b/bookwyrm/tests/activitystreams/test_homestream.py
@@ -44,7 +44,7 @@ class Activitystreams(TestCase):
             user=self.remote_user, content="hi", privacy="public"
         )
         users = activitystreams.HomeStream().get_audience(status)
-        self.assertFalse(users.exists())
+        self.assertEqual(users, [])
 
     def test_homestream_get_audience_with_mentions(self, *_):
         """get a list of users that should see a status"""
@@ -53,8 +53,8 @@ class Activitystreams(TestCase):
         )
         status.mention_users.add(self.local_user)
         users = activitystreams.HomeStream().get_audience(status)
-        self.assertFalse(self.local_user in users)
-        self.assertFalse(self.another_user in users)
+        self.assertFalse(self.local_user.id in users)
+        self.assertFalse(self.another_user.id in users)
 
     def test_homestream_get_audience_with_relationship(self, *_):
         """get a list of users that should see a status"""
@@ -63,5 +63,5 @@ class Activitystreams(TestCase):
             user=self.remote_user, content="hi", privacy="public"
         )
         users = activitystreams.HomeStream().get_audience(status)
-        self.assertTrue(self.local_user in users)
-        self.assertFalse(self.another_user in users)
+        self.assertTrue(self.local_user.id in users)
+        self.assertFalse(self.another_user.id in users)

--- a/bookwyrm/tests/activitystreams/test_localstream.py
+++ b/bookwyrm/tests/activitystreams/test_localstream.py
@@ -54,8 +54,8 @@ class Activitystreams(TestCase):
             user=self.local_user, content="hi", privacy="public"
         )
         users = activitystreams.LocalStream().get_audience(status)
-        self.assertTrue(self.local_user in users)
-        self.assertTrue(self.another_user in users)
+        self.assertTrue(self.local_user.id in users)
+        self.assertTrue(self.another_user.id in users)
 
     def test_localstream_get_audience_unlisted(self, *_):
         """get a list of users that should see a status"""
@@ -88,7 +88,7 @@ class Activitystreams(TestCase):
         )
         # yes book, yes audience
         audience = activitystreams.BooksStream().get_audience(status)
-        self.assertTrue(self.local_user in audience)
+        self.assertTrue(self.local_user.id in audience)
 
     def test_localstream_get_audience_books_book_field(self, *_):
         """get a list of users that should see a status"""
@@ -102,7 +102,7 @@ class Activitystreams(TestCase):
         )
         # yes book, yes audience
         audience = activitystreams.BooksStream().get_audience(status)
-        self.assertTrue(self.local_user in audience)
+        self.assertTrue(self.local_user.id in audience)
 
     def test_localstream_get_audience_books_alternate_edition(self, *_):
         """get a list of users that should see a status"""
@@ -119,7 +119,7 @@ class Activitystreams(TestCase):
         )
         # yes book, yes audience
         audience = activitystreams.BooksStream().get_audience(status)
-        self.assertTrue(self.local_user in audience)
+        self.assertTrue(self.local_user.id in audience)
 
     def test_localstream_get_audience_books_non_public(self, *_):
         """get a list of users that should see a status"""


### PR DESCRIPTION
See #2720.

I decided the easiest way to do this was to refactor the code to mostly pass around user IDs instead of entire user objects, since that's all we use anyways, so the first few commits are just doing that.