### PR TITLE
fix illegal values in redis jobs

### DIFF
--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -112,7 +112,7 @@ class ActivityStream(RedisStore):
         trace.get_current_span().set_attribute("status_privacy", status.privacy)
         trace.get_current_span().set_attribute(
             "status_reply_parent_privacy",
-            status.reply_parent.privacy if status.reply_parent else None,
+            status.reply_parent.privacy if status.reply_parent else status.privacy,
         )
         # direct messages don't appear in feeds, direct comments/reviews/etc do
         if status.privacy == "direct" and status.status_type == "Note":

--- a/bookwyrm/suggested_users.py
+++ b/bookwyrm/suggested_users.py
@@ -254,7 +254,8 @@ def rerank_suggestions_task(user_id):
 def rerank_user_task(user_id, update_only=False):
     """do the hard work in celery"""
     user = models.User.objects.get(id=user_id)
-    suggested_users.rerank_obj(user, update_only=update_only)
+    if user:
+        suggested_users.rerank_obj(user, update_only=update_only)
 
 
 @app.task(queue=SUGGESTED_USERS)


### PR DESCRIPTION
1. `populate_streams_get_audience`

    This function tries to set status_reply_parent_privacy as `None` if there is no status.reply_parent, but `None` is not a valid value for privacy. This doesn't appear to be  breaking anything but does result in a lot of error messages in the logs. I have set the value to equal the original `status.privacy` - this won't really have any effect since it only happens when there is no parent, however we could set this to "direct" if we want to be highly cautious.

2. `rerank_user_task`

    Again, this doesn't seem to caused major issues, but is throwing errors if the user in question no longer exists for some reason. This commit checks whether `user` exists before attempting to rerank.