### PR TITLE
add reverse proxy for flower

### DIFF
--- a/bookwyrm/templates/settings/layout.html
+++ b/bookwyrm/templates/settings/layout.html
@@ -86,6 +86,9 @@
                 <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Celery status" %}</a>
             </li>
             <li>
+                <a href="/flower/"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Flower" %}</a>
+            </li>
+            <li>
                 {% url 'settings-email-config' as url %}
                 <a href="{{ url }}"{% if url in request.path %} class="is-active" aria-selected="true"{% endif %}>{% trans "Email Configuration" %}</a>
             </li>

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -28,6 +28,7 @@ BOOK_PATH = r"^book/(?P<book_id>\d+)"
 STREAMS = "|".join(s["key"] for s in settings.STREAMS)
 
 urlpatterns = [
+    views.FlowerProxyView.as_url(),
     path("admin/", admin.site.urls),
     path(
         "robots.txt",

--- a/bookwyrm/views/admin/flower.py
+++ b/bookwyrm/views/admin/flower.py
@@ -1,0 +1,17 @@
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.urls import path, re_path
+from revproxy.views import ProxyView
+
+class FlowerProxyView(UserPassesTestMixin, ProxyView):
+    upstream = 'http://{}:{}'.format('localhost', 8888)
+    url_prefix = 'flower'
+    rewrite = (
+        (r'^/{}$'.format(url_prefix), r'/{}/'.format(url_prefix)),
+     )
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    @classmethod
+    def as_url(cls):
+        return re_path(r'^(?P<path>{}.*)$'.format(cls.url_prefix), cls.as_view(), name='flower')


### PR DESCRIPTION
This adds a reverse proxy to flower from the admin dashboard so that you don't need to have a separate login for flower. Unfortunately, it relies on `django-revproxy`, and the current version (`0.10.0` on pypi is outdated and does not work with the current version of Django. A fork has been updated to work [django-revproxy 0.11.0](https://github.com/jazzband/django-revproxy) and can manually be installed via `venv/bin/pip install git+https://github.com/jazzband/django-revproxy.git`
Because of this complication, I'm only submitting this as draft pr, maybe someone has an idea on how to make this work without manual intervention?