### PR TITLE
Export/Import user (aka "migrate")

### DIFF
--- a/bookwyrm/forms/forms.py
+++ b/bookwyrm/forms/forms.py
@@ -24,6 +24,7 @@ class FeedStatusTypesForm(CustomForm):
 class ImportForm(forms.Form):
     csv_file = forms.FileField()
 
+
 class ImportUserForm(forms.Form):
     json_file = forms.FileField()
 

--- a/bookwyrm/forms/forms.py
+++ b/bookwyrm/forms/forms.py
@@ -24,6 +24,9 @@ class FeedStatusTypesForm(CustomForm):
 class ImportForm(forms.Form):
     csv_file = forms.FileField()
 
+class ImportUserForm(forms.Form):
+    json_file = forms.FileField()
+
 
 class ShelfForm(CustomForm):
     class Meta:

--- a/bookwyrm/importers/__init__.py
+++ b/bookwyrm/importers/__init__.py
@@ -1,6 +1,7 @@
 """ import classes """
 
 from .importer import Importer
+from .bookwyrm_import import BookwyrmImporter
 from .calibre_import import CalibreImporter
 from .goodreads_import import GoodreadsImporter
 from .librarything_import import LibrarythingImporter

--- a/bookwyrm/importers/bookwyrm_import.py
+++ b/bookwyrm/importers/bookwyrm_import.py
@@ -1,0 +1,384 @@
+"""Import data from Bookwyrm export files"""
+from functools import reduce
+import json
+import operator
+
+from django.apps import apps
+from django.core import serializers
+from django.db.models import Q
+from django.forms.models import model_to_dict
+from django.utils import timezone
+
+from bookwyrm import activitypub, models, settings
+from bookwyrm.models.activitypub_mixin import ActivitypubMixin
+from bookwyrm.views.books.books import set_cover_from_url
+
+
+class BookwyrmImporter:
+    """Import a Bookwyrm User export JSON file.
+    This is kind of a combination of an importer and a connector.
+    """
+
+    def process_import(self, user, json_file, settings):
+        """import user data from a Bookwyrm export file"""
+
+        import_data = json.load(json_file)
+
+        include_user_profile = settings.get("include_user_profile") == "on"
+        include_user_settings = settings.get("include_user_settings") == "on"
+        include_goals = settings.get("include_goals") == "on"
+
+        include_shelves = settings.get("include_shelves") == "on"
+        include_readthroughs = settings.get("include_readthroughs") == "on"
+        include_reviews = settings.get("include_reviews") == "on"
+        include_lists = settings.get("include_lists") == "on"
+
+        include_saved_lists = settings.get("include_saved_lists") == "on"
+        include_follows = settings.get("include_follows") == "on"
+
+        if include_user_profile:
+            self.update_user_profile(user, import_data.get("user"))
+        if include_user_settings:
+            self.update_user_settings(user, import_data.get("user"))
+        if include_goals:
+            self.update_goals(user, import_data.get("goals"))
+
+        # Always import books, otherwise we can't do anything else
+        self.process_books(
+            user=user,
+            books_data=import_data.get("books"),
+            include_shelves=include_shelves,
+            include_readthroughs=include_readthroughs,
+            include_reviews=include_reviews,
+            include_lists=include_lists,
+        )
+
+    def process_books(self, **kwargs):
+        """process user import data related to books"""
+
+        for obj in kwargs["books_data"]:
+
+            # create the books. We need to merge Book and Edition instances
+            # and also check whether these books already exist in the DB
+            des_books = serializers.deserialize("json", obj.get("book"))
+            des_editions = serializers.deserialize("json", obj.get("edition"))
+            next_book = next(des_books)
+            next_edition = next(des_editions)
+            book = self.get_or_create_edition(
+                {"book": next_book.object, "edition": next_edition.object}
+            )
+            # Now we have a local book we can add authors
+            authors = self.get_or_create_authors(obj["authors"])
+            book.authors.set(authors)
+            book.save()
+
+            if kwargs["include_shelves"]:
+                self.create_parent_child_objects_if_not_exists(
+                    models.Shelf, obj.get("shelves"), kwargs["user"], book
+                )
+
+            if kwargs["include_readthroughs"]:
+                self.get_or_create_simple_objects(
+                    models.ReadThrough, obj.get("readthroughs"), kwargs["user"], book
+                )
+
+            if kwargs["include_reviews"]:
+                self.create_merged_objects_if_not_exists(
+                    models.Review, obj.get("lists"), kwargs["user"]
+                )
+
+            if kwargs["include_lists"]:
+                self.create_parent_child_objects_if_not_exists(
+                    models.List, obj.get("lists"), kwargs["user"], book
+                )
+
+            if kwargs["include_saved_lists"]:
+                # TODO
+                pass
+            if kwargs["include_follows"]:
+                # TODO
+                pass
+
+    def update_user_profile(self, user, data):
+        """update the user's profile from import data"""
+
+        user.name = data.get("name")
+        user.summary = data.get("summary")
+        user.save()
+        # TODO: would be ideal to include the actual file in the export and make it a tar
+        avatar = set_cover_from_url(data.get("avatar"))
+        user.avatar.save(*avatar)
+
+    def update_user_settings(self, user, data):
+        """update the user's settings from import data"""
+
+        update_fields = [
+            "manually_approves_followers",
+            "hide_follows",
+            "show_goal",
+            "show_suggested_users",
+            "discoverable",
+            "preferred_timezone",
+            "default_post_privacy",
+        ]
+
+        for field in update_fields:
+            setattr(user, field, data.get(field))
+        user.save()
+
+    def update_goals(self, user, data):
+        """update the user's goals from import data"""
+
+        for goal in data:
+            # edit the existing goal if there is one instead of making a new one
+            existing = models.AnnualGoal.objects.filter(
+                year=goal["year"], user=user
+            ).first()
+            if existing:
+                for k in goal.keys():
+                    setattr(existing, k, goal[k])
+                existing.save()
+            else:
+                goal["user"] = user
+                models.AnnualGoal.objects.create(**goal)
+
+    def get_or_create_authors(self, data):
+        """Take a serialised JSON string of authors
+        find or create the authors in the database
+        and return a list of author instances"""
+
+        authors = []
+        deserialized = serializers.deserialize("json", data)
+        for author in deserialized:
+            clean = self.clean_values(author.object)
+            existing = self.find_existing(models.Author, model_to_dict(clean), None)
+            if existing:
+                authors.append(existing)
+            clean._state.adding = True
+            clean.save()
+            authors.append(clean)
+        return authors
+
+    def get_or_create_edition(self, data):
+        """Take a serialised JSON string of books and
+        editions, find or create the editions in the
+        database and return a list of edotopm instances"""
+
+        book_dict = model_to_dict(data["book"])
+        edition_dict = model_to_dict(data["edition"])
+        clean = self.clean_values(book_dict)
+        keys = [
+            "isbn_10",
+            "isbn_13",
+            "oclc_number",
+            "pages",
+            "physical_format",
+            "physical_format_detail",
+            "publishers",
+        ]
+        for key in keys:
+            clean[key] = edition_dict[key]
+        existing = self.find_existing(models.Edition, clean, None)
+        if existing:
+            return existing
+        new = models.Edition.objects.create(**clean)
+        return new
+
+    def clean_values(self, data):
+        """clean values we don't want when creating new instances"""
+        values = [
+            "id",
+            "pk",
+            "remote_id",
+            "cover",
+            "preview_image",
+            "authors",
+            "last_edited_by",
+            "user",
+            "book_list",
+            "shelf_book",
+        ]
+
+        if isinstance(data, dict):
+            common = data.keys() & values
+            for val in common:
+                data[val] = None
+                data["id"] = None
+        else:
+            common = model_to_dict(data).keys() & values
+            for val in common:
+                setattr(data, val, None)
+        return data
+
+    def find_existing(self, cls, data, user):
+        """User fields that can be used for deduplication
+        to find any existing model instances"""
+
+        identifiers = [
+            "openlibrary_key",
+            "inventaire_id",
+            "librarything_key",
+            "goodreads_key",
+            "asin",
+            "isfdb",
+            "isbn_10",
+            "isbn_13",
+            "oclc_number",
+            "origin_id",
+            "viaf",
+            "wikipedia_link",
+            "isni",
+            "gutenberg_id",
+            "identifier",
+        ]
+
+        match_fields = []
+        for i in identifiers:
+            if i in data and data[i] not in [None, ""]:
+                match_fields.append({i: data.get(i)})
+
+        if cls == models.ReadThrough:
+            match = cls.objects.filter(book=data["book"], start_date=data["start_date"])
+            return match.first()
+        if cls == models.List:
+            match = cls.objects.filter(name=data["name"], user=user)
+            return match.first()
+        if cls == models.Shelf:
+            match = cls.objects.filter(identifier=data["identifier"], user=user)
+            return match.first()
+        if cls == models.ListItem:
+            match = cls.objects.filter(
+                book_list=data["book_list"], book=data["book"], user=user
+            )
+            return match.first()
+        if cls == models.ShelfBook:
+            match = cls.objects.filter(
+                shelf=data["shelf"], book=data["book"], user=user
+            )
+            return match.first()
+        else:
+            if len(match_fields) > 0:
+                match = cls.objects.filter(
+                    reduce(operator.or_, (Q(**f) for f in match_fields))
+                )
+                return match.first()
+        return None
+
+    def get_or_create_simple_objects(self, model, data, user, book):
+        """Take a serialised JSON string of model instances
+        find or create the instances in the database
+        and return a list of saved instances"""
+
+        deserialized = serializers.deserialize("json", data)
+        instances = []
+        for rt in deserialized:
+            clean = self.clean_values(rt.object)
+            existing = self.find_existing(model, model_to_dict(clean), user)
+            if existing:
+                instances.append(existing)
+                continue
+            clean._state.adding = True
+            clean.user = user
+            clean.book = book
+            clean.save()
+            instances.append(clean)
+        return instances
+
+    def create_instance_if_not_exists(self, model, data):
+        """Take a model instance and check
+        whether is already exists before saving"""
+        if model.objects.filter(**data).exists():
+            return
+        model.objects.create(**data)
+
+    def create_parent_child_objects_if_not_exists(self, cls, data, user, book):
+        """Take a serialised JSON string of paired model instances saved together and
+        find or create the instances in the database e.g. List/ListItem, Shelf/ShelfBook"""
+
+        deserialized = serializers.deserialize("json", data)
+        parents = []
+        all_children = []
+        for obj in deserialized:
+            if obj.object.__class__.__name__ in ["List", "Shelf"]:
+                parents.append(obj.object)
+            else:
+                all_children.append(obj.object)
+        for p in parents:
+
+            if cls == models.List:
+                children = [c for c in all_children if p.id == c.book_list.id]
+            if cls == models.Shelf:
+                children = [c for c in all_children if p.id == c.shelf.id]
+
+            clean_parent = self.clean_values(p)
+            clean_parent.user = user
+            parent = self.find_existing(cls, model_to_dict(clean_parent), user)
+            if not parent:
+                parent = clean_parent
+                parent._state.adding = True
+                parent.save()
+            for child in children:
+
+                if cls == models.List:
+                    exists = self.find_existing(
+                        models.ListItem, {"book": book, "book_list": parent}, user
+                    )
+                if cls == models.Shelf:
+                    exists = self.find_existing(
+                        models.ShelfBook,
+                        {
+                            "book": book,
+                            "shelf": parent,
+                            "shelved_date": child.shelved_date,
+                        },
+                        user,
+                    )
+
+                if not exists:
+
+                    if child.__class__.__name__ == "ListItem":
+                        self.create_instance_if_not_exists(
+                            models.ListItem,
+                            {
+                                "book": book,
+                                "book_list": parent,
+                                "notes": child.notes,
+                                "user": user,
+                                "order": child.order,
+                            },
+                        )
+
+                    if child.__class__.__name__ == "ShelfBook":
+                        self.create_instance_if_not_exists(
+                            models.ShelfBook,
+                            {
+                                "book": book,
+                                "shelf": parent,
+                                "shelved_date": child.shelved_date,
+                                "user": user,
+                            },
+                        )
+
+    def create_merged_objects_if_not_exists(self, cls, data, user):
+        """Take a serialised JSON string of two connected model instances saved together and
+        find or create the instances in the database e.g. Reviews"""
+
+        # NOTE this would probably work for quotes and comments with a bit of tweaking
+
+        deserialized = serializers.deserialize("json", data)
+        reviews = []
+        statuses = []
+        for obj in deserialized:
+            if obj.object.__class__.__name__ == "Review":
+                reviews.append(obj.object)
+            else:
+                statuses.append(obj.object)
+
+        if len(reviews) > 0:
+            for r in reviews:
+                status = next(s for s in statuses if s.id == r.id)
+                status.name = r.name
+                status.rating = r.rating
+                status.user = user
+
+            self.create_instance_if_not_exists(models.Review, self.clean_values(status))

