### PR TITLE
Fix Accept header for requesting ActivityPub objects

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -384,7 +384,8 @@ def get_activitypub_data(url):
         resp = requests.get(
             url,
             headers={
-                "Accept": "application/json; charset=utf-8",
+                # pylint: disable=line-too-long
+                "Accept": 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
                 "Date": now,
                 "Signature": make_signature("get", sender, url, now),
             },


### PR DESCRIPTION
This is the header described in the ActivityPub spec, which should fix some federation problems with GoToSocial and potentially other picky services.

Related: #2794, https://github.com/superseriousbusiness/gotosocial/issues/1676