### PR TITLE
Choose installed docker compose command in bw-dev

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -23,21 +23,27 @@ trap showerr EXIT
 source .env
 trap - EXIT
 
+if docker compose &> /dev/null ; then
+	DOCKER_COMPOSE="docker compose"
+else
+	DOCKER_COMPOSE="docker-compose"
+fi
+
 function clean {
-    docker-compose stop
-    docker-compose rm -f
+    $DOCKER_COMPOSE stop
+    $DOCKER_COMPOSE rm -f
 }
 
 function runweb {
-    docker-compose run --rm web "$@"
+    $DOCKER_COMPOSE run --rm web "$@"
 }
 
 function execdb {
-    docker-compose exec db $@
+    $DOCKER_COMPOSE exec db $@
 }
 
 function execweb {
-    docker-compose exec web "$@"
+    $DOCKER_COMPOSE exec web "$@"
 }
 
 function initdb {
@@ -75,23 +81,23 @@ set -x
 
 case "$CMD" in
     up)
-        docker-compose up --build "$@"
+        $DOCKER_COMPOSE up --build "$@"
         ;;
     down)
-        docker-compose down
+        $DOCKER_COMPOSE down
         ;;
     service_ports_web)
         prod_error
-        docker-compose run --rm --service-ports web
+        $DOCKER_COMPOSE run --rm --service-ports web
         ;;
     initdb)
         initdb "@"
         ;;
     resetdb)
         prod_error
-        docker-compose rm -svf
+        $DOCKER_COMPOSE rm -svf
         docker volume rm -f bookwyrm_media_volume bookwyrm_pgdata bookwyrm_redis_activity_data bookwyrm_redis_broker_data bookwyrm_static_volume
-        docker-compose build
+        $DOCKER_COMPOSE build
         migrate
         migrate django_celery_beat
         initdb
@@ -116,7 +122,7 @@ case "$CMD" in
         execdb psql -U ${POSTGRES_USER} ${POSTGRES_DB}
         ;;
     restart_celery)
-        docker-compose restart celery_worker
+        $DOCKER_COMPOSE restart celery_worker
         ;;
     pytest)
         prod_error
@@ -164,7 +170,7 @@ case "$CMD" in
         runweb django-admin compilemessages --ignore venv
         ;;
     build)
-        docker-compose build
+        $DOCKER_COMPOSE build
         ;;
     clean)
         prod_error
@@ -172,7 +178,7 @@ case "$CMD" in
         ;;
     black)
         prod_error
-        docker-compose run --rm dev-tools black celerywyrm bookwyrm
+        $DOCKER_COMPOSE run --rm dev-tools black celerywyrm bookwyrm
         ;;
     pylint)
         prod_error
@@ -181,25 +187,25 @@ case "$CMD" in
         ;;
     prettier)
         prod_error
-        docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
+        $DOCKER_COMPOSE run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
         ;;
     eslint)
         prod_error
-        docker-compose run --rm dev-tools npx eslint bookwyrm/static --ext .js
+        $DOCKER_COMPOSE run --rm dev-tools npx eslint bookwyrm/static --ext .js
         ;;
     stylelint)
         prod_error
-        docker-compose run --rm dev-tools npx stylelint \
+        $DOCKER_COMPOSE run --rm dev-tools npx stylelint \
             bookwyrm/static/css/bookwyrm.scss bookwyrm/static/css/bookwyrm/**/*.scss --fix \
             --config dev-tools/.stylelintrc.js
         ;;
     formatters)
         prod_error
         runweb pylint bookwyrm/
-        docker-compose run --rm dev-tools black celerywyrm bookwyrm
-        docker-compose run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
-        docker-compose run --rm dev-tools npx eslint bookwyrm/static --ext .js
-        docker-compose run --rm dev-tools npx stylelint \
+        $DOCKER_COMPOSE run --rm dev-tools black celerywyrm bookwyrm
+        $DOCKER_COMPOSE run --rm dev-tools npx prettier --write bookwyrm/static/js/*.js
+        $DOCKER_COMPOSE run --rm dev-tools npx eslint bookwyrm/static --ext .js
+        $DOCKER_COMPOSE run --rm dev-tools npx stylelint \
             bookwyrm/static/css/bookwyrm.scss bookwyrm/static/css/bookwyrm/**/*.scss --fix \
             --config dev-tools/.stylelintrc.js
         ;;
@@ -209,14 +215,14 @@ case "$CMD" in
         ;;
     update)
         git pull
-        docker-compose build
+        $DOCKER_COMPOSE build
         # ./update.sh
         runweb python manage.py migrate
         runweb python manage.py compile_themes
         runweb python manage.py collectstatic --no-input
-        docker-compose up -d
-        docker-compose restart web
-        docker-compose restart celery_worker
+        $DOCKER_COMPOSE up -d
+        $DOCKER_COMPOSE restart web
+        $DOCKER_COMPOSE restart celery_worker
         ;;
     populate_streams)
         runweb python manage.py populate_streams "$@"


### PR DESCRIPTION
Docker is removing support for docker-compose, and it doesn't appear to be possible to install it anymore. Instead, it has been replaced with compose V2 which is a docker plugin called with 'docker compose' (no hyphen). See https://docs.docker.com/compose/compose-v2/

Thanks to @Neriderc for noticing this in #2781.