### PR TITLE
Fixes for create-book

### DIFF
--- a/bookwyrm/forms/books.py
+++ b/bookwyrm/forms/books.py
@@ -111,6 +111,7 @@ class EditionFromWorkForm(CustomForm):
         model = models.Work
         fields = [
             "title",
+            "sort_title",
             "subtitle",
             "authors",
             "description",

--- a/bookwyrm/templates/book/edit/edit_book.html
+++ b/bookwyrm/templates/book/edit/edit_book.html
@@ -111,11 +111,11 @@
                     {% endif %}
                     {% endfor %}
                 </div>
-                {% else %}
+                {% elif add_author %}
                 <p class="column is-half">{% blocktrans with name=add_author %}Creating a new author: {{ name }}{% endblocktrans %}</p>
                 {% endif %}
 
-                {% if not book %}
+                {% if not book.parent_work %}
                 <div class="column is-half">
                     <fieldset>
                         <legend class="title is-5 mb-1">

--- a/bookwyrm/templates/book/edit/edit_book_form.html
+++ b/bookwyrm/templates/book/edit/edit_book_form.html
@@ -10,7 +10,9 @@
 {% csrf_token %}
 
 <input type="hidden" name="last_edited_by" value="{{ request.user.id }}">
+{% if form.parent_work %}
 <input type="hidden" name="parent_work" value="{% firstof book.parent_work.id form.parent_work %}">
+{% endif %}
 
 <div class="columns">
     <div class="column is-half">

--- a/bookwyrm/templates/book/editions/editions.html
+++ b/bookwyrm/templates/book/editions/editions.html
@@ -58,6 +58,7 @@
     <form action="{% url 'create-book-data' %}" method="POST" name="add-edition-form">
         {% csrf_token %}
         {{ work_form.title }}
+        {{ work_form.sort_title }}
         {{ work_form.subtitle }}
         {{ work_form.authors }}
         {{ work_form.description }}

--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -157,6 +157,7 @@ def add_authors(request, data):
     """helper for adding authors"""
     add_author = [author for author in request.POST.getlist("add_author") if author]
     if not add_author:
+        data["add_author"] = []
         return data
 
     data["add_author"] = add_author


### PR DESCRIPTION
This PR addresses a couple of smaller issues when using `create-book`:
- When manually adding a new edition and you do not add a new author, you're asked whether you want to add the author `['']`
- When creating a new book manually and leaving the author blank you're asked whether you want to create the author `[]`
- When adding a new book and possible matches are found these are not displayed as `data["book"]` is always set for the subjects (even when none are provided) and when a possible match is selected it is not actually set as parent_work as `parent_work` was sent twice in the POST request (once the selected value and once an empty hidden field)
