### PR TITLE
Shelter stable dates from USE_TZ

### DIFF
--- a/bookwyrm/models/author.py
+++ b/bookwyrm/models/author.py
@@ -32,8 +32,8 @@ class Author(BookDataModel):
         max_length=255, blank=True, null=True, deduplication_field=True
     )
     # idk probably other keys would be useful here?
-    born = fields.DateTimeField(blank=True, null=True)
-    died = fields.DateTimeField(blank=True, null=True)
+    born = fields.StableDateField(blank=True, null=True)
+    died = fields.StableDateField(blank=True, null=True)
     name = fields.CharField(max_length=255)
     aliases = fields.ArrayField(
         models.CharField(max_length=255), blank=True, default=list

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -135,8 +135,8 @@ class Book(BookDataModel):
     preview_image = models.ImageField(
         upload_to="previews/covers/", blank=True, null=True
     )
-    first_published_date = fields.DateTimeField(blank=True, null=True)
-    published_date = fields.DateTimeField(blank=True, null=True)
+    first_published_date = fields.StableDateField(blank=True, null=True)
+    published_date = fields.StableDateField(blank=True, null=True)
 
     objects = InheritanceManager()
     field_tracker = FieldTracker(fields=["authors", "title", "subtitle", "cover"])

--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -563,6 +563,7 @@ class StableDateField(DateTimeField):
     """a date in a datetime column, forcibly unaffected by USE_TZ"""
 
     # TODO: extend to PartialStableDate (or SealedDate).
+    # TODO: override field_from_activity(), if necessary?
 
     def formfield(self, **kwargs):
         kwargs.setdefault("form_class", StableDateFormField)
@@ -570,15 +571,13 @@ class StableDateField(DateTimeField):
 
     def to_python(self, value):
         if isinstance(value, date):
-            tz = timezone.get_fixed_timezone(timedelta(hours=-12))
             naive_dt = datetime(value.year, value.month, value.day)
+            westmost_tz = timezone.get_fixed_timezone(timedelta(hours=-12))
             # Convert to midnight in a timezone that has a stable date
             # across the globe. (This is a hotfix while we keep on
             # storing stable dates as DateTimeField.)
-            return timezone.make_aware(naive_dt, tz)
+            return timezone.make_aware(naive_dt, westmost_tz)
         return super().to_python(value)  # XXX Just return value?
-
-    # TODO: override field_from_activity(), if necessary?
 
 
 class HtmlField(ActivitypubFieldMixin, models.TextField):

--- a/bookwyrm/tests/views/books/test_edit_book.py
+++ b/bookwyrm/tests/views/books/test_edit_book.py
@@ -1,5 +1,4 @@
 """ test for app action functionality """
-from unittest import expectedFailure
 from unittest.mock import patch
 import responses
 from responses import matchers
@@ -229,8 +228,15 @@ class EditBookViews(TestCase):
             view(request)
 
         book = models.Edition.objects.get(title="New Title")
+        pub_datetime = book.published_date
+        new_timezone = timezone.get_fixed_timezone(-12 * 60)
+        pub_date_west = pub_datetime.astimezone(new_timezone)
+
         self.assertEqual(book.title, "New Title")
-        self.assertEqual(book.published_date.date().isoformat(), "2020-01-01")
+        self.assertEqual(book.edition_info, "2020")
+        self.assertEqual(pub_datetime, pub_date_west)
+        self.assertEqual(pub_datetime.date().isoformat(), "2020-01-01")
+        self.assertEqual(pub_date_west.date().isoformat(), "2020-01-01")
 
     def test_create_book_existing_work(self):
         """create an entirely new book and work"""

--- a/bookwyrm/tests/views/books/test_edit_book.py
+++ b/bookwyrm/tests/views/books/test_edit_book.py
@@ -211,7 +211,6 @@ class EditBookViews(TestCase):
         book = models.Edition.objects.get(title="New Title")
         self.assertEqual(book.parent_work.title, "New Title")
 
-    @expectedFailure  # bookwyrm#3028
     def test_create_book_published_date(self):
         """create a book and verify its publication date"""
         view = views.ConfirmEditBook.as_view()


### PR DESCRIPTION
- 28d1d466b08c81d33369ae1dee0d22bd251c7cb4 Add failing test case for "January 1st" offset bug
- 85f04f19ba8f5a71e15d51ff55bbd3b452832000 Shelter stable dates from USE_TZ

-----

Some dates (publication dates, author dates) are meant as _literals_. What
the user inputs through a `SelectDateWidget` should be preserved as-is.
Django's otherwise-excelent support for timezones interferes with it (see
#3028).

Until a better fate of these columns is determined (do we migrate them to a
DateField?), and as a stop-gap measure, we can start being faithful to the 
data by storing them in the Western-most timezone.

This is particularly important because `1/1/YYYY` is a common pattern in
publication dates, given #743.

Fixes: #3028.

-----

#3028 is somewhat intertwined with #743, because both work with the same columns. In general, I try to structure work in chunks that do something small and can be meaningfully applied.

With no need for a migration, I think this is a net win wrt the "shifting year" issue that was recently reported.

Furthermore, I believe in the future we might be able to deduce the correct tz conversions to apply. With this PR, I just offer a small tuning to affect/fix _observable_ behavior.

Many thanks in advance for any reviews!