### PR TITLE
Adds breadcrumbs and better titles to followers/following pages

### DIFF
--- a/bookwyrm/templates/user/layout.html
+++ b/bookwyrm/templates/user/layout.html
@@ -21,6 +21,8 @@
     {% endblock %}
 </header>
 
+{% block breadcrumbs %}{% endblock %}
+
 {# user bio #}
 <div class="block">
     <div class="columns">

--- a/bookwyrm/templates/user/relationships/followers.html
+++ b/bookwyrm/templates/user/relationships/followers.html
@@ -1,11 +1,30 @@
 {% extends 'user/relationships/layout.html' %}
+{% load utilities %}
 {% load i18n %}
+
+{% block title %}
+    {% trans "Followers" %} - {{ user|username }}
+{% endblock %}
 
 {% block header %}
 <h1 class="title">
     {% trans "Followers" %}
 </h1>
 {% endblock %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb subtitle" aria-label="breadcrumbs">
+    <ul>
+        <li><a href="{% url 'user-feed' user|username %}">{% trans "User profile" %}</a></li>
+        <li class="is-active">
+            <a href="#" aria-current="page">
+                {% trans "Followers" %}
+            </a>
+        </li>
+    </ul>
+</nav>
+{% endblock %}
+
 
 {% block nullstate %}
 <div>

--- a/bookwyrm/templates/user/relationships/following.html
+++ b/bookwyrm/templates/user/relationships/following.html
@@ -1,10 +1,28 @@
 {% extends 'user/relationships/layout.html' %}
+{% load utilities %}
 {% load i18n %}
+
+{% block title %}
+    {% trans "Following" %} - {{ user|username }}
+{% endblock %}
 
 {% block header %}
 <h1 class="title">
     {% trans "Following" %}
 </h1>
+{% endblock %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb subtitle" aria-label="breadcrumbs">
+    <ul>
+        <li><a href="{% url 'user-feed' user|username %}">{% trans "User profile" %}</a></li>
+        <li class="is-active">
+            <a href="#" aria-current="page">
+                {% trans "Following" %}
+            </a>
+        </li>
+    </ul>
+</nav>
 {% endblock %}
 
 {% block nullstate %}


### PR DESCRIPTION
This makes it a bit easier to get back to the profile page and clarifies the hierarchy a bit. It also gives these pages distinct titles which is nice. This design pattern mirrors what you see on the user's books pages:
<img width="1203" alt="Screen Shot 2023-08-06 at 3 10 45 PM" src="https://github.com/bookwyrm-social/bookwyrm/assets/1807695/3e263498-8904-4874-b328-26e98db6f8c2">
<img width="741" alt="Screen Shot 2023-08-06 at 3 11 04 PM" src="https://github.com/bookwyrm-social/bookwyrm/assets/1807695/d8690032-3efb-463c-b752-7a75b696882f">
