### PR TITLE
UI changes for notification and download link in import/export flow

### DIFF
--- a/bookwyrm/templates/notifications/items/user_export.html
+++ b/bookwyrm/templates/notifications/items/user_export.html
@@ -1,11 +1,15 @@
 {% extends 'notifications/items/layout.html' %}
 {% load i18n %}
 
+{% block primary_link %}{% spaceless %}
+{% url 'prefs-user-export' %}
+{% endspaceless %}{% endblock %}
+
 {% block icon %}
 <span class="icon icon-list"></span>
 {% endblock %}
 
 {% block description %}
-    {% url 'prefs-export-file' notification.related_user_export.task_id as url %}
+    {% url 'prefs-user-export'  as url %}
     {% blocktrans %}Your <a download href="{{ url }}">user export</a> is ready.{% endblocktrans %}
 {% endblock %}

--- a/bookwyrm/templates/notifications/items/user_export.html
+++ b/bookwyrm/templates/notifications/items/user_export.html
@@ -11,5 +11,5 @@
 
 {% block description %}
     {% url 'prefs-user-export'  as url %}
-    {% blocktrans %}Your <a download href="{{ url }}">user export</a> is ready.{% endblocktrans %}
+    {% blocktrans %}Your <a href="{{ url }}">user export</a> is ready.{% endblocktrans %}
 {% endblock %}

--- a/bookwyrm/templates/notifications/items/user_import.html
+++ b/bookwyrm/templates/notifications/items/user_import.html
@@ -1,6 +1,10 @@
 {% extends 'notifications/items/layout.html' %}
 {% load i18n %}
 
+{% block primary_link %}{% spaceless %}
+{% url 'user-import' %}
+{% endspaceless %}{% endblock %}
+
 {% block icon %}
 <span class="icon icon-list"></span>
 {% endblock %}

--- a/bookwyrm/templates/preferences/export-user.html
+++ b/bookwyrm/templates/preferences/export-user.html
@@ -1,5 +1,6 @@
 {% extends 'preferences/layout.html' %}
 {% load i18n %}
+{% load utilities %}
 
 {% block title %}{% trans "User Export" %}{% endblock %}
 
@@ -40,8 +41,11 @@
                 <th>
                     {% trans "Date" %}
                 </th>
-                <th colspan="2">
+                <th>
                     {% trans "Status" %}
+                </th>
+                <th colspan="2">
+                    {% trans "Size" %}
                 </th>
             </tr>
             {% if not jobs %}
@@ -75,6 +79,9 @@
                             {% trans "Active" %}
                         {% endif %}
                     </span>
+                </td>
+                <td>
+                    <span>{{ job.export_data|get_file_size }}</span>
                 </td>
                 <td>
                     {% if job.complete and not job.status == "stopped" and not job.status == "failed" %}

--- a/bookwyrm/templates/preferences/export-user.html
+++ b/bookwyrm/templates/preferences/export-user.html
@@ -75,9 +75,9 @@
                             {% trans "Active" %}
                         {% endif %}
                     </span>
-                    {% if job.complete and not job.status == "stopped" and not job.status == "failed" %}
                 </td>
                 <td>
+                    {% if job.complete and not job.status == "stopped" and not job.status == "failed" %}
                     <p>
                         <a download="" href="/preferences/user-export/{{ job.task_id }}">
                             <span class="icon icon-download" aria-hidden="true"></span>

--- a/bookwyrm/templates/preferences/export-user.html
+++ b/bookwyrm/templates/preferences/export-user.html
@@ -38,12 +38,9 @@
         <table class="table is-striped is-fullwidth">
             <tr>
                 <th>
-                    {% trans "Date Created" %}
+                    {% trans "Date" %}
                 </th>
-                <th>
-                    {% trans "Last Updated" %}
-                </th>
-                <th>
+                <th colspan="2">
                     {% trans "Status" %}
                 </th>
             </tr>
@@ -56,13 +53,6 @@
             {% endif %}
             {% for job in jobs %}
             <tr>
-                <td>
-                    {% if job.complete and not job.status == "stopped" and not job.status == "failed" %}
-                    <p><a download="" href="/preferences/user-export/{{ job.task_id }}">{{ job.created_date }}</a></p>
-                    {% else %}
-                    <p>{{ job.created_date }}</p>
-                    {% endif %}
-                </td>
                 <td>{{ job.updated_date }}</td>
                 <td>
                     <span
@@ -85,6 +75,18 @@
                             {% trans "Active" %}
                         {% endif %}
                     </span>
+                    {% if job.complete and not job.status == "stopped" and not job.status == "failed" %}
+                </td>
+                <td>
+                    <p>
+                        <a download="" href="/preferences/user-export/{{ job.task_id }}">
+                            <span class="icon icon-download" aria-hidden="true"></span>
+                            <span class="is-hidden-mobile">
+                                {% trans "Download your export" %}
+                            </span>
+                        </a>
+                    </p>
+                    {% endif %}
                 </td>
             </tr>
             {% endfor %}

--- a/bookwyrm/templatetags/utilities.py
+++ b/bookwyrm/templatetags/utilities.py
@@ -125,3 +125,20 @@ def id_to_username(user_id):
         value = f"{name}@{domain}"
 
     return value
+
+
+@register.filter(name="get_file_size")
+def get_file_size(file):
+    """display the size of a file in human readable terms"""
+
+    try:
+        raw_size = os.stat(file.path).st_size
+        if raw_size < 1024:
+            return f"{raw_size} bytes"
+        if raw_size < 1024**2:
+            return f"{raw_size/1024:.2f} KB"
+        if raw_size < 1024**3:
+            return f"{raw_size/1024**2:.2f} MB"
+        return f"{raw_size/1024**3:.2f} GB"
+    except Exception:  # pylint: disable=broad-except
+        return ""


### PR DESCRIPTION
The first change adds a link to the import notification, and changes the export notification to link to the page, rather than the file itself (I found that unexpected behavior). I also changed the table to only show one date (I'm not sure if this is a good change, but I thought both seemed like more info than needed?) and to use an explicit download link rather than having people click the date, which I think is clearer. I was looking at the mastodon export UI for ideas, and I also like that they should file size, but I don't know if that's easy to get.

<img width="884" alt="Screenshot 2023-11-06 at 8 41 26 AM" src="https://github.com/bookwyrm-social/bookwyrm/assets/1807695/85d1f555-460b-4ae8-adc6-5ca82a1c0e73">
