### PR TITLE
Don't show the series as a link if the book has no author

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -46,7 +46,13 @@
                         <meta itemprop="isPartOf" content="{{ book.series | escape }}">
                         <meta itemprop="volumeNumber" content="{{ book.series_number }}">
 
-                        (<a href="{% url 'book-series-by' book.authors.first.id %}?series_name={{ book.series }}">{{ book.series }}{% if book.series_number %} #{{ book.series_number }}{% endif %}</a>)
+                        {% if book.authors.exists %}
+                            <a href="{% url 'book-series-by' book.authors.first.id %}?series_name={{ book.series }}">
+                        {% endif %}
+                        {{ book.series }}{% if book.series_number %} #{{ book.series_number }}{% endif %}
+                        {% if book.authors.exists %}
+                            </a>
+                        {% endif %}
                     {% endif %}
                 </p>
             {% endif %}


### PR DESCRIPTION
The series link needs an author so if it doesn't have one, instead of showing a server error let's just show the series details as plain text without a link.

Fixes: #2797