### PR TITLE
Fallback to showing first published date

### DIFF
--- a/bookwyrm/templates/book/publisher_info.html
+++ b/bookwyrm/templates/book/publisher_info.html
@@ -40,16 +40,13 @@
     </p>
 {% endif %}
 
-{% with date=book.published_date|naturalday publisher=book.publishers|join:', ' %}
-{% if date or book.first_published_date or book.publishers %}
-{% if date or book.first_published_date %}
+{% if book.published_date or book.first_published_date %}
     <meta
         itemprop="datePublished"
         content="{{ book.first_published_date|default:book.published_date|date:'Y-m-d' }}"
     >
 {% endif %}
 <p>
-
     {% comment %}
         @todo The publisher property needs to be an Organization or a Person. We’ll be using Thing which is the more generic ancestor.
         @see https://schema.org/Publisher
@@ -60,6 +57,7 @@
         {% endfor %}
     {% endif %}
 
+    {% with date=book.published_date|default:book.first_published_date|naturalday publisher=book.publishers|join:', ' %}
     {% if date and publisher %}
         {% blocktrans %}Published {{ date }} by {{ publisher }}.{% endblocktrans %}
     {% elif date %}
@@ -67,7 +65,6 @@
     {% elif publisher %}
         {% blocktrans %}Published by {{ publisher }}.{% endblocktrans %}
     {% endif %}
+    {% endwith %}
 </p>
-{% endif %}
-{% endwith %}
 {% endspaceless %}

--- a/bookwyrm/templates/book/publisher_info.html
+++ b/bookwyrm/templates/book/publisher_info.html
@@ -58,12 +58,12 @@
     {% endif %}
 
     {% with date=book.published_date|default:book.first_published_date|naturalday publisher=book.publishers|join:', ' %}
-    {% if date and publisher %}
+    {% if book.published_date and publisher %}
         {% blocktrans %}Published {{ date }} by {{ publisher }}.{% endblocktrans %}
-    {% elif date %}
-        {% blocktrans %}Published {{ date }}{% endblocktrans %}
     {% elif publisher %}
         {% blocktrans %}Published by {{ publisher }}.{% endblocktrans %}
+    {% elif date %}
+        {% blocktrans %}Published {{ date }}{% endblocktrans %}
     {% endif %}
     {% endwith %}
 </p>


### PR DESCRIPTION
First publication date is only shown when the editor is not known
(rationale: if the editor for the first edition is known, the same
date should be set in both fields?).