--- a/bookwyrm/templates/import/import_user.html
+++ b/bookwyrm/templates/import/import_user.html
@@ -1,0 +1,155 @@
+{% extends 'layout.html' %}
+{% load i18n %}
+{% load humanize %}
+
+{% block title %}{% trans "Import User" %}{% endblock %}
+
+{% block content %}
+<div class="block">
+    <h1 class="title">{% trans "Import User" %}</h1>
+
+    {% if invalid %}
+    <div class="notification is-danger">
+        {% trans "Not a valid JSON file" %}
+    </div>
+    {% endif %}
+
+
+        {% if import_size_limit and import_limit_reset %}
+            <div class="notification">
+                <p>{% blocktrans %}Currently you are allowed to import one user every {{ user_import_limit_reset }} days.{% endblocktrans %}</p>
+                <p>{% blocktrans %}You have {{ allowed_imports }} left.{% endblocktrans %}</p>
+            </div>
+        {% endif %}
+        {% if recent_avg_hours or recent_avg_minutes %}
+        <div class="notification">
+            <p>
+            {% if recent_avg_hours %}
+                {% blocktrans trimmed with hours=recent_avg_hours|floatformat:0|intcomma %}
+                    On average, recent imports have taken {{ hours }} hours.
+                {% endblocktrans %}
+            {% else %}
+                {% blocktrans trimmed with minutes=recent_avg_minutes|floatformat:0|intcomma %}
+                    On average, recent imports have taken {{ minutes }} minutes.
+                {% endblocktrans %}
+            {% endif %}
+            </p>
+        </div>
+        {% endif %}
+
+        <form class="box" name="import-user" action="/import-user" method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+
+            <div class="columns">
+            <div class="column is-half">
+                <div class="field">
+                    <label class="label" for="id_json_file">{% trans "Data file:" %}</label>
+                    {{ import_form.json_file }}
+                </div>
+                <div>
+                    <p>Importing this file will overwrite any data you currently have saved.</p>
+                    <p>Deselect any data you do not wish to include in your import.</p>
+                </div>
+            </div>
+
+            <div class="column is-half">
+                <div class="field">
+                    <label class="label">
+                        <input type="checkbox" name="include_user_settings" checked> {% trans "Include user settings" %}
+                    </label>
+                    <label class="label">
+                        <input type="checkbox" name="include_goals" checked> {% trans "Include reading goals" %}
+                    </label>
+                    <label class="label">
+                        <input type="checkbox" name="include_shelves" checked> {% trans "Include shelves" %}
+                    </label>
+                    <label class="label">
+                        <input type="checkbox" name="include_readthroughs" checked> {% trans "Include readthroughs" %}
+                    </label>
+                    <label class="label">
+                        <input type="checkbox" name="include_book_lists" checked> {% trans "Include book lists" %}
+                    </label>
+                    <label class="label">
+                        <input type="checkbox" name="include_reviews" checked> {% trans "Include reviews" %}
+                    </label>
+                    <label class="label">
+                        <input type="checkbox" name="include_saved_lists" checked> {% trans "Include saved lists" %}
+                    </label>
+                    <label class="label">
+                        <input type="checkbox" name="include_follows" checked> {% trans "Include follows" %}
+                    </label>
+                </div>
+            </div>
+            </div>
+            {% if not import_limit_reset and not import_size_limit or allowed_imports > 0 %}
+                <button class="button is-primary" type="submit">{% trans "Import" %}</button>
+            {% else %}
+                <button class="button is-primary is-disabled" type="submit">{% trans "Import" %}</button>
+                <p>{% trans "You've reached the import limit." %}</p>
+            {% endif%}
+        </form>
+
+</div>
+
+<div class="content block">
+    <h2 class="title">{% trans "Recent Imports" %}</h2>
+    <div class="table-container">
+        <table class="table is-striped is-fullwidth">
+            <tr>
+                <th>
+                    {% trans "Date Created" %}
+                </th>
+                <th>
+                    {% trans "Last Updated" %}
+                </th>
+                <th>
+                    {% trans "Items" %}
+                </th>
+                <th>
+                    {% trans "Status" %}
+                </th>
+            </tr>
+            {% if not jobs %}
+            <tr>
+                <td colspan="4">
+                    <em>{% trans "No recent imports" %}</em>
+                </td>
+            </tr>
+            {% endif %}
+            {% for job in jobs %}
+            <tr>
+                <td>
+                    <a href="{% url 'import-status' job.id %}">{{ job.created_date }}</a>
+                </td>
+                <td>{{ job.updated_date }}</td>
+                <td>{{ job.item_count|intcomma }}</td>
+                <td>
+                    <span
+                        {% if job.status == "stopped" %}
+                        class="tag is-danger"
+                        {% elif job.status == "pending" %}
+                        class="tag is-warning"
+                        {% elif job.complete %}
+                        class="tag"
+                        {% else %}
+                        class="tag is-success"
+                        {% endif %}
+                    >
+                        {% if job.status %}
+                        {{ job.status }}
+                            {{ job.status_display }}
+                        {% elif job.complete %}
+                            {% trans "Complete" %}
+                        {% else %}
+                            {% trans "Active" %}
+                        {% endif %}
+                    </span>
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
+    </div>
+
+    {% include 'snippets/pagination.html' with page=jobs path=request.path %}
+</div>
+{% endblock %}

