### PR TITLE
Add message about shelf privacy in user settings

### DIFF
--- a/bookwyrm/templates/preferences/edit_user.html
+++ b/bookwyrm/templates/preferences/edit_user.html
@@ -131,6 +131,10 @@
                     {{ form.default_post_privacy }}
                 </div>
             </div>
+            {% url 'user-shelves' request.user.localname as path %}
+            <p class="notification is-light">
+                {% blocktrans %}Looking for shelf privacy? You can set a sepearate visibility level for each of your shelves. Go to <a href="{{ path }}">Your Books</a>, pick a shelf from the tab bar, and click "Edit shelf."{% endblocktrans %}
+            </p>
         </div>
     </section>
     <div class="field"><button class="button is-primary" type="submit">{% trans "Save" %}</button></div>


### PR DESCRIPTION
Following up from #2748, here's a very small PR to add a hint about where to find shelf privacy. I think it could still be nice to further refine how privacy works in Bookwyrm, but hopefully this is a step towards alleviating some of the confusion of having privacy settings that exist in very different places.

I just did this in the Github in-browser editor, so please double-check that I'm not just proposing nonsense -- I have no idea how Django templating works!

The url comes from [`user_menu.html`](https://github.com/bookwyrm-social/bookwyrm/blob/e9d08e7424d66c9a7b45a6853ec8fae09e7f74c0/bookwyrm/templates/user_menu.html#L38-L40); the url binding and locale block format is cribbed [a little up the file in `edit_user.html`](https://github.com/bookwyrm-social/bookwyrm/blob/e9d08e7424d66c9a7b45a6853ec8fae09e7f74c0/bookwyrm/templates/preferences/edit_user.html#L83-L86) (but I don't know how scoping works and whether it's ok to redeclare `path` like this). The `notification` class is [used in `delete_user.html`](https://github.com/bookwyrm-social/bookwyrm/blob/e9d08e7424d66c9a7b45a6853ec8fae09e7f74c0/bookwyrm/templates/preferences/delete_user.html#L14-L16), though I've removed the additional colour class (`is-link`).