### PR TITLE
chore: bump version to match the latest tag

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ImproperlyConfigured
 env = Env()
 env.read_env()
 DOMAIN = env("DOMAIN")
-VERSION = "0.6.4"
+VERSION = "0.6.5"
 
 RELEASE_API = env(
     "RELEASE_API",


### PR DESCRIPTION
I see this despite being updated to the latest release:
![image](https://github.com/bookwyrm-social/bookwyrm/assets/18251194/05eb7229-e97b-4989-a645-96f8237dff2f)
