### PR TITLE
Ensure report button triggers modal

### DIFF
--- a/bookwyrm/static/js/bookwyrm.js
+++ b/bookwyrm/static/js/bookwyrm.js
@@ -40,9 +40,6 @@ let BookWyrm = new (class {
 
         document.querySelectorAll("details.dropdown").forEach((node) => {
             node.addEventListener("toggle", this.handleDetailsDropdown.bind(this));
-            node.querySelectorAll("[data-modal-open]").forEach((modal_node) =>
-                modal_node.addEventListener("click", () => (node.open = false))
-            );
         });
 
         document


### PR DESCRIPTION
Clicking on "report" in any context closes the dropdown menu and requires a second click on the dropdown to trigger the modal. Obviously this is fairly suboptimal.

With this change, the modal opens as expected.

Reverses part of #2322 - as best I can tell, simply changing the z-index is enough for #2322 to work as intended.