### PR TITLE
Use context processor for 500 page

### DIFF
--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -773,3 +773,6 @@ urlpatterns = [
     ),
     path("guided-tour/<tour>", views.toggle_guided_tour),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# pylint: disable=invalid-name
+handler500 = "bookwyrm.views.server_error"

--- a/bookwyrm/views/__init__.py
+++ b/bookwyrm/views/__init__.py
@@ -165,3 +165,4 @@ from .annual_summary import (
     summary_add_key,
     summary_revoke_key,
 )
+from .server_error import server_error

--- a/bookwyrm/views/server_error.py
+++ b/bookwyrm/views/server_error.py
@@ -1,0 +1,8 @@
+"""custom 500 handler to enable context processors"""
+from django.template.response import TemplateResponse
+
+
+def server_error(request):
+    """server error page"""
+
+    return TemplateResponse(request, "500.html")


### PR DESCRIPTION
By default, Django doesn't run any context processors for server errors, to make the error path as simple as possible. However, this has the downside that our template does not load correctly. To fix this, I added a custom 500 error handler, which will run the context processor.

Fixes: #2736