### PR TITLE
fix format_links errors on wrapped punctuation

### DIFF
--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -304,16 +304,23 @@ def format_links(content):
     for potential_link in split_content:
         if not potential_link:
             continue
-        wrapped = _wrapped(potential_link)
-        if wrapped:
-            wrapper_close = potential_link[-1]
-            formatted_content += potential_link[0]
-            potential_link = potential_link[1:-1]
 
         ends_with_punctuation = _ends_with_punctuation(potential_link)
         if ends_with_punctuation:
             punctuation_glyph = potential_link[-1]
             potential_link = potential_link[0:-1]
+
+        wrapped = _wrapped(potential_link)
+        wrapped_ends_with_punctuation = False
+        if wrapped:
+            wrapper_close = potential_link[-1]
+            formatted_content += potential_link[0]
+            potential_link = potential_link[1:-1]
+
+            wrapped_ends_with_punctuation = _ends_with_punctuation(potential_link)
+            if wrapped_ends_with_punctuation:
+                wrapped_punctuation_glyph = potential_link[-1]
+                potential_link = potential_link[0:-1]
 
         try:
             # raises an error on anything that's not a valid link
@@ -330,6 +337,9 @@ def format_links(content):
             formatted_content += f'<a href="{potential_link}">{link}</a>'
         except (ValidationError, UnicodeError):
             formatted_content += potential_link
+
+        if wrapped_ends_with_punctuation:
+            formatted_content += wrapped_punctuation_glyph
 
         if wrapped:
             formatted_content += wrapper_close


### PR DESCRIPTION
`format_links` checks for wrapping and end-punctuation in a different order to how it puts the formatted text back together:

1. check whether it is "wrapped"
2. if so, remove final wrapper character
3. check whether it ends in punctuation
4. if so remove end punctuation
5. check is valid URL
6. if wrapped, add closing wrapper
7. if end punctuation, add punctuation at end.

This creates a problem if there is end-punctuation _inside the wrapper_. Examples:

`[..]` => `[...` => `[..` => `[..]` => `[..].`
`(?)` => `(?` => `(` => `()` => `()?`

This commit makes the following changes to resolve this:

1. Check whether the string ends in punctuation before checking for wrappers
2. Check separately whether strings inside wrappers end in punctuation
3. Add wrapped end-punctuation before adding closing wrapper
4. Add closing wrapper before adding end-punctuation

fixes #2993 
fixes #3049 