### PR TITLE
Fix a few strings that weren’t marked as translatable

### DIFF
--- a/bookwyrm/templates/get_started/books.html
+++ b/bookwyrm/templates/get_started/books.html
@@ -30,7 +30,7 @@
         <fieldset name="books" class="columns is-mobile">
             {% if book_results %}
                 <div class="column is-narrow">
-                    <p class="help mb-0">Search results</p>
+                    <p class="help mb-0">{% trans "Search results" %}</p>
 
                     <div class="columns is-mobile">
                         {% for book in book_results %}

--- a/bookwyrm/templates/get_started/users.html
+++ b/bookwyrm/templates/get_started/users.html
@@ -5,7 +5,7 @@
 <div class="block">
     <h2 class="title is-4">{% trans "Who to follow" %}</h2>
 
-    <p class="subtitle is-6">You can follow users on other BookWyrm instances and federated services like Mastodon.</p>
+    <p class="subtitle is-6">{% trans "You can follow users on other BookWyrm instances and federated services like Mastodon." %}</p>
     <form class="field has-addons" method="get" action="{% url 'get-started-users' %}">
         <div class="control">
             <input type="text" name="query" value="{{ request.GET.query }}" class="input" placeholder="{% trans 'Search for a user' %}" aria-label="{% trans 'Search for a user' %}">

--- a/bookwyrm/templates/search/layout.html
+++ b/bookwyrm/templates/search/layout.html
@@ -29,7 +29,7 @@
         </div>
         <div class="control">
             <button type="submit" class="button is-primary">
-                <span>Search</span>
+                <span>{% trans "Search" %}</span>
                 <span class="icon icon-search" aria-hidden="true"></span>
             </button>
         </div>


### PR DESCRIPTION
- The search button for the search form in the search results page
- The title of the search results section in the getting started questionnaire
- The note about following other users in the getting started questionnaire