### PR TITLE
Fix federation with GoToSocial and inconsistent KeyId in headers

### DIFF
--- a/bookwyrm/activitypub/__init__.py
+++ b/bookwyrm/activitypub/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from .base_activity import ActivityEncoder, Signature, naive_parse
 from .base_activity import Link, Mention, Hashtag
-from .base_activity import ActivitySerializerError, resolve_remote_id, get_activitypub_data
+from .base_activity import ActivitySerializerError, resolve_remote_id
 from .image import Document, Image
 from .note import Note, GeneratedNote, Article, Comment, Quotation
 from .note import Review, Rating

--- a/bookwyrm/activitypub/__init__.py
+++ b/bookwyrm/activitypub/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from .base_activity import ActivityEncoder, Signature, naive_parse
 from .base_activity import Link, Mention, Hashtag
-from .base_activity import ActivitySerializerError, resolve_remote_id
+from .base_activity import ActivitySerializerError, resolve_remote_id, get_activitypub_data
 from .image import Document, Image
 from .note import Note, GeneratedNote, Article, Comment, Quotation
 from .note import Review, Rating

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -540,7 +540,6 @@ async def sign_and_send(
 
     digest = make_digest(data)
 
-
     headers = {
         "Date": now,
         "Digest": digest,
@@ -557,14 +556,20 @@ async def sign_and_send(
                 )
                 logger.info("Trying again with legacy keyId")
                 # try with incorrect keyId to enable communication with legacy Bookwyrm servers
-                legacy_signature = make_signature("post", sender, destination, now, digest, True)
+                legacy_signature = make_signature(
+                    "post", sender, destination, now, digest, True
+                )
                 headers["Signature"] = legacy_signature
-                async with session.post(destination, data=data, headers=headers) as response: 
+                async with session.post(
+                    destination, data=data, headers=headers
+                ) as response:
                     if not response.ok:
                         logger.exception(
-                        "Failed to send broadcast with legacy keyId to %s: %s", destination, response.reason
-                    )
-                
+                            "Failed to send broadcast with legacy keyId to %s: %s",
+                            destination,
+                            response.reason,
+                        )
+
             return response
     except asyncio.TimeoutError:
         logger.info("Connection timed out for url: %s", destination)

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -540,7 +540,7 @@ async def sign_and_send(
 
     digest = make_digest(data)
     signature = make_signature(
-        "post", sender, destination, now, digest, kwargs.get("use_legacy_key")
+        "post", sender, destination, now, digest=digest, use_legacy_key=kwargs.get("use_legacy_key")
     )
 
     headers = {

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -563,9 +563,7 @@ async def sign_and_send(
                     "Failed to send broadcast to %s: %s", destination, response.reason
                 )
                 if kwargs.get("use_legacy_key") is not True:
-                    # try with incorrect keyId to enable communication with legacy Bookwyrm servers
                     logger.info("Trying again with legacy keyId header value")
-
                     asyncio.ensure_future(
                         sign_and_send(
                             session, sender, data, destination, use_legacy_key=True

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -540,7 +540,12 @@ async def sign_and_send(
 
     digest = make_digest(data)
     signature = make_signature(
-        "post", sender, destination, now, digest=digest, use_legacy_key=kwargs.get("use_legacy_key")
+        "post",
+        sender,
+        destination,
+        now,
+        digest=digest,
+        use_legacy_key=kwargs.get("use_legacy_key"),
     )
 
     headers = {

--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -379,7 +379,12 @@ class TagField(ManyToManyField):
 
     def field_from_activity(self, value, allow_external_connections=True):
         if not isinstance(value, list):
-            return None
+            # GoToSocial DMs and single-user mentions are
+            # sent as objects, not as an array of objects
+            if isinstance(value, dict):
+                value = [value]
+            else: 
+                return None
         items = []
         for link_json in value:
             link = activitypub.Link(**link_json)

--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -371,7 +371,7 @@ class TagField(ManyToManyField):
             tags.append(
                 activitypub.Link(
                     href=item.remote_id,
-                    name=getattr(item, item.name_field),
+                    name=f"@{getattr(item, item.name_field)}",
                     type=activity_type,
                 )
             )

--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -383,7 +383,7 @@ class TagField(ManyToManyField):
             # sent as objects, not as an array of objects
             if isinstance(value, dict):
                 value = [value]
-            else: 
+            else:
                 return None
         items = []
         for link_json in value:

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -137,9 +137,9 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         if activity.tag == MISSING or activity.tag is None:
             return True
 
-        # BUG: this fixes the TypeError but we still don't get any notifs
-        # and DMs are dropped
-        tags = activity.tag if type(activity.tag) == list else [activity.tag]
+        # BUG: this fixes the TypeError but if there is only one user mentioned
+        # we still don't get any notifs and DMs are dropped.
+        tags = activity.tag if type(activity.tag) == list else [ activity.tag ]
         user_model = apps.get_model("bookwyrm.User", require_ready=True)
         for tag in tags:
             if (

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -138,7 +138,7 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
             return True
         # GoToSocial sends single tags as objects
         # not wrapped in a list
-        tags = activity.tag if isinstance(activity.tag, list) else [ activity.tag ]
+        tags = activity.tag if isinstance(activity.tag, list) else [activity.tag]
         user_model = apps.get_model("bookwyrm.User", require_ready=True)
         for tag in tags:
             if (

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -136,10 +136,16 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         # keep notes if they mention local users
         if activity.tag == MISSING or activity.tag is None:
             return True
-        tags = [l["href"] for l in activity.tag if l["type"] == "Mention"]
+
+        tags = activity.tag if type(activity.tag) == list else [activity.tag]
         user_model = apps.get_model("bookwyrm.User", require_ready=True)
         for tag in tags:
-            if user_model.objects.filter(remote_id=tag, local=True).exists():
+            if (
+                tag["type"] == "Mention"
+                and user_model.objects.filter(
+                    remote_id=tag["href"], local=True
+                ).exists()
+            ):
                 # we found a mention of a known use boost
                 return False
         return True

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -136,10 +136,9 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         # keep notes if they mention local users
         if activity.tag == MISSING or activity.tag is None:
             return True
-
-        # BUG: this fixes the TypeError but if there is only one user mentioned
-        # we still don't get any notifs and DMs are dropped.
-        tags = activity.tag if type(activity.tag) == list else [ activity.tag ]
+        # GoToSocial sends single tags as objects
+        # not wrapped in a list
+        tags = activity.tag if isinstance(activity.tag, list) else [ activity.tag ]
         user_model = apps.get_model("bookwyrm.User", require_ready=True)
         for tag in tags:
             if (

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -137,6 +137,8 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         if activity.tag == MISSING or activity.tag is None:
             return True
 
+        # BUG: this fixes the TypeError but we still don't get any notifs
+        # and DMs are dropped
         tags = activity.tag if type(activity.tag) == list else [activity.tag]
         user_model = apps.get_model("bookwyrm.User", require_ready=True)
         for tag in tags:

--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -22,7 +22,9 @@ def create_key_pair():
     return private_key, public_key
 
 
-def make_signature(method, sender, destination, date, digest=None, use_legacy_key=False):
+def make_signature(
+    method, sender, destination, date, digest=None, use_legacy_key=False
+):
     """uses a private key to sign an outgoing message"""
     inbox_parts = urlparse(destination)
     signature_headers = [
@@ -39,7 +41,11 @@ def make_signature(method, sender, destination, date, digest=None, use_legacy_ke
     signer = pkcs1_15.new(RSA.import_key(sender.key_pair.private_key))
     signed_message = signer.sign(SHA256.new(message_to_sign.encode("utf8")))
     # For legacy reasons we need to use an incorrect keyId for older Bookwyrm versions
-    key_id = f"{sender.remote_id}#main-key" if use_legacy_key else f"{sender.remote_id}/#main-key"
+    key_id = (
+        f"{sender.remote_id}#main-key"
+        if use_legacy_key
+        else f"{sender.remote_id}/#main-key"
+    )
     signature = {
         "keyId": key_id,
         "algorithm": "rsa-sha256",

--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -23,7 +23,7 @@ def create_key_pair():
 
 
 def make_signature(
-    method, sender, destination, date, digest=None, use_legacy_key=False
+    method, sender, destination, date, **kwargs
 ):
     """uses a private key to sign an outgoing message"""
     inbox_parts = urlparse(destination)
@@ -33,6 +33,7 @@ def make_signature(
         f"date: {date}",
     ]
     headers = "(request-target) host date"
+    digest = kwargs.get("digest")
     if digest is not None:
         signature_headers.append(f"digest: {digest}")
         headers = "(request-target) host date digest"
@@ -43,7 +44,7 @@ def make_signature(
     # For legacy reasons we need to use an incorrect keyId for older Bookwyrm versions
     key_id = (
         f"{sender.remote_id}#main-key"
-        if use_legacy_key
+        if kwargs.get("use_legacy_key")
         else f"{sender.remote_id}/#main-key"
     )
     signature = {

--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -38,7 +38,6 @@ def make_signature(method, sender, destination, date, digest=None):
     message_to_sign = "\n".join(signature_headers)
     signer = pkcs1_15.new(RSA.import_key(sender.key_pair.private_key))
     signed_message = signer.sign(SHA256.new(message_to_sign.encode("utf8")))
-    # TODO: this should be /#main-key to match our user key ids, even though that was probably a mistake in hindsight.
     signature = {
         "keyId": f"{sender.remote_id}/#main-key",
         "algorithm": "rsa-sha256",

--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -38,8 +38,9 @@ def make_signature(method, sender, destination, date, digest=None):
     message_to_sign = "\n".join(signature_headers)
     signer = pkcs1_15.new(RSA.import_key(sender.key_pair.private_key))
     signed_message = signer.sign(SHA256.new(message_to_sign.encode("utf8")))
+    # TODO: this should be /#main-key to match our user key ids, even though that was probably a mistake in hindsight.
     signature = {
-        "keyId": f"{sender.remote_id}#main-key",
+        "keyId": f"{sender.remote_id}/#main-key",
         "algorithm": "rsa-sha256",
         "headers": headers,
         "signature": b64encode(signed_message).decode("utf8"),

--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -22,9 +22,7 @@ def create_key_pair():
     return private_key, public_key
 
 
-def make_signature(
-    method, sender, destination, date, **kwargs
-):
+def make_signature(method, sender, destination, date, **kwargs):
     """uses a private key to sign an outgoing message"""
     inbox_parts = urlparse(destination)
     signature_headers = [

--- a/bookwyrm/tests/models/test_fields.py
+++ b/bookwyrm/tests/models/test_fields.py
@@ -404,7 +404,7 @@ class ModelFields(TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].href, "https://e.b/c")
-        self.assertEqual(result[0].name, "Name")
+        self.assertEqual(result[0].name, "@Name")
         self.assertEqual(result[0].type, "Serializable")
 
     def test_tag_field_from_activity(self, *_):

--- a/bookwyrm/tests/test_signing.py
+++ b/bookwyrm/tests/test_signing.py
@@ -159,7 +159,7 @@ class Signature(TestCase):
                 "bookwyrm.models.relationship.UserFollowRequest.accept"
             ) as accept_mock:
                 response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 200) #BUG this is 401
+            self.assertEqual(response.status_code, 200)  # BUG this is 401
             self.assertTrue(accept_mock.called)
 
             # Old key is cached, so still works:

--- a/bookwyrm/tests/test_signing.py
+++ b/bookwyrm/tests/test_signing.py
@@ -111,6 +111,7 @@ class Signature(TestCase):
         datafile = pathlib.Path(__file__).parent.joinpath("data/ap_user.json")
         data = json.loads(datafile.read_bytes())
         data["id"] = self.fake_remote.remote_id
+        data["publicKey"]["id"] = f"{self.fake_remote.remote_id}/#main-key"
         data["publicKey"]["publicKeyPem"] = self.fake_remote.key_pair.public_key
         del data["icon"]  # Avoid having to return an avatar.
         responses.add(responses.GET, self.fake_remote.remote_id, json=data, status=200)
@@ -138,6 +139,7 @@ class Signature(TestCase):
         datafile = pathlib.Path(__file__).parent.joinpath("data/ap_user.json")
         data = json.loads(datafile.read_bytes())
         data["id"] = self.fake_remote.remote_id
+        data["publicKey"]["id"] = f"{self.fake_remote.remote_id}/#main-key"
         data["publicKey"]["publicKeyPem"] = self.fake_remote.key_pair.public_key
         del data["icon"]  # Avoid having to return an avatar.
         responses.add(responses.GET, self.fake_remote.remote_id, json=data, status=200)
@@ -157,7 +159,7 @@ class Signature(TestCase):
                 "bookwyrm.models.relationship.UserFollowRequest.accept"
             ) as accept_mock:
                 response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200) #BUG this is 401
             self.assertTrue(accept_mock.called)
 
             # Old key is cached, so still works:

--- a/bookwyrm/tests/test_signing.py
+++ b/bookwyrm/tests/test_signing.py
@@ -87,7 +87,7 @@ class Signature(TestCase):
         data = json.dumps(get_follow_activity(sender, self.rat))
         digest = digest or make_digest(data)
         signature = make_signature(
-            "post", signer or sender, self.rat.inbox, now, digest
+            "post", signer or sender, self.rat.inbox, now, digest=digest
         )
         with patch("bookwyrm.views.inbox.activity_task.apply_async"):
             with patch("bookwyrm.models.user.set_remote_server.delay"):

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -137,7 +137,8 @@ def has_valid_signature(request, activity):
             return False
 
         if signature.key_id != remote_user.key_pair.remote_id:
-            raise ValueError("Wrong actor created signature.")
+            if signature.key_id != f"{remote_user.remote_id}#main-key": # legacy Bookwyrm
+                raise ValueError("Wrong actor created signature.")
 
         try:
             signature.verify(remote_user.key_pair.public_key, request)

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -137,7 +137,9 @@ def has_valid_signature(request, activity):
             return False
 
         if signature.key_id != remote_user.key_pair.remote_id:
-            if signature.key_id != f"{remote_user.remote_id}#main-key": # legacy Bookwyrm
+            if (
+                signature.key_id != f"{remote_user.remote_id}#main-key"
+            ):  # legacy Bookwyrm
                 raise ValueError("Wrong actor created signature.")
 
         try:

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -130,7 +130,9 @@ def has_valid_signature(request, activity):
     """verify incoming signature"""
     try:
         signature = Signature.parse(request)
-        remote_user = activitypub.resolve_remote_id(activity.get("actor"), model=models.User)
+        remote_user = activitypub.resolve_remote_id(
+            activity.get("actor"), model=models.User
+        )
         if not remote_user:
             return False
 

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -3,7 +3,6 @@ import json
 import re
 import logging
 
-from urllib.parse import urldefrag
 import requests
 
 from django.http import HttpResponse, Http404

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -130,14 +130,12 @@ def has_valid_signature(request, activity):
     """verify incoming signature"""
     try:
         signature = Signature.parse(request)
-
-        key_actor = urldefrag(signature.key_id).url
-        if key_actor != activity.get("actor"):
-            raise ValueError("Wrong actor created signature.")
-
-        remote_user = activitypub.resolve_remote_id(key_actor, model=models.User)
+        remote_user = activitypub.resolve_remote_id(activity.get("actor"), model=models.User)
         if not remote_user:
             return False
+
+        if signature.key_id != remote_user.key_pair.remote_id:
+            raise ValueError("Wrong actor created signature.")
 
         try:
             signature.verify(remote_user.key_pair.public_key, request)


### PR DESCRIPTION
Fixes #2801
Fixes #2794

This PR resolves a number of problems specific to GoToSocial federation but also potentially affecting other fediverse software.

## Fix making assumptions about location of `main-key`

It is legitimate to use any url for the user's key id. We have been assuming this id is the user id plus a fragment (`{userid}#main-key`) but this is not always the case, notably in the case of GoToSocial it is at `{userid}/main-key`. This commit instead checks the remote user's information to see if the key id listed matches the key id of the message allegedly received from them.

This resolves most of the `401` errors when trying to communicate with GtS servers.

## Fix Bookwyrm using wrong keyId in signed request headers

Whilst troubleshooting this it also became apparent that there is a mismatch between Bookwyrm users' keyId and the keyId we claim to be using in signed requests:

* Actual keyId defined in `User`: `{userid}/#main-key`
* keyId stated in signed request headers: `{userid}#main-key`

This commit changes the keyId listed in request headers to align with that assigned to users on creation.

## Fix GoToSOcial DMs not appearing and single-user mentions not notifying

This error was caused by GtS sending the `tag` value for these posts as a single object (dict) rather than an array containing the object, and Bookwyrm assuming it would be an array (list).

This commit wraps the dict in a list where necessary.

## Maintain backwards compatibility with legacy Bookwyrm instances

Aligning the keyId in the signatures with the real keyId of Bookwyrm users would break compatibility with all Bookwyrm versions before this change. The PR adds some logic to re-send the request with the old (wrong) keyId in the header if the first request is rejected. As Bookwyrm instances are updated this will become less of a problem.
