### PR TITLE
File resubmit Option 1

### DIFF
--- a/bookwyrm/forms/books.py
+++ b/bookwyrm/forms/books.py
@@ -3,6 +3,7 @@ from django import forms
 
 from bookwyrm import models
 from bookwyrm.models.fields import ClearableFileInputWithWarning
+from file_resubmit.admin import AdminResubmitImageWidget
 from .custom_form import CustomForm
 from .widgets import ArrayWidget, SelectDateWidget, Select
 
@@ -70,9 +71,7 @@ class EditionForm(CustomForm):
             "published_date": SelectDateWidget(
                 attrs={"aria-describedby": "desc_published_date"}
             ),
-            "cover": ClearableFileInputWithWarning(
-                attrs={"aria-describedby": "desc_cover"}
-            ),
+            "cover": AdminResubmitImageWidget(attrs={"aria-describedby": "desc_cover"}),
             "physical_format": Select(
                 attrs={"aria-describedby": "desc_physical_format"}
             ),

--- a/bookwyrm/forms/books.py
+++ b/bookwyrm/forms/books.py
@@ -1,9 +1,9 @@
 """ using django model forms """
 from django import forms
 
-from bookwyrm import models
-from bookwyrm.models.fields import ClearableFileInputWithWarning
 from file_resubmit.admin import AdminResubmitImageWidget
+
+from bookwyrm import models
 from .custom_form import CustomForm
 from .widgets import ArrayWidget, SelectDateWidget, Select
 

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -99,6 +99,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
+    "file_resubmit",
     "sass_processor",
     "bookwyrm",
     "celery",
@@ -252,7 +253,11 @@ else:
             "OPTIONS": {
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
             },
-        }
+        },
+        "file_resubmit": {
+            "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+            "LOCATION": "/tmp/file_resubmit/",
+        },
     }
 
     SESSION_ENGINE = "django.contrib.sessions.backends.cache"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ celery==5.2.7
 colorthief==0.2.1
 Django==3.2.20
 django-celery-beat==2.4.0
+django-file-resubmit==0.5.2
 django-compressor==4.3.1
 django-imagekit==4.1.0
 django-model-utils==4.3.1


### PR DESCRIPTION
This fixes #2760 by using [django-file-resubmit](https://github.com/un1t/django-file-resubmit).

Pro: this is an off-the-shelf import

Con: `django-file-resubmit` hasn't been updated for 4 years, is written for Python 2, and leaves a confusing file input indicating that no file has been selected, when it has actually cached the file.

I will send a second PR shortly with an alternative option which pulls the code directly into Bookwyrm. It's MIT licensed so we can do this.

I believe ~~Option 1~~ Option 2 is the better option, but am providing both to compare.