### PR TITLE
Fix creation of covers for ActivityPub imports

### DIFF
--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -482,10 +482,12 @@ class ImageField(ActivitypubFieldMixin, models.ImageField):
         image_slug = value
         # when it's an inline image (User avatar/icon, Book cover), it's a json
         # blob, but when it's an attached image, it's just a url
-        if hasattr(image_slug, "url"):
-            url = image_slug.url
-        elif isinstance(image_slug, str):
+        if isinstance(image_slug, str):
             url = image_slug
+        elif isinstance(image_slug, dict):
+            url = image_slug.get("url")
+        elif hasattr(image_slug, "url"):  # Serialized to Image/Document object?
+            url = image_slug.url
         else:
             return None
 


### PR DESCRIPTION
-----
Imports for other BookWyrm instances were showing without covers for me, and I think this is the cause?

Code seemed correct, as in, I _thought_ `value` here would be a document. But then the comment refers to receiving JSON, in which case the code is not correct. For this reason I've left both.