### PR TITLE
temporarily fix signed get requests failing

### DIFF
--- a/contrib/systemd/bookwyrm.service
+++ b/contrib/systemd/bookwyrm.service
@@ -6,7 +6,7 @@ After=network.target postgresql.service redis.service
 User=bookwyrm
 Group=bookwyrm
 WorkingDirectory=/opt/bookwyrm/
-ExecStart=/opt/bookwyrm/venv/bin/gunicorn bookwyrm.wsgi:application --threads=2 --bind 0.0.0.0:8000
+ExecStart=/opt/bookwyrm/venv/bin/gunicorn bookwyrm.wsgi:application --threads=8 --bind 0.0.0.0:8000
 StandardOutput=journal
 StandardError=inherit
 

--- a/contrib/systemd/bookwyrm.service
+++ b/contrib/systemd/bookwyrm.service
@@ -6,7 +6,7 @@ After=network.target postgresql.service redis.service
 User=bookwyrm
 Group=bookwyrm
 WorkingDirectory=/opt/bookwyrm/
-ExecStart=/opt/bookwyrm/venv/bin/gunicorn bookwyrm.wsgi:application --bind 0.0.0.0:8000
+ExecStart=/opt/bookwyrm/venv/bin/gunicorn bookwyrm.wsgi:application --threads=2 --bind 0.0.0.0:8000
 StandardOutput=journal
 StandardError=inherit
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   web:
     build: .
     env_file: .env
-    command: gunicorn bookwyrm.wsgi:application --threads=2 --bind 0.0.0.0:8000
+    command: gunicorn bookwyrm.wsgi:application --threads=8 --bind 0.0.0.0:8000
     logging: *default-logging
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   web:
     build: .
     env_file: .env
-    command: gunicorn bookwyrm.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn bookwyrm.wsgi:application --threads=2 --bind 0.0.0.0:8000
     logging: *default-logging
     volumes:
       - .:/app


### PR DESCRIPTION
Various issues have been raised regarding HTTP requests that seem to be dropped. The real fix for this in #2717 - "Stop making HTTP requests in views"

This commit is a quick fix in some circumstances - particularly #2844 - signed GET requests failing in production. It adds an extra thread to Gunicorn to make the default configuration multi-threaded. This will now match the multi-threaded nature of the development environment, which is why we have not been able to replicate these errors in dev.