### PR TITLE
fix button text when editing posts

### DIFF
--- a/bookwyrm/templates/snippets/create_status/post_options_block.html
+++ b/bookwyrm/templates/snippets/create_status/post_options_block.html
@@ -15,7 +15,11 @@
     <div class="control">
         <button class="button is-link" type="submit">
             <span class="icon icon-spinner" aria-hidden="true"></span>
+            {% if draft %}
+            <span>{% trans "Save" %}</span>
+            {% else %}
             <span>{% trans "Post" %}</span>
+            {% endif %}
         </button>
     </div>
 </div>

--- a/bookwyrm/templates/snippets/create_status/post_options_block.html
+++ b/bookwyrm/templates/snippets/create_status/post_options_block.html
@@ -16,7 +16,7 @@
         <button class="button is-link" type="submit">
             <span class="icon icon-spinner" aria-hidden="true"></span>
             {% if draft %}
-            <span>{% trans "Save" %}</span>
+            <span>{% trans "Update" %}</span>
             {% else %}
             <span>{% trans "Post" %}</span>
             {% endif %}


### PR DESCRIPTION
Indicate edited post is saved

Should close #2642 and #2671. Gives a minimal solution to #2668.