### PR TITLE
Adds management command to repair editions in bad state

### DIFF
--- a/bookwyrm/management/commands/repair_editions.py
+++ b/bookwyrm/management/commands/repair_editions.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 from bookwyrm import models
 
 
-class Commmand(BaseCommand):
+class Command(BaseCommand):
     """command-line options"""
 
     help = "Repairs an edition that is in a broken state"

--- a/bookwyrm/management/commands/repair_editions.py
+++ b/bookwyrm/management/commands/repair_editions.py
@@ -1,0 +1,21 @@
+""" Repair editions with missing works """
+from django.core.management.base import BaseCommand
+from bookwyrm import models
+
+
+class Commmand(BaseCommand):
+    """command-line options"""
+
+    help = "Repairs an edition that is in a broken state"
+
+    # pylint: disable=unused-argument
+    def handle(self, *args, **options):
+        """Find and repair broken editions"""
+        # Find broken editions
+        editions = models.Edition.objects.filter(parent_work__isnull=True)
+        self.stdout.write(f"Repairing {editions.count()} edition(s):")
+
+        # Do repair
+        for edition in editions:
+            edition.repair()
+            self.stdout.write(".", ending="")

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -126,18 +126,6 @@ class ActivitypubMixin:
         # there OUGHT to be only one match
         return match.first()
 
