### PR TITLE
Disable Spellcheck on header search inputs

### DIFF
--- a/bookwyrm/templates/book/editions/search_filter.html
+++ b/bookwyrm/templates/book/editions/search_filter.html
@@ -4,7 +4,7 @@
 {% block filter %}
 <div class="control">
     <label class="label" for="id_search">{% trans "Search editions" %}</label>
-    <input type="text" class="input" name="q" value="{{ request.GET.q|default:'' }}" id="id_search">
+    <input type="text" class="input" name="q" value="{{ request.GET.q|default:'' }}" id="id_search" spellcheck="false">
 </div>
 {% endblock %}
 

--- a/bookwyrm/templates/get_started/books.html
+++ b/bookwyrm/templates/get_started/books.html
@@ -6,7 +6,7 @@
     <h2 class="title is-4">{% trans "What are you reading?" %}</h2>
     <form class="field has-addons" method="get" action="{% url 'get-started-books' %}">
         <div class="control">
-            <input type="text" name="query" value="{{ request.GET.query }}" class="input" placeholder="{% trans 'Search for a book' %}" aria-label="{% trans 'Search for a book' %}">
+            <input type="text" name="query" value="{{ request.GET.query }}" class="input" placeholder="{% trans 'Search for a book' %}" aria-label="{% trans 'Search for a book' %}" spellcheck="false">
             {% if request.GET.query and not book_results %}
             <p class="help">{% blocktrans with query=request.GET.query %}No books found for "{{ query }}"{% endblocktrans %}. {% blocktrans %}You can add books when you start using {{ site_name }}.{% endblocktrans %}</p>
             {% endif %}

--- a/bookwyrm/templates/get_started/users.html
+++ b/bookwyrm/templates/get_started/users.html
@@ -8,7 +8,7 @@
     <p class="subtitle is-6">{% trans "You can follow users on other BookWyrm instances and federated services like Mastodon." %}</p>
     <form class="field has-addons" method="get" action="{% url 'get-started-users' %}">
         <div class="control">
-            <input type="text" name="query" value="{{ request.GET.query }}" class="input" placeholder="{% trans 'Search for a user' %}" aria-label="{% trans 'Search for a user' %}">
+            <input type="text" name="query" value="{{ request.GET.query }}" class="input" placeholder="{% trans 'Search for a user' %}" aria-label="{% trans 'Search for a user' %}" spellcheck="false">
             {% if request.GET.query and no_results %}
             <p class="help">{% blocktrans with query=request.GET.query %}No users found for "{{ query }}"{% endblocktrans %}</p>
             {% endif %}

--- a/bookwyrm/templates/groups/members.html
+++ b/bookwyrm/templates/groups/members.html
@@ -8,7 +8,7 @@
 <div class="block">
     <form class="field has-addons" method="get" action="{% url 'group-find-users' group.id %}">
         <div class="control">
-            <input type="text" name="user_query" value="{{ request.GET.user_query }}" class="input" placeholder="{% trans 'Search to add a user' %}" aria-label="{% trans 'Search to add a user' %}">
+            <input type="text" name="user_query" value="{{ request.GET.user_query }}" class="input" placeholder="{% trans 'Search to add a user' %}" aria-label="{% trans 'Search to add a user' %}" spellcheck="false">
         </div>
         <div class="control" id="tour-group-member-search">
             <button class="button" type="submit">

--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -38,7 +38,7 @@
                         {% else %}
                             {% trans "Search for a book" as search_placeholder %}
                         {% endif %}
-                        <input aria-label="{{ search_placeholder }}" id="tour-search" class="input" type="text" name="q" placeholder="{{ search_placeholder }}" value="{{ query }}">
+                        <input aria-label="{{ search_placeholder }}" id="tour-search" class="input" type="text" name="q" placeholder="{{ search_placeholder }}" value="{{ query }}" spellcheck="false">
                     </div>
                     <div class="control">
                         <button class="button" type="submit">

--- a/bookwyrm/templates/lists/list.html
+++ b/bookwyrm/templates/lists/list.html
@@ -210,7 +210,7 @@
         <form name="search" action="{% url 'list' list_id=list.id slug=list.name|slugify %}" method="GET" class="block">
             <div class="field has-addons">
                 <div class="control">
-                    <input aria-label="{% trans 'Search for a book' %}" class="input" type="text" name="q" placeholder="{% trans 'Search for a book' %}" value="{{ query }}">
+                    <input aria-label="{% trans 'Search for a book' %}" class="input" type="text" name="q" placeholder="{% trans 'Search for a book' %}" value="{{ query }}" spellcheck="false">
                 </div>
                 <div class="control">
                     <button class="button" type="submit">

--- a/bookwyrm/templates/search/layout.html
+++ b/bookwyrm/templates/search/layout.html
@@ -14,7 +14,7 @@
 <form class="block" action="{% url 'search' %}" method="GET">
     <div class="field has-addons">
         <div class="control">
-            <input type="text" class="input" name="q" value="{{ query }}" aria-label="{% trans 'Search query' %}" id="tour-search-page-input">
+            <input type="text" class="input" name="q" value="{{ query }}" aria-label="{% trans 'Search query' %}" id="tour-search-page-input" spellcheck="false">
         </div>
         <div class="control">
             <div class="select" aria-label="{% trans 'Search type' %}">


### PR DESCRIPTION
The header search input shouldn't accept automatic spellcheck. Searching for a book or an author means entering words that are not in the dictionary (like author names, invented places, etc.), and I shouldn't have my computer or mobile phone automagically change these words just before I submit the search

On the technical side, here's the doc for the `spellcheck` attribute on `input` elements: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#spellcheck

(This PR hasn't been tested yet)