### PR TITLE
fix missing types in `BookData` file fields

### DIFF
--- a/bookwyrm/activitypub/book.py
+++ b/bookwyrm/activitypub/book.py
@@ -22,8 +22,6 @@ class BookData(ActivityObject):
     aasin: Optional[str] = None
     isfdb: Optional[str] = None
     lastEditedBy: Optional[str] = None
-    links: list[str] = field(default_factory=list)
-    fileLinks: list[str] = field(default_factory=list)
 
 
 # pylint: disable=invalid-name
@@ -44,6 +42,8 @@ class Book(BookData):
     authors: list[str] = field(default_factory=list)
     firstPublishedDate: str = ""
     publishedDate: str = ""
+
+    fileLinks: list[str] = field(default_factory=list)
 
     cover: Optional[Document] = None
     type: str = "Book"


### PR DESCRIPTION
`activitypub.BookData` includes fields for 'files' and 'fileLinks'. 

This is a problem because `BookData` is inherited by `Book` and `Author`, neither of which have 'files' as a field in the main model. Additionally, Author doesn't have a value for 'file_links'. 

When serializing to JSON, BookData therefore throws `TypeError: Object of type _MISSING_TYPE is not JSON serializable`

This PR fixes the problem by removing `links` and moving `fileLinks` to `activitypub.Book`.