-    def get_dedpulication_field_json(self):
-        """A json blob of deduplication fields (like remote_id, or ISBN)"""
-        data = {}
-        for field in self._meta.get_fields():
-            if (
-                not hasattr(field, "deduplication_field")
-                or not field.deduplication_field
-            ):
-                continue
-            data[field.name] = getattr(self, field.name)
-        return data
-
     def broadcast(self, activity, sender, software=None, queue=BROADCAST):
         """send out an activity"""
         broadcast_task.apply_async(

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -126,6 +126,18 @@ class ActivitypubMixin:
         # there OUGHT to be only one match
         return match.first()
 
+    def get_dedpulication_field_json(self):
+        """A json blob of deduplication fields (like remote_id, or ISBN)"""
+        data = {}
+        for field in self._meta.get_fields():
+            if (
+                not hasattr(field, "deduplication_field")
+                or not field.deduplication_field
+            ):
+                continue
+            data[field.name] = getattr(self, field.name)
+        return data
+
     def broadcast(self, activity, sender, software=None, queue=BROADCAST):
         """send out an activity"""
         broadcast_task.apply_async(

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -2,6 +2,7 @@
 from itertools import chain
 import re
 
+from django.apps import apps
 from django.contrib.postgres.search import SearchVectorField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.cache import cache
@@ -379,6 +380,26 @@ class Edition(Book):
                 )
 
         return super().save(*args, **kwargs)
+
+    def repair(self):
+        """If an edition is in a bad state (missing a work), let's fix that"""
+        # made sure it actually NEEDS reapir
+        if self.parent_work:
+            return
+
+        # try to find a duplicate of this edition first
+        model = apps.get_model("bookwyrm.Edition", require_ready=True)
+        data = self.get_dedpulication_field_json()
+        existing_match = model.find_existing(data)
+
+        # assign this edition to the parent of the duplicate edition
+        new_work = existing_match.parent_work
+        # if not, create a new work for it
+        if not new_work:
+            new_work = models.Work.objects.create(title=self.title)
+
+        self.parent_work = new_work
+        self.save(update_fields=["parent_work"], broadcast=False)
 
     @classmethod
     def viewer_aware_objects(cls, viewer):

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -387,7 +387,6 @@ class Edition(Book):
         if self.parent_work:
             return
 
-        # assign this edition to the parent of the duplicate edition
         new_work = Work.objects.create(title=self.title)
         new_work.authors.set(self.authors.all())
 

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -393,10 +393,10 @@ class Edition(Book):
         existing_match = model.find_existing(data)
 
         # assign this edition to the parent of the duplicate edition
-        new_work = existing_match.parent_work
-        # if not, create a new work for it
-        if not new_work:
-            new_work = models.Work.objects.create(title=self.title)
+        if existing_match and existing_match.parent_work:
+            new_work = existing_match.parent_work
+        else:
+            new_work = Work.objects.create(title=self.title)
 
         self.parent_work = new_work
         self.save(update_fields=["parent_work"], broadcast=False)

--- a/bookwyrm/templatetags/rating_tags.py
+++ b/bookwyrm/templatetags/rating_tags.py
@@ -12,6 +12,10 @@ register = template.Library()
 @register.filter(name="rating")
 def get_rating(book, user):
     """get the overall rating of a book"""
+    # this shouldn't happen, but it CAN
+    if not book.parent_work:
+        return None
+
     return cache.get_or_set(
         f"book-rating-{book.parent_work.id}",
         lambda u, b: models.Review.objects.filter(

--- a/bookwyrm/tests/models/test_book_model.py
+++ b/bookwyrm/tests/models/test_book_model.py
@@ -24,7 +24,7 @@ class Book(TestCase):
             title="Example Work", remote_id="https://example.com/book/1"
         )
         self.first_edition = models.Edition.objects.create(
-            title="Example Edition", parent_work=self.work, isbn_10="1111111111"
+            title="Example Edition", parent_work=self.work
         )
         self.second_edition = models.Edition.objects.create(
             title="Another Example Edition",

--- a/bookwyrm/tests/models/test_book_model.py
+++ b/bookwyrm/tests/models/test_book_model.py
@@ -143,3 +143,13 @@ class Book(TestCase):
             for article in articles
         )
         self.assertTrue(all(book.sort_title == "test edition" for book in books))
+
+    def test_repair_edition(self):
+        """Fix editions with no works"""
+        edition = models.Edition.objects.create(title="test")
+        self.assertIsNone(edition.parent_work)
+
+        edition.repair()
+        edition.refresh_from_db()
+
+        self.assertEqual(edition.parent_work.title, "test")

--- a/bookwyrm/tests/models/test_book_model.py
+++ b/bookwyrm/tests/models/test_book_model.py
@@ -24,8 +24,7 @@ class Book(TestCase):
             title="Example Work", remote_id="https://example.com/book/1"
         )
         self.first_edition = models.Edition.objects.create(
-            title="Example Edition",
-            parent_work=self.work,
+            title="Example Edition", parent_work=self.work, isbn_10="1111111111"
         )
         self.second_edition = models.Edition.objects.create(
             title="Another Example Edition",
@@ -147,9 +146,11 @@ class Book(TestCase):
     def test_repair_edition(self):
         """Fix editions with no works"""
         edition = models.Edition.objects.create(title="test")
+        edition.authors.set([models.Author.objects.create(name="Author Name")])
         self.assertIsNone(edition.parent_work)
 
         edition.repair()
         edition.refresh_from_db()
 
         self.assertEqual(edition.parent_work.title, "test")
+        self.assertEqual(edition.parent_work.authors.count(), 1)

--- a/bookwyrm/tests/templatetags/test_rating_tags.py
+++ b/bookwyrm/tests/templatetags/test_rating_tags.py
@@ -71,6 +71,12 @@ class RatingTags(TestCase):
         )
         self.assertEqual(rating_tags.get_rating(self.book, self.local_user), 5)
 
+    def test_get_rating_broken_edition(self, *_):
+        """Don't have a server error if an edition is missing a work"""
+        broken_book = models.Edition.objects.create(title="Test")
+        broken_book.parent_work = None
+        self.assertIsNone(rating_tags.get_rating(broken_book, self.local_user))
+
     def test_get_user_rating(self, *_):
         """get a user's most recent rating of a book"""
         with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):


### PR DESCRIPTION
Sometimes editions are created without an associated parent work, which is Not Great, but difficult to ensure never happen. This command will match an orphan edition with a work, if there's another edition with the same unique identifiers (like ISBN), and create a new work if not. I've also added some logic to have this case fail gracefully in the UI to avoid server errors popping up all over the place.

I didn't have a chance to test this code before I had to go hang out with a cool baby so it needs more work, but should be the right idea

Fixes #2895 