### PR TITLE
Pass allow_external_connections through ignore_activity

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -127,7 +127,7 @@ class ActivityObject:
         if (
             allow_create
             and hasattr(model, "ignore_activity")
-            and model.ignore_activity(self)
+            and model.ignore_activity(self, allow_external_connections)
         ):
             return None
 

--- a/bookwyrm/models/favorite.py
+++ b/bookwyrm/models/favorite.py
@@ -20,8 +20,9 @@ class Favorite(ActivityMixin, BookWyrmModel):
 
     activity_serializer = activitypub.Like
 
+    # pylint: disable=unused-argument
     @classmethod
-    def ignore_activity(cls, activity):
+    def ignore_activity(cls, activity, allow_external_connections=True):
         """don't bother with incoming favs of unknown statuses"""
         return not Status.objects.filter(remote_id=activity.object).exists()
 

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -116,10 +116,16 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         return list(set(mentions))
 
     @classmethod
-    def ignore_activity(cls, activity):  # pylint: disable=too-many-return-statements
+    def ignore_activity(
+        cls, activity, allow_external_connections=True
+    ):  # pylint: disable=too-many-return-statements
         """keep notes if they are replies to existing statuses"""
         if activity.type == "Announce":
-            boosted = activitypub.resolve_remote_id(activity.object, get_activity=True)
+            boosted = activitypub.resolve_remote_id(
+                activity.object,
+                get_activity=True,
+                allow_external_connections=allow_external_connections,
+            )
             if not boosted:
                 # if we can't load the status, definitely ignore it
                 return True


### PR DESCRIPTION
Previously, ignore_activity could unexpectedly make a outgoing HTTP connection, leading to unwanted latency, particularly when called via ActivityObject.to_model, which had the allow_external_connections parameter already.

Related: #2717