### PR TITLE
Add a management command to merge works

### DIFF
--- a/bookwyrm/management/commands/merge_works.py
+++ b/bookwyrm/management/commands/merge_works.py
@@ -1,0 +1,12 @@
+""" PROCEED WITH CAUTION: uses deduplication fields to permanently
+merge work data objects """
+from bookwyrm import models
+from bookwyrm.management.merge_command import MergeCommand
+
+
+class Command(MergeCommand):
+    """merges two works by ID"""
+
+    help = "merges specified works into one"
+
+    MODEL = models.Work


### PR DESCRIPTION
This is similar to the commands in [PR2821](https://github.com/bookwyrm-social/bookwyrm/pull/2821) to merge authors and editions but it merges works instead. It can be used to combine editions that appear as unrelated books so that they appear as editions of the same work. You can get the ID number for a work clicking on the link for the list of editions in the page for a book. The number in the URL is the number of the work. Then you can merge the works with a command like this:

```
docker-compose run --rm web python manage.py merge_works --canonical=37 --other=39
```

The original version of this patch tried to make the command take edition numbers and then figure out the work ID from that because I thought the work ID wasn’t accessible in the UI. However in the PR Mouse Reeve pointed out how to get the work ID. I think it is less confusing this way because then the command is consistent with the other merge commands.