### PR TITLE
Small UI fixes

### DIFF
--- a/bookwyrm/templates/directory/community_filter.html
+++ b/bookwyrm/templates/directory/community_filter.html
@@ -4,11 +4,11 @@
 {% block filter %}
 <legend class="label">{% trans "Community" %}</legend>
 <label class="is-block">
-    <input type="radio" class="radio" name="scope" value="local" {% if request.GET.scope == "local" %}checked{% endif %}>
+    <input type="radio" class="radio" name="scope" value="local" {% if scope == "local" %}checked{% endif %}>
     {% trans "Local users" %}
 </label>
 <label class="is-block">
-    <input type="radio" class="radio" name="scope" value="federated" {% if request.GET.scope == "federated" %}checked{% endif %}>
+    <input type="radio" class="radio" name="scope" value="federated" {% if scope == "federated" %}checked{% endif %}>
     {% trans "Federated community" %}
 </label>
 {% endblock %}

--- a/bookwyrm/templates/directory/sort_filter.html
+++ b/bookwyrm/templates/directory/sort_filter.html
@@ -6,8 +6,8 @@
 <div class="control">
     <div class="select">
         <select name="sort" id="id_sort">
-            <option value="recent" {% if request.GET.sort == "recent" %}selected{% endif %}>{% trans "Recently active" %}</option>
-            <option value="suggested" {% if request.GET.sort == "suggested" %}selected{% endif %}>{% trans "Suggested" %}</option>
+            <option value="recent" {% if sort == "recent" %}selected{% endif %}>{% trans "Recently active" %}</option>
+            <option value="suggested" {% if sort == "suggested" %}selected{% endif %}>{% trans "Suggested" %}</option>
         </select>
     </div>
 </div>

--- a/bookwyrm/templates/groups/user_groups.html
+++ b/bookwyrm/templates/groups/user_groups.html
@@ -31,5 +31,7 @@
             </div>
         </div>
     </div>
+    {% empty %}
+    <p class="column"><em>{% trans "No groups found." %}</em></p>
     {% endfor %}
 </div>

--- a/bookwyrm/templates/lists/list_items.html
+++ b/bookwyrm/templates/lists/list_items.html
@@ -46,8 +46,7 @@
             </div>
         </div>
     </div>
-    {% endfor %}
-    {% if not lists or not lists.exists %}
+    {% empty %}
     <p class="column"><em>{% trans "No lists found." %}</em></p>
-    {% endif %}
+    {% endfor %}
 </div>

--- a/bookwyrm/templates/lists/list_items.html
+++ b/bookwyrm/templates/lists/list_items.html
@@ -47,4 +47,7 @@
         </div>
     </div>
     {% endfor %}
+    {% if not lists or not lists.exists %}
+    <p class="column"><em>{% trans "No lists found." %}</em></p>
+    {% endif %}
 </div>

--- a/bookwyrm/templates/lists/lists.html
+++ b/bookwyrm/templates/lists/lists.html
@@ -43,7 +43,6 @@
 </nav>
 {% endif %}
 
-{% if lists %}
 <section class="block">
     {% include 'lists/list_items.html' with lists=lists %}
 </section>
@@ -51,7 +50,6 @@
 <div>
     {% include 'snippets/pagination.html' with page=lists path=path %}
 </div>
-{% endif %}
 
 {% endblock %}
 

--- a/bookwyrm/templates/user/goal.html
+++ b/bookwyrm/templates/user/goal.html
@@ -1,6 +1,10 @@
 {% extends 'user/layout.html' %}
-{% load i18n %}
 {% load utilities %}
+{% load i18n %}
+
+{% block title %}
+{% trans "Reading Goal" %} - {{ user|username }}
+{% endblock %}
 
 {% block header %}
 <div class="columns is-mobile">

--- a/bookwyrm/templates/user/groups.html
+++ b/bookwyrm/templates/user/groups.html
@@ -35,10 +35,6 @@
     </div>
 
     {% include 'groups/user_groups.html' with memberships=memberships %}
-
-    {% if not memberships or not memberships.exists %}
-    <p><em>{% trans "No groups found." %}</em></p>
-    {% endif %}
 </section>
 <div>
     {% include 'snippets/pagination.html' with page=user.memberships path=path %}

--- a/bookwyrm/templates/user/groups.html
+++ b/bookwyrm/templates/user/groups.html
@@ -1,5 +1,10 @@
 {% extends 'user/layout.html' %}
+{% load utilities %}
 {% load i18n %}
+
+{% block title %}
+{% trans "Groups" %} - {{ user|username }}
+{% endblock %}
 
 {% block header %}
 <div class="columns is-mobile">
@@ -30,6 +35,10 @@
     </div>
 
     {% include 'groups/user_groups.html' with memberships=memberships %}
