### PR TITLE
Fix dbshell command

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -32,8 +32,8 @@ function runweb {
     docker-compose run --rm web "$@"
 }
 
-function rundb {
-    docker-compose run --rm db $@
+function execdb {
+    docker-compose exec db $@
 }
 
 function execweb {
@@ -110,7 +110,7 @@ case "$CMD" in
         runweb python manage.py shell
         ;;
     dbshell)
-        rundb psql -U ${POSTGRES_USER} ${POSTGRES_DB}
+        execdb psql -U ${POSTGRES_USER} ${POSTGRES_DB}
         ;;
     restart_celery)
         docker-compose restart celery_worker


### PR DESCRIPTION
dbshell needs to be run in a already-running container, thus exec rather than run is the correct docker-compose command.