### PR TITLE
Minor vocabulary fixes and structured data improvements

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -45,7 +45,7 @@
 
                     {% if book.series %}
                         <meta itemprop="isPartOf" content="{{ book.series | escape }}">
-                        <meta itemprop="volumeNumber" content="{{ book.series_number }}">
+                        <meta itemprop="position" content="{{ book.series_number }}">
 
                         {% if book.authors.exists %}
                             <a href="{% url 'book-series-by' book.authors.first.id %}?series_name={{ book.series | urlencode }}">

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -44,16 +44,18 @@
                     {% endif %}
 
                     {% if book.series %}
-                        <meta itemprop="isPartOf" content="{{ book.series | escape }}">
                         <meta itemprop="position" content="{{ book.series_number }}">
-
+                        <span itemprop="isPartOf" itemscope itemtype="https://schema.org/BookSeries">
                         {% if book.authors.exists %}
-                            <a href="{% url 'book-series-by' book.authors.first.id %}?series_name={{ book.series | urlencode }}">
+                            <a href="{% url 'book-series-by' book.authors.first.id %}?series_name={{ book.series | urlencode }}"
+                               itemprop="url">
                         {% endif %}
-                        {{ book.series }}{% if book.series_number %} #{{ book.series_number }}{% endif %}
+                        <span itemprop="name">{{ book.series }}</span>
+                        {% if book.series_number %} #{{ book.series_number }}{% endif %}
                         {% if book.authors.exists %}
                             </a>
                         {% endif %}
+                        </span>
                     {% endif %}
                 </p>
             {% endif %}

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -186,8 +186,6 @@
                     itemtype="https://schema.org/AggregateRating"
                 >
                     <meta itemprop="ratingValue" content="{{ rating|floatformat }}">
-                    {# @todo Is it possible to not hard-code the value? #}
-                    <meta itemprop="bestRating" content="5">
                     <meta itemprop="reviewCount" content="{{ review_count }}">
 
                     <span>

--- a/bookwyrm/templates/book/rating.html
+++ b/bookwyrm/templates/book/rating.html
@@ -5,13 +5,18 @@
             {% include 'snippets/avatar.html' with user=user %}
         </div>
 
-        <div class="media-content">
-            <div>
-                <a href="{{ user.local_path }}">{{ user.display_name }}</a>
+        <div class="media-content" itemprop="review" itemscope itemtype="https://schema.org/Review">
+            <div itemprop="author"
+                 itemscope
+                 itemtype="https://schema.org/Person"
+            >
+                <a href="{{ user.local_path }}" itemprop="url">
+                    <span itemprop="name">{{ user.display_name }}</span>
+                </a>
             </div>
-            <div class="is-flex">
+            <div class="is-flex" itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
+                <meta itemprop="ratingValue" content="{{ rating.rating|floatformat }}">
                 <p class="mr-1">{% trans "rated it" %}</p>
-
                 {% include 'snippets/stars.html' with rating=rating.rating %}
             </div>
             <div>

--- a/bookwyrm/templates/book/series.html
+++ b/bookwyrm/templates/book/series.html
@@ -5,15 +5,15 @@
 {% block title %}{{ series_name }}{% endblock %}
 
 {% block content %}
-<div class="block">
-	<h1 class="title">{{ series_name }}</h1>
+<div class="block" itemscope itemtype="https://schema.org/BookSeries">
+	<h1 class="title" itemprop="name">{{ series_name }}</h1>
 	<div class="subtitle" dir="auto">
 		{% trans "Series by" %} <a
 			href="{{ author.local_path }}"
 			class="author {{ link_class }}"
-			itemprop="author"
+			itemprop="creator"
 			itemscope
-			itemtype="https://schema.org/Thing"
+			itemtype="https://schema.org/Person"
 			><span
 					itemprop="name"
 					>{{ author.name }}</span></a>
@@ -22,6 +22,7 @@
 	<div class="columns is-multiline is-mobile">
 	{% for book in books %}
 	{% with book=book %}
+			{# @todo Set `hasPart` property in some meaningful way #}
 			<div class="column is-one-fifth-tablet is-half-mobile is-flex is-flex-direction-column">
 				<div class="is-flex-grow-1 mb-3">
 					<span class="subtitle">{% if book.series_number %}{% blocktrans with series_number=book.series_number %}Book {{ series_number }}{% endblocktrans %}{% else %}{% trans 'Unsorted Book' %}{% endif %}</span>

--- a/bookwyrm/templates/snippets/status/content_status.html
+++ b/bookwyrm/templates/snippets/status/content_status.html
@@ -6,14 +6,6 @@
 {% load humanize %}
 
 {% with status_type=status.status_type %}
-<div
-    class="block"
-    {% if status_type == "Review" %}
-        itemprop="rating"
-        itemtype="https://schema.org/Rating"
-    {% endif %}
->
-
     <div class="columns is-gapless">
         {% if not hide_book %}
             {% with book=status.book|default:status.mention_books.first %}
@@ -154,6 +146,5 @@
             </div>
         </article>
     </div>
-</div>
 
 {% endwith %}

--- a/bookwyrm/templates/snippets/status/content_status.html
+++ b/bookwyrm/templates/snippets/status/content_status.html
@@ -50,9 +50,6 @@
                         {% endif %}
                     >
                         <meta itemprop="ratingValue" content="{{ status.rating|floatformat }}">
-
-                        {# @todo Is it possible to not hard-code the value? #}
-                        <meta itemprop="bestRating" content="5">
                     </span>
                     {% include 'snippets/stars.html' with rating=status.rating %}
                 </h4>

--- a/bookwyrm/templates/snippets/status/headers/rating.html
+++ b/bookwyrm/templates/snippets/status/headers/rating.html
@@ -16,9 +16,6 @@
         >
             <span class="is-hidden" {{ rating_type }}>
                 <meta itemprop="ratingValue" content="{{ status.rating|floatformat }}">
-
-                {# @todo Is it possible to not hard-code the value? #}
-                <meta itemprop="bestRating" content="5">
             </span>
         </span>
     </span>


### PR DESCRIPTION
- 4a96a9333f7b5e49b53ac0c58f5d781c6edb53ba Remove duplicate Review object under `rating` property
- b1887081058a3ca1579c811d21008c6b53cc5b0e Drop `bestRating` property in ratings, since it defaults to 5
- 80879411a0a0ecfe604687726b0c3813b2819d24 Create Rating object (and its enclosing Review) in book/rating.html
- 02409a4700ae6f4a2a7c3eb993e56b9ed5d7c602 Use `position` property for Book objects in a series
- 1be6f7957439ec45cb835852a0935cd5a5c364cd Give URL of book series when setting `isPartOf`
- d368ea51b76e824617c2398144516376fba7a16a series.html: Create empty BookSeries object

-----


Most of these are fixes (as in, validator.schema.org warned about them); the last two are minor improvements.

The validator is actually run by Google, and they have additional checks of their own (for example, they don't allow _reviewCount_ to be zero in an AggregateRating). I could include a fix for those as well.