### PR TITLE
File resubmit Option 2 - Retain uploaded images when creating new books

### DIFF
--- a/bookwyrm/forms/books.py
+++ b/bookwyrm/forms/books.py
@@ -3,6 +3,7 @@ from django import forms
 
 from bookwyrm import models
 from bookwyrm.models.fields import ClearableFileInputWithWarning
+from file_resubmit.admin import AdminResubmitImageWidget
 from .custom_form import CustomForm
 from .widgets import ArrayWidget, SelectDateWidget, Select
 
@@ -70,9 +71,7 @@ class EditionForm(CustomForm):
             "published_date": SelectDateWidget(
                 attrs={"aria-describedby": "desc_published_date"}
             ),
-            "cover": ClearableFileInputWithWarning(
-                attrs={"aria-describedby": "desc_cover"}
-            ),
+            "cover": AdminResubmitImageWidget(attrs={"aria-describedby": "desc_cover"}),
             "physical_format": Select(
                 attrs={"aria-describedby": "desc_physical_format"}
             ),

--- a/bookwyrm/forms/books.py
+++ b/bookwyrm/forms/books.py
@@ -2,8 +2,7 @@
 from django import forms
 
 from bookwyrm import models
-from bookwyrm.models.fields import ClearableFileInputWithWarning
-from file_resubmit.admin import AdminResubmitImageWidget
+from bookwyrm.utils.file_resubmit import AdminResubmitImageWidget
 from .custom_form import CustomForm
 from .widgets import ArrayWidget, SelectDateWidget, Select
 

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -99,7 +99,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
-    "file_resubmit",
     "sass_processor",
     "bookwyrm",
     "celery",

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -99,6 +99,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
+    "file_resubmit",
     "sass_processor",
     "bookwyrm",
     "celery",
@@ -252,7 +253,11 @@ else:
             "OPTIONS": {
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
             },
-        }
+        },
+        "file_resubmit": {
+            "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+            "LOCATION": "/tmp/file_resubmit/",
+        },
     }
 
     SESSION_ENGINE = "django.contrib.sessions.backends.cache"

--- a/bookwyrm/utils/file_resubmit.py
+++ b/bookwyrm/utils/file_resubmit.py
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from io import BytesIO
 import os
+from typing import Any
 import uuid
 
 from django import forms
@@ -37,7 +38,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 
 from django.forms import ClearableFileInput
 from django.forms.widgets import FILE_INPUT_CONTRADICTION
-from django.utils.safestring import mark_safe
+from django.utils.safestring import mark_safe, SafeString
 
 
 get_cache = lambda cache_name: caches[cache_name]
