### PR TITLE
parent_work was not always included when needed

### DIFF
--- a/bookwyrm/templates/book/edit/edit_book_form.html
+++ b/bookwyrm/templates/book/edit/edit_book_form.html
@@ -10,7 +10,7 @@
 {% csrf_token %}
 
 <input type="hidden" name="last_edited_by" value="{{ request.user.id }}">
-{% if form.parent_work %}
+{% if book.parent_work.id or form.parent_work %}
 <input type="hidden" name="parent_work" value="{% firstof book.parent_work.id form.parent_work %}">
 {% endif %}
 


### PR DESCRIPTION
parent_work was only included in the edit book form when ` form.parent_work` was set and not `book.parent_work.id`.

Fix #2973
Fix  #2978
