### PR TITLE
Add management commands to merge a pair of editions or authors

### DIFF
--- a/bookwyrm/management/commands/deduplicate_book_data.py
+++ b/bookwyrm/management/commands/deduplicate_book_data.py
@@ -1,50 +1,9 @@
 """ PROCEED WITH CAUTION: uses deduplication fields to permanently
 merge book data objects """
 from django.core.management.base import BaseCommand
-from django.db.models import Count, ManyToManyField
+from django.db.models import Count
 from bookwyrm import models
-
-
-def update_related(canonical, obj):
-    """update all the models with fk to the object being removed"""
-    # move related models to canonical
-    related_models = [
-        (r.remote_field.name, r.related_model) for r in canonical._meta.related_objects
-    ]
-    for (related_field, related_model) in related_models:
-        # Skip the ManyToMany fields that aren’t auto-created. These
-        # should have a corresponding OneToMany field in the model for
-        # the linking table anyway. If we update it through that model
-        # instead then we won’t lose the extra fields in the linking
-        # table.
-        related_field_obj = related_model._meta.get_field(related_field)
-        if isinstance(related_field_obj, ManyToManyField):
-            through = related_field_obj.remote_field.through
-            if not through._meta.auto_created:
-                continue
-        related_objs = related_model.objects.filter(**{related_field: obj})
-        for related_obj in related_objs:
-            print("replacing in", related_model.__name__, related_field, related_obj.id)
-            try:
-                setattr(related_obj, related_field, canonical)
-                related_obj.save()
-            except TypeError:
-                getattr(related_obj, related_field).add(canonical)
-                getattr(related_obj, related_field).remove(obj)
-
-
-def copy_data(canonical, obj):
-    """try to get the most data possible"""
-    for data_field in obj._meta.get_fields():
-        if not hasattr(data_field, "activitypub_field"):
-            continue
-        data_value = getattr(obj, data_field.name)
-        if not data_value:
-            continue
-        if not getattr(canonical, data_field.name):
-            print("setting data field", data_field.name, data_value)
-            setattr(canonical, data_field.name, data_value)
-    canonical.save()
+from bookwyrm.management.merge import merge_objects
 
 
 def dedupe_model(model):
@@ -71,10 +30,7 @@ def dedupe_model(model):
             print("keeping", canonical.remote_id)
             for obj in objs[1:]:
                 print(obj.remote_id)
-                copy_data(canonical, obj)
-                update_related(canonical, obj)
-                # remove the outdated entry
-                obj.delete()
+                merge_objects(canonical, obj)
 
 
 class Command(BaseCommand):

--- a/bookwyrm/management/commands/merge_authors.py
+++ b/bookwyrm/management/commands/merge_authors.py
@@ -1,0 +1,12 @@
+""" PROCEED WITH CAUTION: uses deduplication fields to permanently
+merge author data objects """
+from bookwyrm import models
+from bookwyrm.management.merge_command import MergeCommand
+
+
+class Command(MergeCommand):
+    """merges two authors by ID"""
+
+    help = "merges specified authors into one"
+
+    MODEL = models.Author

--- a/bookwyrm/management/commands/merge_editions.py
+++ b/bookwyrm/management/commands/merge_editions.py
@@ -1,0 +1,12 @@
+""" PROCEED WITH CAUTION: uses deduplication fields to permanently
+merge edition data objects """
+from bookwyrm import models
+from bookwyrm.management.merge_command import MergeCommand
+
+
+class Command(MergeCommand):
+    """merges two editions by ID"""
+
+    help = "merges specified editions into one"
+
+    MODEL = models.Edition

