### PR TITLE
Fix two places where the reading status shelf name wasn’t translated

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -4,6 +4,7 @@
 {% load humanize %}
 {% load utilities %}
 {% load static %}
+{% load shelf_tags %}
 
 {% block title %}{{ book|book_title }}{% endblock %}
 
@@ -239,7 +240,7 @@
                 <ul>
                 {% for shelf in user_shelfbooks %}
                     <li class="box">
-                        <a href="{{ shelf.shelf.local_path }}">{{ shelf.shelf.name }}</a>
+                        <a href="{{ shelf.shelf.local_path }}">{{ shelf.shelf|translate_shelf_name }}</a>
                         <div class="is-pulled-right">
                             {% include 'snippets/shelf_selector.html' with shelf=shelf.shelf class="is-small" readthrough=readthrough %}
                         </div>

--- a/bookwyrm/templatetags/shelf_tags.py
+++ b/bookwyrm/templatetags/shelf_tags.py
@@ -14,6 +14,7 @@ SHELF_NAMES = {
     "to-read": _("To Read"),
     "reading": _("Currently Reading"),
     "read": _("Read"),
+    "stopped-reading": _("Stopped Reading"),
 }
 
 

--- a/bookwyrm/templatetags/shelf_tags.py
+++ b/bookwyrm/templatetags/shelf_tags.py
@@ -9,6 +9,14 @@ from bookwyrm.utils import cache
 register = template.Library()
 
 
+SHELF_NAMES = {
+    "all": _("All books"),
+    "to-read": _("To Read"),
+    "reading": _("Currently Reading"),
+    "read": _("Read"),
+}
+
+
 @register.filter(name="is_book_on_shelf")
 def get_is_book_on_shelf(book, shelf):
     """is a book on a shelf"""
@@ -42,15 +50,11 @@ def get_translated_shelf_name(shelf):
         return ""
     # support obj or dict
     identifier = shelf["identifier"] if isinstance(shelf, dict) else shelf.identifier
-    if identifier == "all":
-        return _("All books")
-    if identifier == "to-read":
-        return _("To Read")
-    if identifier == "reading":
-        return _("Currently Reading")
-    if identifier == "read":
-        return _("Read")
-    return shelf["name"] if isinstance(shelf, dict) else shelf.name
+
+    try:
+        return SHELF_NAMES[identifier]
+    except KeyError:
+        return shelf["name"] if isinstance(shelf, dict) else shelf.name
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
- In the list of shelves on the page for a book, the name of the reading status shelf was always in English.
- The “stopped-reading” status shelf was never translated.