@@ -46,10 +47,10 @@ get_cache = lambda cache_name: caches[cache_name]
 class FileCache:
     """Use for temporarily caching image files in forms"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.backend = get_backend()
 
-    def set(self, key, upload):
+    def set(self, key: str, upload: Any) -> None:
         """set the state"""
         upload.file.seek(0)
         state = {
@@ -62,7 +63,7 @@ class FileCache:
         upload.file.seek(0)
         self.backend.set(key, state)
 
-    def get(self, key, field_name):
+    def get(self, key: str, field_name: str) -> Any:
         """get the state"""
         upload = None
         state = self.backend.get(key)
@@ -77,10 +78,10 @@ class FileCache:
                 size=state["size"],
                 charset=state["charset"],
             )
-            upload.file.seek(0)
+            upload.file.seek(0)  # type: ignore
         return upload
 
-    def delete(self, key):
+    def delete(self, key: str) -> None:
         """delete the cached file"""
         self.backend.delete(key)
 
@@ -88,13 +89,13 @@ class FileCache:
 class ResubmitBaseWidget(ClearableFileInput):
     """Base widget class for file_resubmit"""
 
-    def __init__(self, attrs=None, field_type=None):
+    def __init__(self, attrs: Any = None, field_type: Any = None) -> None:
         super().__init__(attrs=attrs)
         self.cache_key = ""
         self.field_type = field_type
-        self.input_name = None
+        self.input_name: str = ""
 
-    def value_from_datadict(self, data, files, name):
+    def value_from_datadict(self, data: Any, files: Any, name: str) -> Any:
         """get the value of the file"""
         upload = super().value_from_datadict(data, files, name)
         if upload == FILE_INPUT_CONTRADICTION:
@@ -114,8 +115,8 @@ class ResubmitBaseWidget(ClearableFileInput):
                 files[name] = upload
         return upload
 
-    def output_extra_data(self, value=None):
-        """output the name of the file if there already is one"""
+    def output_extra_data(self, value: Any = None) -> str:
+        """output the filename and hidden element if it is cached"""
         output = ""
         if value and self.cache_key:
             output += " " + filename_from_value(value)
@@ -131,7 +132,9 @@ class ResubmitBaseWidget(ClearableFileInput):
 class AdminResubmitImageWidget(ResubmitBaseWidget, BaseWidget):
     """class for saving original image upload in two-stage forms"""
 
-    def render(self, name, value, attrs=None, renderer=None):
+    def render(
+        self, name: str, value: Any, attrs: Any = None, renderer: Any = None
+    ) -> SafeString:
         if self.cache_key:
             output = self.output_extra_data(value)
         else:
@@ -140,16 +143,16 @@ class AdminResubmitImageWidget(ResubmitBaseWidget, BaseWidget):
         return mark_safe(output)
 
 
-def get_backend():
+def get_backend() -> Any:
     """get the file cache"""
-    return get_cache("file_resubmit")
+    return get_cache("file_resubmit")  # type: ignore
 
 
-def random_key():
+def random_key() -> str:
     """get a random UUID"""
     return uuid.uuid4().hex
 
 
-def filename_from_value(value):
+def filename_from_value(value: Any) -> Any:
     """get the file name"""
     return os.path.split(value.name)[-1] if value else ""

--- a/bookwyrm/utils/file_resubmit.py
+++ b/bookwyrm/utils/file_resubmit.py
@@ -1,0 +1,130 @@
+"""BookWyrm implementation of django-file-resubmit"""
+
+from io import BytesIO
+import os
+import uuid
+
+from django import forms
+
+from django.contrib.admin.widgets import AdminFileWidget as BaseWidget
+from django.core.cache import caches
+from django.core.files.uploadedfile import InMemoryUploadedFile
+
+from django.forms import ClearableFileInput
+from django.forms.widgets import FILE_INPUT_CONTRADICTION
+from django.utils.safestring import mark_safe
+
+
+get_cache = lambda cache_name: caches[cache_name]
+
+
+class FileCache:
+    """Use for temporarily caching image files in forms"""
+
+    def __init__(self):
+        self.backend = get_backend()
+
+    def set(self, key, upload):
+        """set the state"""
+        upload.file.seek(0)
+        state = {
+            "name": upload.name,
+            "size": upload.size,
+            "content_type": upload.content_type,
+            "charset": upload.charset,
+            "content": upload.file.read(),
+        }
+        upload.file.seek(0)
+        self.backend.set(key, state)
+
+    def get(self, key, field_name):
+        """get the state"""
+        upload = None
+        state = self.backend.get(key)
+        if state:
+            file = BytesIO()
+            file.write(state["content"])
+            upload = InMemoryUploadedFile(
+                file=file,
+                field_name=field_name,
+                name=state["name"],
+                content_type=state["content_type"],
+                size=state["size"],
+                charset=state["charset"],
+            )
+            upload.file.seek(0)
+        return upload
+
+    def delete(self, key):
+        """delete the cached file"""
+        self.backend.delete(key)
+
+
+class ResubmitBaseWidget(ClearableFileInput):
+    """Base widget class for file_resubmit"""
+
+    def __init__(self, attrs=None, field_type=None):
+        super().__init__(attrs=attrs)
+        self.cache_key = ""
+        self.field_type = field_type
+        self.input_name = None
+
+    def value_from_datadict(self, data, files, name):
+        """get the value of the file"""
+        upload = super().value_from_datadict(data, files, name)
+        if upload == FILE_INPUT_CONTRADICTION:
+            return upload
+
+        self.input_name = f"{name}_cache_key"
+        self.cache_key = data.get(self.input_name, "")
+
+        if name in files:
+            self.cache_key = random_key()[:10]
+            upload = files[name]
+            FileCache().set(self.cache_key, upload)
+        elif self.cache_key:
+            restored = FileCache().get(self.cache_key, name)
+            if restored:
+                upload = restored
+                files[name] = upload
+        return upload
+
+    def output_extra_data(self, value=None):
+        """output the name of the file if there already is one"""
+        output = ""
+        if value and self.cache_key:
+            output += " " + filename_from_value(value)
+        if self.cache_key:
+            output += forms.HiddenInput().render(
+                self.input_name,
+                self.cache_key,
+                {},
+            )
+        return output
+
+
+class AdminResubmitImageWidget(ResubmitBaseWidget, BaseWidget):
+    """class for saving original image upload in two-stage forms"""
+
+    def render(self, name, value, attrs=None, renderer=None):
+        if self.cache_key:
+            output = self.output_extra_data(value)
+        else:
+            output = super().render(name, value, attrs)
+            output += self.output_extra_data(value)
+        return mark_safe(output)
+
+
+def get_backend():
+    """get the file cache"""
+    return get_cache("file_resubmit")
+
+
+def random_key():
+    """get a random UUID"""
+    return uuid.uuid4().hex
+
+
+def filename_from_value(value):
+    """get the file name"""
+    return os.path.split(value.name)[-1] if value else ""

--- a/bookwyrm/utils/file_resubmit.py
+++ b/bookwyrm/utils/file_resubmit.py
@@ -1,4 +1,29 @@
-"""BookWyrm implementation of django-file-resubmit"""
+"""BookWyrm implementation of django-file-resubmit
+
+The majority of this code is originally from django-file-resubmit:
+https://github.com/un1t/django-file-resubmit,
+with some minor updates
+
+Copyright (C) 2011 by Ilya Shalyapin, ishalyapin@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
 
 from io import BytesIO
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ celery==5.2.7
 colorthief==0.2.1
 Django==3.2.20
 django-celery-beat==2.4.0
-django-file-resubmit==0.5.2
 django-compressor==4.3.1
 django-imagekit==4.1.0
 django-model-utils==4.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ celery==5.2.7
 colorthief==0.2.1
 Django==3.2.20
 django-celery-beat==2.4.0
+django-file-resubmit==0.5.2
 django-compressor==4.3.1
 django-imagekit==4.1.0
 django-model-utils==4.3.1


### PR DESCRIPTION
django-file-resubmit works ok, but it hasn't been updated for 4 years and seems to be abandoned. It also:

- leaves a file selector visible indicating no file is selected, which is confusing
- is written for Python 2

This PR brings the relevant parts of django-file-resubmit into Bookwyrm directly, under utils, and fixes the issue with the file selector.

Fixes #2760 