### PR TITLE
Remove '@' from the beginning of hashtag names in activity

### DIFF
--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -368,10 +368,16 @@ class TagField(ManyToManyField):
             activity_type = item.__class__.__name__
             if activity_type == "User":
                 activity_type = "Mention"
+
+            if activity_type == "Hashtag":
+                name = item.name
+            else:
+                name = f"@{getattr(item, item.name_field)}"
+
             tags.append(
                 activitypub.Link(
                     href=item.remote_id,
-                    name=f"@{getattr(item, item.name_field)}",
+                    name=name,
                     type=activity_type,
                 )
             )


### PR DESCRIPTION
All tag names got a '@' as prefix when converting to activity, which you would not expect for hashtags as this results in the name '@#hashtag'. I added an exception for hashtags. This addresses the second point in #2901

Should the default behaviour for tags actually be that the name is preceded by '@' or should this maybe just be the exception for Users?