--- a/bookwyrm/templates/import/import_user.html
+++ b/bookwyrm/templates/import/import_user.html
@@ -37,7 +37,7 @@
         </div>
         {% endif %}
 
-        <form class="box" name="import-user" action="/import-user" method="post" enctype="multipart/form-data">
+        <form class="box" name="import-user" action="/user-import" method="post" enctype="multipart/form-data">
             {% csrf_token %}
 
             <div class="columns">
@@ -48,12 +48,15 @@
                 </div>
                 <div>
                     <p>Importing this file will overwrite any data you currently have saved.</p>
-                    <p>Deselect any data you do not wish to include in your import.</p>
+                    <p>Deselect any data you do not wish to include in your import. Books will always be imported</p>
                 </div>
             </div>
 
             <div class="column is-half">
                 <div class="field">
+                    <label class="label">
+                        <input type="checkbox" name="include_user_profile" checked> {% trans "Include user profile" %}
+                    </label>
                     <label class="label">
                         <input type="checkbox" name="include_user_settings" checked> {% trans "Include user settings" %}
                     </label>
@@ -64,13 +67,13 @@
                         <input type="checkbox" name="include_shelves" checked> {% trans "Include shelves" %}
                     </label>
                     <label class="label">
-                        <input type="checkbox" name="include_readthroughs" checked> {% trans "Include readthroughs" %}
+                        <input type="checkbox" name="include_readthroughs" checked> {% trans "Include 'readthroughs'" %}
                     </label>
                     <label class="label">
