### PR TITLE
Fix language constant to show correct lang in API

### DIFF
--- a/bookwyrm/views/wellknown.py
+++ b/bookwyrm/views/wellknown.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_GET
 from bookwyrm import models
 from bookwyrm.settings import DOMAIN, VERSION, LANGUAGE_CODE
 
+
 @require_GET
 def webfinger(request):
     """allow other servers to ask about a user"""

--- a/bookwyrm/views/wellknown.py
+++ b/bookwyrm/views/wellknown.py
@@ -9,8 +9,7 @@ from django.utils import timezone
 from django.views.decorators.http import require_GET
 
 from bookwyrm import models
-from bookwyrm.settings import DOMAIN, VERSION
-
+from bookwyrm.settings import DOMAIN, VERSION, LANGUAGE_CODE
 
 @require_GET
 def webfinger(request):
@@ -110,7 +109,7 @@ def instance_info(_):
                 "status_count": status_count,
             },
             "thumbnail": logo,
-            "languages": ["en"],
+            "languages": [LANGUAGE_CODE[:2]],
             "registrations": site.allow_registration,
             "approval_required": not site.allow_registration
             and site.allow_invite_requests,


### PR DESCRIPTION
api/v1/instance had "en" hardcoded as language. This fix takes LANGUAGE_CODE from settings.py/.env and takes the first two letters as response.

this fixes #2830 