### PR TITLE
Only trigger add_status_task when status is first created

### DIFF
--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -329,10 +329,9 @@ def add_status_on_create(sender, instance, created, *args, **kwargs):
         remove_status_task.delay(instance.id)
         return
 
-    # To avoid creating a zillion unnecessary tasks caused by re-saving the model,
-    # check if it's actually ready to send before we go. We're trusting this was
-    # set correctly by the inbox or view
-    if not instance.ready:
+    # We don't want to create multiple add_status_tasks for each status, and because
+    # the transactions are atomic, on_commit won't run until the status is ready to add.
+    if not created:
         return
 
     # when creating new things, gotta wait on the transaction

--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -62,7 +62,7 @@ class StatusTransactions(TransactionTestCase):
         with patch("bookwyrm.activitystreams.add_status_task.apply_async") as mock:
             view(request, "comment")
 
-        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(mock.call_count, 1)
 
 
 @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")


### PR DESCRIPTION
I think the reason I didn't do this initially was so that related users and books, which are added necessarily after the model instance is crated, will be part of the object when the task runs, but I have investigated this and because of the transaction.atomic statement in the to_model method in bookwyrm/activitypub/base_activity.py and in the status view (added in this commit), this is not an issue.