### PR TITLE
Use the translated shelf name in the message for when another edition is shelved

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -256,7 +256,7 @@
                 {% endif %}
                 {% for shelf in other_edition_shelves %}
                 <p>
-                {% blocktrans with book_path=shelf.book.local_path shelf_path=shelf.shelf.local_path shelf_name=shelf.shelf.name %}A <a href="{{ book_path }}">different edition</a> of this book is on your <a href="{{ shelf_path }}">{{ shelf_name }}</a> shelf.{% endblocktrans %}
+                {% blocktrans with book_path=shelf.book.local_path shelf_path=shelf.shelf.local_path shelf_name=shelf.shelf|translate_shelf_name %}A <a href="{{ book_path }}">different edition</a> of this book is on your <a href="{{ shelf_path }}">{{ shelf_name }}</a> shelf.{% endblocktrans %}
                     {% include 'snippets/switch_edition_button.html' with edition=book %}
                 </p>
                 {% endfor %}


### PR DESCRIPTION
In the page for an edition, if the user has a different edition of the same work on a shelf then a message is shown. Currently the shelf name for status shelves isn’t translated so this PR fixes that.