### PR TITLE
Retain subjects and authors when new book form fails validation

### DIFF
--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -45,6 +45,7 @@ class EditBook(View):
         data = {"book": book, "form": form}
         ensure_transient_values_persist(request, data)
         if not form.is_valid():
+            ensure_transient_values_persist(request, data, add_author=True)
             return TemplateResponse(request, "book/edit/edit_book.html", data)
 
         data = add_authors(request, data)
@@ -147,6 +148,8 @@ def ensure_transient_values_persist(request, data, **kwargs):
     if kwargs and kwargs.get("form"):
         data["book"] = data.get("book") or {}
         data["book"]["subjects"] = kwargs["form"].cleaned_data["subjects"]
+        data["add_author"] = request.POST.getlist("add_author")
+    elif kwargs and kwargs.get("add_author") is True:
         data["add_author"] = request.POST.getlist("add_author")
 
 

--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -103,12 +103,12 @@ class CreateBook(View):
             }
 
         if not form.is_valid():
-            ensure_transient_values_persist(request, data, form)
+            ensure_transient_values_persist(request, data, form=form)
             return TemplateResponse(request, "book/edit/edit_book.html", data)
 
         # we have to call this twice because it requires form.cleaned_data
         # which only exists after we validate the form
-        ensure_transient_values_persist(request, data, form)
+        ensure_transient_values_persist(request, data, form=form)
         data = add_authors(request, data)
 
         # check if this is an edition of an existing work
@@ -141,10 +141,10 @@ class CreateBook(View):
         return redirect(f"/book/{book.id}")
 
 
-def ensure_transient_values_persist(request, data, form):
+def ensure_transient_values_persist(request, data, **kwargs):
     """ensure that values of transient form fields persist when re-rendering the form"""
     data["book"] = data.get("book") or {}
-    data["book"]["subjects"] = form.cleaned_data["subjects"]
+    data["book"]["subjects"] = kwargs["form"].cleaned_data["subjects"]
     data["add_author"] = request.POST.getlist("add_author")
     data["cover_url"] = request.POST.get("cover-url")
 

--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -143,10 +143,11 @@ class CreateBook(View):
 
 def ensure_transient_values_persist(request, data, **kwargs):
     """ensure that values of transient form fields persist when re-rendering the form"""
-    data["book"] = data.get("book") or {}
-    data["book"]["subjects"] = kwargs["form"].cleaned_data["subjects"]
-    data["add_author"] = request.POST.getlist("add_author")
     data["cover_url"] = request.POST.get("cover-url")
+    if kwargs and kwargs.get("form"):
+        data["book"] = data.get("book") or {}
+        data["book"]["subjects"] = kwargs["form"].cleaned_data["subjects"]
+        data["add_author"] = request.POST.getlist("add_author")
 
 
 def add_authors(request, data):


### PR DESCRIPTION
Fixes #2480
Fixes #2571

Persists `book.subjects` and `add_author` when form validation fails. The problem here was that `add_author` is not a field in the `Form`, and the template logic is a bit complicated because we use the same form for creating new books and editing existing ones.

This PR does not resolve the problem of cover image uploads being dropped because this is a broader problem and is covered separately in #2760.