### PR TITLE
fix opensearch template

### DIFF
--- a/bookwyrm/templates/opensearch.xml
+++ b/bookwyrm/templates/opensearch.xml
@@ -3,14 +3,13 @@
     xmlns="http://a9.com/-/spec/opensearch/1.1/"
     xmlns:moz="http://www.mozilla.org/2006/browser/search/"
 >
-    <ShortName>{{ site_name }}</ShortName>
+    <ShortName>{{ site.name }}</ShortName>
     <Description>{% blocktrans trimmed with site_name=site.name %}
         {{ site_name }} search
     {% endblocktrans %}</Description>
     <Image width="16" height="16" type="image/x-icon">{{ image }}</Image>
     <Url
         type="text/html"
-        method="get"
         template="https://{{ DOMAIN }}{% url 'search' %}?q={searchTerms}"
     />
 </OpenSearchDescription>


### PR DESCRIPTION
* "method" is not a valid attribute of the `Url` element
* "ShortName" cannot be empty - fixes `site_name` being used before it is assigned

fixes #2971 