### PR TITLE
On readthrough, progressupdate or status delete return to previous page

### DIFF
--- a/bookwyrm/views/reading.py
+++ b/bookwyrm/views/reading.py
@@ -203,7 +203,7 @@ def delete_readthrough(request):
     readthrough.raise_not_deletable(request.user)
 
     readthrough.delete()
-    return redirect("/")
+    return redirect_to_referer(request)
 
 
 @login_required
@@ -214,4 +214,4 @@ def delete_progressupdate(request):
     update.raise_not_deletable(request.user)
 
     update.delete()
-    return redirect("/")
+    return redirect_to_referer(request)

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -8,7 +8,7 @@ from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseBadRequest, Http404
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -176,7 +176,7 @@ class DeleteStatus(View):
 
         # perform deletion
         status.delete()
-        return redirect("/")
+        return redirect_to_referer(request)
 
 
 @login_required

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -8,7 +8,7 @@ from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseBadRequest, Http404
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -176,7 +176,7 @@ class DeleteStatus(View):
 
         # perform deletion
         status.delete()
-        return redirect_to_referer(request)
+        return redirect("/")
 
 
 @login_required


### PR DESCRIPTION
When deleting, for example, a readthrough on a bookpage you are redirected to the main page. I expected to stay on the bookpage in that case. This PR changes the redirect to `/` to `redirect_to_referer`.