+
+    {% if not memberships or not memberships.exists %}
+    <p><em>{% trans "No groups found." %}</em></p>
+    {% endif %}
 </section>
 <div>
     {% include 'snippets/pagination.html' with page=user.memberships path=path %}

--- a/bookwyrm/templates/user/lists.html
+++ b/bookwyrm/templates/user/lists.html
@@ -1,5 +1,10 @@
 {% extends 'user/layout.html' %}
+{% load utilities %}
 {% load i18n %}
+
+{% block title %}
+{% trans "Lists" %} - {{ user|username }}
+{% endblock %}
 
 {% block header %}
 <div class="columns is-mobile">

--- a/bookwyrm/templates/user/reviews_comments.html
+++ b/bookwyrm/templates/user/reviews_comments.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load utilities %}
 
-{% block title %}{{ user.display_name }}{% endblock %}
+{% block title %}
+{% trans "Reviews and Comments" %} - {{ user|username }}
+{% endblock %}
 
 {% block header %}
 <div class="columns is-mobile">
@@ -21,7 +23,7 @@
     {% endfor %}
     {% if not activities %}
     <div class="block">
-        <p>{% trans "No reviews or comments yet!" %}</p>
+        <p><em>{% trans "No reviews or comments yet!" %}</em></p>
     </div>
     {% endif %}
 

--- a/bookwyrm/templates/user/user.html
+++ b/bookwyrm/templates/user/user.html
@@ -126,7 +126,7 @@
     {% endfor %}
     {% if not activities %}
     <div class="block">
-        <p>{% trans "No activities yet!" %}</p>
+        <p><em>{% trans "No activities yet!" %}</em></p>
     </div>
     {% endif %}
 

--- a/bookwyrm/templates/user/user.html
+++ b/bookwyrm/templates/user/user.html
@@ -51,9 +51,15 @@
             {% endfor %}
             </div>
         </div>
+        {% empty %}
+        <p class="column">
+            <em>No books found.</em>
+        </p>
         {% endfor %}
     </div>
+    {% if shelves.exists %}
     <small><a href="{% url 'user-shelves' user|username %}">{% trans "View all books" %}</a></small>
+    {% endif %}
 </div>
 {% endif %}
 
@@ -119,16 +125,16 @@
         </div>
         {% endif %}
     </div>
+
     {% for activity in activities %}
     <div class="block" id="feed_{{ activity.id }}">
         {% include 'snippets/status/status.html' with status=activity %}
     </div>
-    {% endfor %}
-    {% if not activities %}
+    {% empty %}
     <div class="block">
         <p><em>{% trans "No activities yet!" %}</em></p>
     </div>
-    {% endif %}
+    {% endfor %}
 
     {% include 'snippets/pagination.html' with page=activities path=user.local_path anchor="#feed" mode="chronological" %}
 </div>

--- a/bookwyrm/templates/user/user_preview.html
+++ b/bookwyrm/templates/user/user_preview.html
@@ -23,12 +23,12 @@
         <p>
             {% if request.user.id == user.id or admin_mode %}
 
-                <a href="{% url 'user-relationships' user|username 'followers' %}">{% blocktrans trimmed count counter=user.followers.count %}
-                        {{ counter }} follower
+                <a href="{% url 'user-relationships' user|username 'followers' %}">{% blocktrans trimmed count counter=user.followers.count with display_count=user.followers.count|intcomma %}
+                        {{ display_count }} follower
                     {% plural %}
-                        {{ counter }} followers
+                        {{ display_count }} followers
                 {% endblocktrans %}</a>,
-                <a href="{% url 'user-relationships' user|username 'following' %}">{% blocktrans trimmed with counter=user.following.count %}
+                <a href="{% url 'user-relationships' user|username 'following' %}">{% blocktrans trimmed with counter=user.following.count|intcomma %}
                     {{ counter }} following
                 {% endblocktrans %}</a>
 

--- a/bookwyrm/views/directory.py
+++ b/bookwyrm/views/directory.py
@@ -19,7 +19,7 @@ class Directory(View):
         software = request.GET.get("software")
         if not software or software == "bookwyrm":
             filters["bookwyrm_user"] = True
-        scope = request.GET.get("scope")
+        scope = request.GET.get("scope", "federated")
         if scope == "local":
             filters["local"] = True
 
@@ -38,6 +38,8 @@ class Directory(View):
                 page.number, on_each_side=2, on_ends=1
             ),
             "users": page,
+            "sort": sort,
+            "scope": scope,
         }
         return TemplateResponse(request, "directory/directory.html", data)
 


### PR DESCRIPTION
A couple tiny things I noticed that were bugging me:
 - Follower/following counts don't use the intcomma filter -- now you will have "1,234" instead of "1234" followers, for example
 - The default filter values weren't being shown in the directory page, now they will be
 - The page title for the sub-pages of user profiles were all just the username, which was confusing. Now they say what page you are on
 - Added null state text for when you have no lists/groups/et ceters
 - Updates the formatting of null state text to all match (italics)