-                        <input type="checkbox" name="include_book_lists" checked> {% trans "Include book lists" %}
+                        <input type="checkbox" name="include_reviews" checked> {% trans "Include book reviews" %}
                     </label>
                     <label class="label">
-                        <input type="checkbox" name="include_reviews" checked> {% trans "Include reviews" %}
+                        <input type="checkbox" name="include_lists" checked> {% trans "Include book lists" %}
                     </label>
                     <label class="label">
                         <input type="checkbox" name="include_saved_lists" checked> {% trans "Include saved lists" %}

--- a/bookwyrm/templates/preferences/export-json.html
+++ b/bookwyrm/templates/preferences/export-json.html
@@ -13,7 +13,7 @@
         {% trans "Your JSON export file will include all user data for import into another Bookwyrm server" %}
     </p>
     <p>
-        <form name="export" method="POST" href="{% url 'prefs-export-json' %}">
+        <form name="export" method="POST" href="{% url 'prefs-user-export' %}">
             {% csrf_token %}
             <button type="submit" class="button">
                 <span class="icon icon-download" aria-hidden="true"></span>

--- a/bookwyrm/templates/preferences/export-json.html
+++ b/bookwyrm/templates/preferences/export-json.html
@@ -1,19 +1,19 @@
 {% extends 'preferences/layout.html' %}
 {% load i18n %}
 
