### PR TITLE
Don't show notification for user follow request if the user is inactive

### DIFF
--- a/bookwyrm/templates/notifications/item.html
+++ b/bookwyrm/templates/notifications/item.html
@@ -10,7 +10,9 @@
 {% elif notification.notification_type == 'FOLLOW' %}
     {% include 'notifications/items/follow.html' %}
 {% elif notification.notification_type == 'FOLLOW_REQUEST' %}
-    {% include 'notifications/items/follow_request.html' %}
+    {% if notification.related_users.0.is_active %}
+        {% include 'notifications/items/follow_request.html' %}
+    {% endif %}
 {% elif notification.notification_type == 'IMPORT' %}
     {% include 'notifications/items/import.html' %}
 {% elif notification.notification_type == 'ADD' %}


### PR DESCRIPTION
Fixes #3024 -- this removes the notification (which is how it works on the profile page, the button is hidden)