### PR TITLE
Pre-populate sort title in edit book form if not provided

### DIFF
--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -217,6 +217,13 @@ class Book(BookDataModel):
         """editions and works both use "book" instead of model_name"""
         return f"https://{DOMAIN}/book/{self.id}"
 
+    def guess_sort_title(self):
+        """Get a best-guess sort title for the current book"""
+        articles = chain(
+            *(LANGUAGE_ARTICLES.get(language, ()) for language in tuple(self.languages))
+        )
+        return re.sub(f'^{" |^".join(articles)} ', "", str(self.title).lower())
+
     def __repr__(self):
         # pylint: disable=consider-using-f-string
         return "<{} key={!r} title={!r}>".format(
@@ -375,15 +382,7 @@ class Edition(Book):
         # Create sort title by removing articles from title
         if self.sort_title in [None, ""]:
             if self.sort_title in [None, ""]:
-                articles = chain(
-                    *(
-                        LANGUAGE_ARTICLES.get(language, ())
-                        for language in tuple(self.languages)
-                    )
-                )
-                self.sort_title = re.sub(
-                    f'^{" |^".join(articles)} ', "", str(self.title).lower()
-                )
+                self.sort_title = self.guess_sort_title()
 
         return super().save(*args, **kwargs)
 

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -381,8 +381,7 @@ class Edition(Book):
 
         # Create sort title by removing articles from title
         if self.sort_title in [None, ""]:
-            if self.sort_title in [None, ""]:
-                self.sort_title = self.guess_sort_title()
+            self.sort_title = self.guess_sort_title()
 
         return super().save(*args, **kwargs)
 

--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -32,6 +32,9 @@ class EditBook(View):
     def get(self, request, book_id):
         """info about a book"""
         book = get_edition(book_id)
+        # This doesn't update the sort title, just pre-populates it in the form
+        if book.sort_title in ["", None]:
+            book.sort_title = book.guess_sort_title()
         if not book.description:
             book.description = book.parent_work.description
         data = {"book": book, "form": forms.EditionForm(instance=book)}
@@ -40,6 +43,7 @@ class EditBook(View):
     def post(self, request, book_id):
         """edit a book cool"""
         book = get_object_or_404(models.Edition, id=book_id)
+
         form = forms.EditionForm(request.POST, request.FILES, instance=book)
 
         data = {"book": book, "form": form}


### PR DESCRIPTION
It's confusing to edit a book when this isn't set, so this provides the best-guess version of the sort title if there isn't one provided, and allows the user to change it as needed.

Fixes #2944