### PR TITLE
Add automatic instrumentation to Postgres queries

### DIFF
--- a/bookwyrm/apps.py
+++ b/bookwyrm/apps.py
@@ -40,6 +40,7 @@ class BookwyrmConfig(AppConfig):
             from bookwyrm.telemetry import open_telemetry
 
             open_telemetry.instrumentDjango()
+            open_telemetry.instrumentPostgres()
 
         if settings.ENABLE_PREVIEW_IMAGES and settings.FONTS:
             # Download any fonts that we don't have yet

--- a/bookwyrm/telemetry/open_telemetry.py
+++ b/bookwyrm/telemetry/open_telemetry.py
@@ -22,6 +22,12 @@ def instrumentDjango():
     DjangoInstrumentor().instrument()
 
 
+def instrumentPostgres():
+    from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
+
+    Psycopg2Instrumentor().instrument()
+
+
 def instrumentCelery():
     from opentelemetry.instrumentation.celery import CeleryInstrumentor
     from celery.signals import worker_process_init

--- a/celerywyrm/apps.py
+++ b/celerywyrm/apps.py
@@ -11,3 +11,4 @@ class CelerywyrmConfig(AppConfig):
             from bookwyrm.telemetry import open_telemetry
 
             open_telemetry.instrumentCelery()
+            open_telemetry.instrumentPostgres()

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ opentelemetry-api==1.16.0
 opentelemetry-exporter-otlp-proto-grpc==1.16.0
 opentelemetry-instrumentation-celery==0.37b0
 opentelemetry-instrumentation-django==0.37b0
+opentelemetry-instrumentation-psycopg2==0.37b0
 opentelemetry-sdk==1.16.0
 protobuf==3.20.*
 pyotp==2.8.0


### PR DESCRIPTION
This enables automatic instrumentation of Postgres queries when OpenTelemetry instrumentation is enabled, which will help with debugging performance problems.