### PR TITLE
create instance user on instance creation

### DIFF
--- a/bookwyrm/activitypub/__init__.py
+++ b/bookwyrm/activitypub/__init__.py
@@ -4,7 +4,11 @@ import sys
 
 from .base_activity import ActivityEncoder, Signature, naive_parse
 from .base_activity import Link, Mention, Hashtag
-from .base_activity import ActivitySerializerError, resolve_remote_id
+from .base_activity import (
+    ActivitySerializerError,
+    resolve_remote_id,
+    get_representative,
+)
 from .image import Document, Image
 from .note import Note, GeneratedNote, Article, Comment, Quotation
 from .note import Review, Rating

--- a/bookwyrm/tests/views/test_setup.py
+++ b/bookwyrm/tests/views/test_setup.py
@@ -72,7 +72,7 @@ class SetupViews(TestCase):
         self.site.refresh_from_db()
         self.assertFalse(self.site.install_mode)
 
-        user = models.User.objects.get()
+        user = models.User.objects.first()
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_superuser)
         self.assertTrue(user.is_staff)

--- a/bookwyrm/views/setup.py
+++ b/bookwyrm/views/setup.py
@@ -9,6 +9,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.views import View
 
+from bookwyrm.activitypub import get_representative
 from bookwyrm import forms, models
 from bookwyrm import settings
 from bookwyrm.utils import regex
@@ -96,4 +97,5 @@ class CreateAdmin(View):
         login(request, user)
         site.install_mode = False
         site.save()
+        get_representative()  # create the instance user
         return redirect("settings-site")


### PR DESCRIPTION
On a completely fresh install, sending a message from Bookwyrm to a formerly-unknown AP server requiring signed GET requests (aka `AUTHORIZED_FETCH` or secure mode) fails because the request is sent before the `bookwyrm.instance.user` creation is completed. Namely the user page `404`s, and then the receiving server rejects the request as it can't be verified.

This small PR creates the instance user at the point of initial admin user registration, preventing this problem.