### PR TITLE
Final prettier re-run

### DIFF
--- a/bookwyrm/static/js/autocomplete.js
+++ b/bookwyrm/static/js/autocomplete.js
@@ -88,64 +88,64 @@ const tries = {
     mimetype: {
         a: {
             a: {
-                c: "AAC"
+                c: "AAC",
             },
             z: {
-                w: "AZW"
-            }
+                w: "AZW",
+            },
         },
         d: {
             a: {
                 i: {
                     s: {
-                        y: "Daisy"
-                    }
-                }
-            }
+                        y: "Daisy",
+                    },
+                },
+            },
         },
         e: {
             p: {
                 u: {
-                    b: "EPUB"
-                }
-            }
+                    b: "EPUB",
+                },
+            },
         },
         f: {
             l: {
                 a: {
-                    c: "FLAC"
-                }
-            }
+                    c: "FLAC",
+                },
+            },
         },
         h: {
             t: {
                 m: {
-                    l: "HTML"
-                }
-            }
+                    l: "HTML",
+                },
+            },
         },
         m: {
             4: {
                 a: "M4A",
-                b: "M4B"
+                b: "M4B",
             },
             o: {
                 b: {
-                    i: "MOBI"
-                }
+                    i: "MOBI",
+                },
             },
             p: {
-                3: "MP3"
-            }
+                3: "MP3",
+            },
         },
         o: {
             g: {
-                g: "OGG"
-            }
+                g: "OGG",
+            },
         },
         p: {
             d: {
-                f: "PDF"
+                f: "PDF",
             },
             l: {
                 a: {
@@ -154,13 +154,13 @@ const tries = {
                             t: {
                                 e: {
                                     x: {
-                                        t: "Plaintext"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                                        t: "Plaintext",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
             },
             r: {
                 i: {
@@ -170,15 +170,15 @@ const tries = {
                                 b: {
                                     o: {
                                         o: {
-                                            k: "Print book"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+                                            k: "Print book",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
 };

--- a/bookwyrm/static/js/bookwyrm.js
+++ b/bookwyrm/static/js/bookwyrm.js
@@ -352,8 +352,8 @@ let BookWyrm = new (class {
             method: "POST",
             body: new FormData(form),
             headers: {
-                Accept: "application/json"
-            }
+                Accept: "application/json",
+            },
         });
     }
 
@@ -620,7 +620,7 @@ let BookWyrm = new (class {
                 'input:not([type="hidden"]):not([disabled])',
                 "select:not([disabled])",
                 "details:not([disabled])",
-                '[tabindex]:not([tabindex="-1"]):not([disabled])'
+                '[tabindex]:not([tabindex="-1"]):not([disabled])',
             ].join(",")
         );
         const firstFocusableEl = focusableEls[0];
@@ -675,8 +675,8 @@ let BookWyrm = new (class {
                         target: scannerNode,
                         constraints: {
                             facingMode: "environment",
-                            deviceId: cameraId
-                        }
+                            deviceId: cameraId,
+                        },
                     },
                     decoder: {
                         readers: [
@@ -684,12 +684,12 @@ let BookWyrm = new (class {
                             {
                                 format: "ean_reader",
                                 config: {
-                                    supplements: ["ean_2_reader", "ean_5_reader"]
-                                }
-                            }
+                                    supplements: ["ean_2_reader", "ean_5_reader"],
+                                },
+                            },
                         ],
-                        multiple: false
-                    }
+                        multiple: false,
+                    },
                 },
                 (err) => {
                     if (err) {
@@ -756,7 +756,7 @@ let BookWyrm = new (class {
                         .forEach((box) => {
                             Quagga.ImageDebug.drawPath(box, { x: 0, y: 1 }, drawingCtx, {
                                 color: "green",
-                                lineWidth: 2
+                                lineWidth: 2,
                             });
                         });
                 }
@@ -764,14 +764,14 @@ let BookWyrm = new (class {
                 if (result.box) {
                     Quagga.ImageDebug.drawPath(result.box, { x: 0, y: 1 }, drawingCtx, {
                         color: "#00F",
-                        lineWidth: 2
+                        lineWidth: 2,
                     });
                 }
 
                 if (result.codeResult && result.codeResult.code) {
                     Quagga.ImageDebug.drawPath(result.line, { x: "x", y: "y" }, drawingCtx, {
                         color: "red",
-                        lineWidth: 3
+                        lineWidth: 3,
                     });
                 }
             }

--- a/bookwyrm/static/js/guided_tour.js
+++ b/bookwyrm/static/js/guided_tour.js
@@ -9,10 +9,10 @@ function disableGuidedTour(csrf_token) {
     "use strict";
     fetch("/guided-tour/False", {
         headers: {
-            "X-CSRFToken": csrf_token
+            "X-CSRFToken": csrf_token,
         },
         method: "POST",
         redirect: "follow",
-        mode: "same-origin"
+        mode: "same-origin",
     });
 }

--- a/bookwyrm/static/js/tabs.js
+++ b/bookwyrm/static/js/tabs.js
@@ -32,7 +32,7 @@ class TabGroup {
             left: 37,
             up: 38,
             right: 39,
-            down: 40
+            down: 40,
         };
     }
 
@@ -42,7 +42,7 @@ class TabGroup {
             37: -1,
             38: -1,
             39: 1,
-            40: 1
+            40: 1,
         };
     }
 


### PR DESCRIPTION
After #3042, the prettier config is the one we want ('es5', compatible with ESLint), but an update to the tree is necessary (since trailing commas were removed as part of #3034).

From what I've checked now: 3034 + 3042 + this PR = no diff in JS files, just prettier config.

So I think we're all set now!

/cc @jaschaurbach 