### PR TITLE
Serve static files in debug mode

### DIFF
--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -1,6 +1,7 @@
 """ url routing for the app and api """
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import path, re_path
 from django.views.generic.base import TemplateView
 
@@ -773,6 +774,9 @@ urlpatterns = [
     ),
     path("guided-tour/<tour>", views.toggle_guided_tour),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# Serves /static when DEBUG is true.
+urlpatterns.extend(staticfiles_urlpatterns())
 
 # pylint: disable=invalid-name
 handler500 = "bookwyrm.views.server_error"


### PR DESCRIPTION
I develop without Docker (plain gunicorn), and this would be very useful.

(For this reason I would also add gunicorn to requirements.txt, if you're okay with that.)

P.S.: Here's the [documentation](https://docs.djangoproject.com/en/4.2/ref/contrib/staticfiles/#django.contrib.staticfiles.urls.staticfiles_urlpatterns) for `staticfiles_urlpatthers`, where it's clearly documented that it's DEBUG-only.

Thanks!