-{% block title %}{% trans "Books Export" %}{% endblock %}
+{% block title %}{% trans "User Export" %}{% endblock %}
 
 {% block header %}
-{% trans "Books Export" %}
+{% trans "User Export" %}
 {% endblock %}
 
 {% block panel %}
 <div class="block content">
     <p class="notification">
-        {% trans "Your CSV export file will include all the books on your shelves, books you have reviewed, and books with reading activity. <br/>Use this to import into a service like Goodreads." %}
+        {% trans "Your JSON export file will include all user data for import into another Bookwyrm server" %}
     </p>
     <p>
-        <form name="export" method="POST" href="{% url 'prefs-export' %}">
+        <form name="export" method="POST" href="{% url 'prefs-export-json' %}">
             {% csrf_token %}
             <button type="submit" class="button">
                 <span class="icon icon-download" aria-hidden="true"></span>

--- a/bookwyrm/templates/preferences/layout.html
+++ b/bookwyrm/templates/preferences/layout.html
@@ -32,11 +32,19 @@
         <ul class="menu-list">
             <li>
                 {% url 'import' as url %}
-                <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Import" %}</a>
+                <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Import Books" %}</a>
+            </li>
+            <li>
+                {% url 'user-import' as url %}
+                <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Import User" %}</a>
             </li>
             <li>
                 {% url 'prefs-export' as url %}
