### PR TITLE
Increase network timeout in Celery tasks

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -226,7 +226,7 @@ STREAMS = [
 # total time in seconds that the instance will spend searching connectors
 SEARCH_TIMEOUT = env.int("SEARCH_TIMEOUT", 8)
 # timeout for a query to an individual connector
-QUERY_TIMEOUT = env.int("QUERY_TIMEOUT", 5)
+QUERY_TIMEOUT = env.int("INTERACTIVE_QUERY_TIMEOUT", env.int("QUERY_TIMEOUT", 5))
 
 # Redis cache backend
 if env.bool("USE_DUMMY_CACHE", False):

--- a/celerywyrm/settings.py
+++ b/celerywyrm/settings.py
@@ -3,6 +3,8 @@
 # pylint: disable=unused-wildcard-import
 from bookwyrm.settings import *
 
+QUERY_TIMEOUT = env.int("CELERY_QUERY_TIMEOUT", env.int("QUERY_TIMEOUT", 30))
+
 # pylint: disable=line-too-long
 REDIS_BROKER_PASSWORD = requests.utils.quote(env("REDIS_BROKER_PASSWORD", ""))
 REDIS_BROKER_HOST = env("REDIS_BROKER_HOST", "redis_broker")


### PR DESCRIPTION
Since Celery tasks don't affect interactive latency, we should have a more generous timeout. This also allows admins to set the timeout for Celery and the web frontend separately, without breaking backwards compatibility with the previous environment variable.