### PR TITLE
Small quality of life improvements to list handling

### DIFF
--- a/bookwyrm/templates/lists/created_text.html
+++ b/bookwyrm/templates/lists/created_text.html
@@ -3,7 +3,7 @@
 
 {% if list.curation == 'group' %}
 {% blocktrans with username=list.user.display_name userpath=list.user.local_path groupname=list.group.name grouppath=list.group.local_path %}Created by <a href="{{ userpath }}">{{ username }}</a> and managed by <a href="{{ grouppath }}">{{ groupname }}</a>{% endblocktrans %}
-{% elif list.curation != 'open' %}
+{% elif list.curation == 'curated' %}
 {% blocktrans with username=list.user.display_name path=list.user.local_path %}Created and curated by <a href="{{ path }}">{{ username }}</a>{% endblocktrans %}
 {% else %}
 {% blocktrans with username=list.user.display_name path=list.user.local_path %}Created by <a href="{{ path }}">{{ username }}</a>{% endblocktrans %}

--- a/bookwyrm/views/list/list.py
+++ b/bookwyrm/views/list/list.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from django.db.models import Avg, DecimalField, Q, Max
 from django.db.models.functions import Coalesce
 from django.http import HttpResponseBadRequest, HttpResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -183,7 +183,7 @@ def delete_list(request, list_id):
     book_list.raise_not_deletable(request.user)
 
     book_list.delete()
-    return redirect_to_referer(request, "lists")
+    return redirect("/list")
 
 
 @require_POST


### PR DESCRIPTION
This small PR improves the clarity of the list status, as closed lists currently say they are curated, which led me to wonder why I couldn't suggest titles to add. I also got a stack trace in debug mode/404 in production on deleting a list as it returns the user to the now-deleted list. I changed it to return back to the /list view that shows all the lists (now minus the deleted one).