-                <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "CSV export" %}</a>
+                <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Export Books" %}</a>
+            </li>
+            <li>
+                {% url 'prefs-export-json' as url %}
+                <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Export User" %}</a>
             </li>
         </ul>
         <h2 class="menu-label">{% trans "Relationships" %}</h2>

--- a/bookwyrm/templates/preferences/layout.html
+++ b/bookwyrm/templates/preferences/layout.html
@@ -43,7 +43,7 @@
                 <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Export Books" %}</a>
             </li>
             <li>
-                {% url 'prefs-export-json' as url %}
+                {% url 'prefs-user-export' as url %}
                 <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Export User" %}</a>
             </li>
         </ul>

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -396,6 +396,7 @@ urlpatterns = [
     re_path(r"^search/?$", views.Search.as_view(), name="search"),
     # imports
     re_path(r"^import/?$", views.Import.as_view(), name="import"),
+    re_path(r"^json-import/?$", views.UserImport.as_view(), name="user-import"),
     re_path(
         r"^import/(?P<job_id>\d+)/?$",
         views.ImportStatus.as_view(),
@@ -593,6 +594,7 @@ urlpatterns = [
         name="prompt-2fa",
     ),
     re_path(r"^preferences/export/?$", views.Export.as_view(), name="prefs-export"),
+    re_path(r"^preferences/json-export/?$", views.ExportJson.as_view(), name="prefs-export-json"),
     re_path(r"^preferences/delete/?$", views.DeleteUser.as_view(), name="prefs-delete"),
     re_path(
         r"^preferences/deactivate/?$",

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -396,7 +396,7 @@ urlpatterns = [
     re_path(r"^search/?$", views.Search.as_view(), name="search"),
     # imports
     re_path(r"^import/?$", views.Import.as_view(), name="import"),
-    re_path(r"^json-import/?$", views.UserImport.as_view(), name="user-import"),
+    re_path(r"^user-import/?$", views.UserImport.as_view(), name="user-import"),
     re_path(
         r"^import/(?P<job_id>\d+)/?$",
         views.ImportStatus.as_view(),
@@ -594,7 +594,11 @@ urlpatterns = [
         name="prompt-2fa",
     ),
     re_path(r"^preferences/export/?$", views.Export.as_view(), name="prefs-export"),
-    re_path(r"^preferences/json-export/?$", views.ExportJson.as_view(), name="prefs-export-json"),
+    re_path(
+        r"^preferences/user-export/?$",
+        views.ExportUser.as_view(),
+        name="prefs-user-export",
+    ),
     re_path(r"^preferences/delete/?$", views.DeleteUser.as_view(), name="prefs-delete"),
     re_path(
         r"^preferences/deactivate/?$",

--- a/bookwyrm/views/__init__.py
+++ b/bookwyrm/views/__init__.py
@@ -36,7 +36,7 @@ from .admin.user_admin import UserAdmin, UserAdminList, ActivateUserAdmin
 # user preferences
 from .preferences.change_password import ChangePassword
 from .preferences.edit_user import EditUser
-from .preferences.export import Export
+from .preferences.export import Export, ExportJson
 from .preferences.delete_user import DeleteUser, DeactivateUser, ReactivateUser
 from .preferences.block import Block, unblock
 from .preferences.two_factor_auth import (
@@ -80,7 +80,7 @@ from .shelf.shelf_actions import create_shelf, delete_shelf
 from .shelf.shelf_actions import shelve, unshelve
 
 # csv import
-from .imports.import_data import Import
+from .imports.import_data import Import, UserImport
 from .imports.import_status import ImportStatus, retry_item, stop_import
 from .imports.troubleshoot import ImportTroubleshoot
 from .imports.manually_review import (

--- a/bookwyrm/views/__init__.py
+++ b/bookwyrm/views/__init__.py
@@ -36,7 +36,7 @@ from .admin.user_admin import UserAdmin, UserAdminList, ActivateUserAdmin
 # user preferences
 from .preferences.change_password import ChangePassword
 from .preferences.edit_user import EditUser
-from .preferences.export import Export, ExportJson
+from .preferences.export import Export, ExportUser
 from .preferences.delete_user import DeleteUser, DeactivateUser, ReactivateUser
 from .preferences.block import Block, unblock
 from .preferences.two_factor_auth import (

--- a/bookwyrm/views/imports/import_data.py
+++ b/bookwyrm/views/imports/import_data.py
@@ -127,3 +127,19 @@ def get_average_import_time() -> float:
     if recent_avg:
         return recent_avg.total_seconds()
     return None
+
+
+# TODO: UserImport
+
+
+# pylint: disable= no-self-use
+@method_decorator(login_required, name="dispatch")
+class UserImport(View):
+    """import user view"""
+
+    def get(self, request, invalid=False):
+        """load user import page"""
+
+        data = { "import_form": forms.ImportUserForm(), }
+        
+        return TemplateResponse(request, "import/import_user.html", data)

--- a/bookwyrm/views/preferences/export.py
+++ b/bookwyrm/views/preferences/export.py
@@ -1,8 +1,10 @@
 """ Let users export their book data """
 import csv
 import io
+import json
 
 from django.contrib.auth.decorators import login_required
+from django.core import serializers
 from django.db.models import Q
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
@@ -10,6 +12,7 @@ from django.views import View
 from django.utils.decorators import method_decorator
 
 from bookwyrm import models
+from bookwyrm.settings import DOMAIN
 
 # pylint: disable=no-self-use
 @method_decorator(login_required, name="dispatch")
@@ -84,3 +87,160 @@ class Export(View):
                 "Content-Disposition": 'attachment; filename="bookwyrm-export.csv"'
             },
         )
+
+# pylint: disable=no-self-use
+@method_decorator(login_required, name="dispatch")
+class ExportJson(View):
+    """Let users export user data to import into another Bookwyrm instance"""
+
+    def get(self, request):
+        """Request json file"""
+        return TemplateResponse(request, "preferences/export-json.html")
+
+    def post(self, request):
+        """Download the json file of a user's data"""
+
+        # user
+        s_user = {}
+        vals = [
+            "name", 
+            "summary",
+            "manually_approves_followers",
+            "hide_follows",
+            "show_goal",
+            "show_suggested_users",
+            "discoverable",
+            "preferred_timezone",
+            "default_post_privacy",
+        ]
+        for k in vals:
+            s_user[k] = getattr(request.user, k)
+            s_user["avatar"] = f'https://{DOMAIN}{getattr(request.user, "avatar").url}'
+        serialized_user = json.dumps(s_user)
+
+        # reading goals
+        reading_goals = models.AnnualGoal.objects.filter(user=request.user).distinct()
+        goals_list = []
+        try:
+            for goal in reading_goals:
+                goals_list.append({"goal": goal.goal, "year": goal.year, "privacy": goal.privacy})
+        except Exception: 
+            pass
+        serialized_goals = json.dumps(goals_list)
+
+        # read-throughs
+        try:
+            readthroughs = models.ReadThrough.objects.filter(user=request.user).distinct()
+            s_readthroughs = json.loads(serializers.serialize('json', readthroughs.all()))
+            serialized_readthroughs = json.dumps(s_readthroughs["fields"])
+
+        except Exception as e:
+            serialized_readthroughs = []
+
+        # books
+        books = models.Edition.viewer_aware_objects(request.user)
+        editions_for_export = books.filter(
+            Q(shelves__user=request.user) |
+            Q(readthrough__user=request.user) |
+            Q(review__user=request.user)    
+        ).distinct()
+        eds = json.loads(serializers.serialize('json', editions_for_export.all()))
+        editions = self.get_fields_for_each(eds)
+        books_for_export = models.Book.objects.filter(id__in=editions_for_export).distinct()
+        bks = json.loads(serializers.serialize('json', books_for_export.all()))
+        books = self.get_fields_for_each(bks)
+
+        final_books =[]
+
+        for book in books:
+            # editions
+            for edition in editions:
+                if book["pk"] == edition["pk"]:
+                    book.update(edition)
+            # authors
+            b_authors = book["authors"]
+            authors = models.Author.objects.filter(id__in=b_authors)
+            serialized_authors = json.loads(serializers.serialize("json", authors.all()))
+            author_fields = []
+            for author in serialized_authors:
+                author_fields.append(author["fields"])
+            book["authors"] = []
+            book["extra"] = {}
+            book["extra"]["authors"] = author_fields
+
+            # shelves 
+            shelf_books = models.ShelfBook.objects.filter(user=request.user, book_id=book["pk"]).distinct()
+            serialized_shelf_books = json.loads(serializers.serialize("json", shelf_books.all()))
+            shelves_from_books = models.Shelf.objects.filter(shelfbook__in=shelf_books)
+            serialized_shelves_from_books = json.loads(serializers.serialize("json", shelves_from_books.all()))
+            
+            shelf_book_list = []
+            for b in serialized_shelf_books:
+                shelf_book = b["fields"]
+                for s in serialized_shelves_from_books:
+                    if s["pk"] == shelf_book["shelf"]:
+                        shelf_book["shelf"] = s["fields"]
+                
+                shelf_book_list.append(shelf_book)
+            book["extra"]["shelf_books"] = shelf_book_list
+
+            # book lists
+            list_items = models.ListItem.objects.filter(user=request.user, book_id=book["pk"]).distinct()
+            serialized_items = json.loads(serializers.serialize("json", list_items.all()))
+            book_lists = models.List.objects.filter(id__in=list_items).distinct()
+            serialized_lists = json.loads(serializers.serialize("json", book_lists.all()))
+            booklist_items = []
+            for i in serialized_items:
+                item = i["fields"]
+                for l in serialized_lists:
+                    if item["book_list"] == l["pk"]:
+                        item["book_list"] = l["fields"]
+                booklist_items.append(item)
+            book["extra"]["list_items"] = booklist_items
+
+            # reviews
+            reviews = models.Review.objects.filter(user=request.user, book_id=book["pk"]).distinct()
+            serialized_reviews = json.loads(serializers.serialize("json", reviews.all()))
+            book_reviews = []
+            for r in serialized_reviews:
+                status = models.Status.objects.get(id=r["pk"])
+                serialized_status = json.loads(serializers.serialize("json", [status]))
+                review = r["fields"]
+                detail = serialized_status[0]["fields"]
+                review.update(detail)
+                book_reviews.append(review)
+            book["extra"]["reviews"] = book_reviews
+
+            # append everything
+            final_books.append(book)
+        serialized_books = json.dumps(final_books)
+
+        # saved book lists
+        saved_lists = models.List.objects.filter(id__in=request.user.saved_lists.all()).distinct()
+        serialized_saved_lists = json.dumps([l.remote_id for l in saved_lists])
+
+        # follows
+        follows = models.UserFollows.objects.filter(user_subject=request.user).distinct()
+        following = models.User.objects.filter(userfollows_user_object__in=follows).distinct()
+        serialized_follows = json.dumps([f.remote_id for f in following])
+
+        data = f'{{"user": {serialized_user}, "goals": {serialized_goals}, "books": {serialized_books}, "saved_lists": {serialized_saved_lists}, "follows": {serialized_follows} }}'
+        
+        return HttpResponse(
+            data,
+            content_type="application/json",
+            headers={
+                "Content-Disposition": 'attachment; filename="bookwyrm-account-export.json"'
+            },
+        )
+
+    def get_fields_for_each(self, data):
+        return_value = []
+        if len(data) > 0:
+            for val in data:
+                r_data = val["fields"]
+                r_data["pk"] = val["pk"]
+                return_value.append(r_data)
+            return return_value
+        else:
+            return


### PR DESCRIPTION
## Preliminary work on an Export/Import flow for users

**This is very preliminary and subject to change, potentially in major ways.**

Intended to resolve #1012 

Users can export a JSON file and import the file into another instance.
Uses `serializers.serialize` so this is just a straight Django dump, not an ActivityPub JSON format.

- [x] import user profile
- [x] import selected user settings
- [x] import goals
- [x] import books (as combined `Book` and `Edition` objects) and their authors
- [x] import shelves and ShelfBooks
- [x] import lists and ListItems
- [x] import reviews (as combined `Review` and `Status` objects)
- [ ] import readthroughs
- [ ] saved lists
- [ ] follows
- [ ] user blocks
- [ ] load book images
- [ ] flip curation on group-curating lists (see below)
- [ ] use task manager for imports

## Related future work

We will also need a way to indicate in the old instance that the user has moved. I am anticipating we'll do that in a separate PR, using a `Move` ActivityPub action similar to how Mastodon does it ("Alice has `Move`d Alice to Bob") but also possibly `Move`ing book lists.

## Exclusions

* I initially did not intend to migrate quotes and comments but we could do this fairly easily.
* as `Group`s are not _currently_ ActivityPub-aware objects, I have excluded them, though in future these need to be ActivityPub objects and therefore included. Not this also means we should flip any Group curated lists back to default. i.e. Groups can only exist between users who are all _local_ users.