### PR TITLE
Use the translated shelf name in the “remove from” shelf button

### DIFF
--- a/bookwyrm/templates/snippets/shelf_selector.html
+++ b/bookwyrm/templates/snippets/shelf_selector.html
@@ -91,7 +91,9 @@
         {% csrf_token %}
         <input type="hidden" name="book" value="{{ book.id }}">
         <input type="hidden" name="shelf" value="{{ shelf.id }}">
-        <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">{% trans "Remove from" %} {{ shelf.name }}</button>
+        <button class="button is-fullwidth is-small is-radiusless is-danger is-light" type="submit">
+            {% blocktrans with name=shelf|translate_shelf_name %}Remove from {{ name }}{% endblocktrans %}
+        </button>
     </form>
 </li>
 {% endif %}


### PR DESCRIPTION
I found another place where the shelf name wasn’t translated. Sorry to keep pestering the devs with these…