### PR TITLE
Added command 'down', to bring down containers

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -287,6 +287,7 @@ case "$CMD" in
         echo "Unrecognised command. Try:"
         echo "    setup"
         echo "    up [container]"
+        echo "    down [container]"        
         echo "    service_ports_web"
         echo "    initdb"
         echo "    resetdb"

--- a/bw-dev
+++ b/bw-dev
@@ -77,6 +77,9 @@ case "$CMD" in
     up)
         docker-compose up --build "$@"
         ;;
+    down)
+        docker-compose down
+        ;;
     service_ports_web)
         prod_error
         docker-compose run --rm --service-ports web


### PR DESCRIPTION
Added the command 'down', which can be used to bring down the docker containers. Equivalent to running 'docker-compose down'