--- a/bookwyrm/management/merge.py
+++ b/bookwyrm/management/merge.py
@@ -1,0 +1,50 @@
+from django.db.models import ManyToManyField
+
+
+def update_related(canonical, obj):
+    """update all the models with fk to the object being removed"""
+    # move related models to canonical
+    related_models = [
+        (r.remote_field.name, r.related_model) for r in canonical._meta.related_objects
+    ]
+    for (related_field, related_model) in related_models:
+        # Skip the ManyToMany fields that aren’t auto-created. These
+        # should have a corresponding OneToMany field in the model for
+        # the linking table anyway. If we update it through that model
+        # instead then we won’t lose the extra fields in the linking
+        # table.
+        related_field_obj = related_model._meta.get_field(related_field)
+        if isinstance(related_field_obj, ManyToManyField):
+            through = related_field_obj.remote_field.through
+            if not through._meta.auto_created:
+                continue
+        related_objs = related_model.objects.filter(**{related_field: obj})
+        for related_obj in related_objs:
+            print("replacing in", related_model.__name__, related_field, related_obj.id)
+            try:
+                setattr(related_obj, related_field, canonical)
+                related_obj.save()
+            except TypeError:
+                getattr(related_obj, related_field).add(canonical)
+                getattr(related_obj, related_field).remove(obj)
+
+
+def copy_data(canonical, obj):
+    """try to get the most data possible"""
+    for data_field in obj._meta.get_fields():
+        if not hasattr(data_field, "activitypub_field"):
+            continue
+        data_value = getattr(obj, data_field.name)
+        if not data_value:
+            continue
+        if not getattr(canonical, data_field.name):
+            print("setting data field", data_field.name, data_value)
+            setattr(canonical, data_field.name, data_value)
+    canonical.save()
+
+
+def merge_objects(canonical, obj):
+    copy_data(canonical, obj)
+    update_related(canonical, obj)
+    # remove the outdated entry
+    obj.delete()

--- a/bookwyrm/management/merge_command.py
+++ b/bookwyrm/management/merge_command.py
@@ -1,0 +1,30 @@
+from bookwyrm.management.merge import merge_objects
+from django.core.management.base import BaseCommand
+
+
+class MergeCommand(BaseCommand):
+    """base class for merge commands"""
+
+    def add_arguments(self, parser):
+        """add the arguments for this command"""
+        parser.add_argument("--canonical", type=int, required=True)
+        parser.add_argument("--other", type=int, required=True)
+
+    # pylint: disable=no-self-use,unused-argument
+    def handle(self, *args, **options):
+        """merge the two objects"""
+        model = self.MODEL
+
+        try:
+            canonical = model.objects.get(id=options["canonical"])
+        except model.DoesNotExist:
+            print("canonical book doesn’t exist!")
+            return
+        try:
+            other = model.objects.get(id=options["other"])
+        except model.DoesNotExist:
+            print("other book doesn’t exist!")
+            return
+
+        merge_objects(canonical, other)
+    

--- a/bookwyrm/management/merge_command.py
+++ b/bookwyrm/management/merge_command.py
@@ -27,4 +27,3 @@ class MergeCommand(BaseCommand):
             return
 
         merge_objects(canonical, other)
-    


### PR DESCRIPTION
This is mostly a request for comments because I’m not sure if it’s a good idea. I made this because I wanted to remove a duplicate author and book from my instance. The existing `deduplicate_book_data` management command should be able to do the trick but it has a scary warning about proceeding with caution and I was too scared to let the whole script run on my live instance. This branch adds commands which use the same code to merge objects but the pair of objects are specified explicitly with command line arguments so that if it goes horribly wrong then at least the damage is limited to a small set of things.

If you use this branch you can for example merge two editions with a command like this:

```
docker-compose run --rm web python manage.py merge_editions --canonical=27 --other=38
```

All the information from the “other” edition that is missing in the “canoncial” edition will be copied over and all comments, lists and reviews etc will be changed to point to the canonical edition. Then the “other” edition will be deleted. You can find the numbers to set by visiting the page for a book and then looking at the number in the URL.

There is a second command to merge two authors like this:

```
docker-compose run --rm web python manage.py merge_authors --canonical=37 --other=96
```

Note that this branch includes the commit from PR #2818 because it’s not very useful without it.