### PR TITLE
accept hs2019-obfuscated http signatures

### DIFF
--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -57,7 +57,7 @@ def make_digest(data):
 def verify_digest(request):
     """checks if a digest is syntactically valid and matches the message"""
     algorithm, digest = request.headers["digest"].split("=", 1)
-    if algorithm == "SHA-256":
+    if algorithm == "SHA-256" or algorithm == "hs2019":
         hash_function = hashlib.sha256
     elif algorithm == "SHA-512":
         hash_function = hashlib.sha512
@@ -65,8 +65,12 @@ def verify_digest(request):
         raise ValueError(f"Unsupported hash function: {algorithm}")
 
     expected = hash_function(request.body).digest()
+    if algorithm == "hs2019" and b64decode(digest) != expected:
+        hash_function = hashlib.sha512
+        expected = hash_function(request.body).digest()
+
     if b64decode(digest) != expected:
-        raise ValueError("Invalid HTTP Digest header")
+        raise ValueError(f"Invalid HTTP Digest header: {algorithm}")
 
 
 class Signature:


### PR DESCRIPTION
Partial fix for #2794 (can't follow to/from GoToSocial)

hs2019 is used by some libraries to obfuscate the real algorithm per the spec https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12