### PR TITLE
Create NotificationType as class, not through API

### DIFF
--- a/bookwyrm/models/__init__.py
+++ b/bookwyrm/models/__init__.py
@@ -34,7 +34,7 @@ from .site import PasswordReset, InviteRequest
 from .announcement import Announcement
 from .antispam import EmailBlocklist, IPBlocklist, AutoMod, automod_task
 
-from .notification import Notification
+from .notification import Notification, NotificationType
 
 from .hashtag import Hashtag
 

--- a/bookwyrm/models/antispam.py
+++ b/bookwyrm/models/antispam.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 
 from bookwyrm.tasks import app, MISC
 from .base_model import BookWyrmModel
+from .notification import NotificationType
 from .user import User
 
 
@@ -80,7 +81,7 @@ def automod_task():
     with transaction.atomic():
         for admin in admins:
             notification, _ = notification_model.objects.get_or_create(
-                user=admin, notification_type=notification_model.REPORT, read=False
+                user=admin, notification_type=NotificationType.REPORT, read=False
             )
             notification.related_reports.set(reports)
 

--- a/bookwyrm/models/move.py
+++ b/bookwyrm/models/move.py
@@ -6,7 +6,7 @@ from bookwyrm import activitypub
 from .activitypub_mixin import ActivityMixin
 from .base_model import BookWyrmModel
 from . import fields
-from .notification import Notification
+from .notification import Notification, NotificationType
 
 
 class Move(ActivityMixin, BookWyrmModel):
@@ -49,7 +49,6 @@ class MoveUser(Move):
 
         # only allow if the source is listed in the target's alsoKnownAs
         if self.user in self.target.also_known_as.all():
-
             self.user.also_known_as.add(self.target.id)
             self.user.update_active_date()
             self.user.moved_to = self.target.remote_id
@@ -65,7 +64,7 @@ class MoveUser(Move):
             for follower in self.user.followers.all():
                 if follower.local:
                     Notification.notify(
-                        follower, self.user, notification_type=Notification.MOVE
+                        follower, self.user, notification_type=NotificationType.MOVE
                     )
 
         else:

--- a/bookwyrm/tests/models/test_notification.py
+++ b/bookwyrm/tests/models/test_notification.py
@@ -43,7 +43,7 @@ class Notification(TestCase):
     def test_notification(self):
         """New notifications are unread"""
         notification = models.Notification.objects.create(
-            user=self.local_user, notification_type=models.Notification.FAVORITE
+            user=self.local_user, notification_type=models.NotificationType.FAVORITE
         )
         self.assertFalse(notification.read)
 
@@ -52,7 +52,7 @@ class Notification(TestCase):
         models.Notification.notify(
             self.local_user,
             self.remote_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertTrue(models.Notification.objects.exists())
 
@@ -61,7 +61,7 @@ class Notification(TestCase):
         models.Notification.notify(
             self.local_user,
             self.remote_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertEqual(models.Notification.objects.count(), 1)
         notification = models.Notification.objects.get()
@@ -70,7 +70,7 @@ class Notification(TestCase):
         models.Notification.notify(
             self.local_user,
             self.another_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertEqual(models.Notification.objects.count(), 1)
         notification.refresh_from_db()
@@ -92,7 +92,7 @@ class Notification(TestCase):
         models.Notification.notify(
             self.remote_user,
             self.local_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertFalse(models.Notification.objects.exists())
 
@@ -101,7 +101,7 @@ class Notification(TestCase):
         models.Notification.notify(
             self.local_user,
             self.local_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertFalse(models.Notification.objects.exists())
 
@@ -154,14 +154,14 @@ class Notification(TestCase):
         models.Notification.notify(
             self.local_user,
             self.remote_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertTrue(models.Notification.objects.exists())
 
         models.Notification.unnotify(
             self.local_user,
             self.remote_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertFalse(models.Notification.objects.exists())
 
@@ -170,25 +170,25 @@ class Notification(TestCase):
         models.Notification.notify(
             self.local_user,
             self.remote_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         models.Notification.notify(
             self.local_user,
             self.another_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertTrue(models.Notification.objects.exists())
 
         models.Notification.unnotify(
             self.local_user,
             self.remote_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertTrue(models.Notification.objects.exists())
 
         models.Notification.unnotify(
             self.local_user,
             self.another_user,
-            notification_type=models.Notification.FAVORITE,
+            notification_type=models.NotificationType.FAVORITE,
         )
         self.assertFalse(models.Notification.objects.exists())

--- a/bookwyrm/views/group.py
+++ b/bookwyrm/views/group.py
@@ -13,8 +13,10 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django.db.models.functions import Greatest
 
 from bookwyrm import forms, models
+from bookwyrm.models import NotificationType
 from bookwyrm.suggested_users import suggested_users
 from .helpers import get_user_from_username, maybe_redirect_local_path
+
 
 # pylint: disable=no-self-use
 class Group(View):
@@ -59,11 +61,11 @@ class Group(View):
         model = apps.get_model("bookwyrm.Notification", require_ready=True)
         for field in form.changed_data:
             notification_type = (
-                model.GROUP_PRIVACY
+                NotificationType.GROUP_PRIVACY
                 if field == "privacy"
-                else model.GROUP_NAME
+                else NotificationType.GROUP_NAME
                 if field == "name"
-                else model.GROUP_DESCRIPTION
+                else NotificationType.GROUP_DESCRIPTION
                 if field == "description"
                 else None
             )
@@ -251,7 +253,9 @@ def remove_member(request):
 
         memberships = models.GroupMember.objects.filter(group=group)
         model = apps.get_model("bookwyrm.Notification", require_ready=True)
-        notification_type = model.LEAVE if user == request.user else model.REMOVE
+        notification_type = (
+            NotificationType.LEAVE if user == request.user else NotificationType.REMOVE
+        )
         # let the other members know about it
         for membership in memberships:
             member = membership.user
@@ -264,7 +268,7 @@ def remove_member(request):
                 )
 
         # let the user (now ex-member) know as well, if they were removed
-        if notification_type == model.REMOVE:
+        if notification_type == NotificationType.REMOVE:
             model.notify(
                 user, None, related_group=group, notification_type=notification_type
             )


### PR DESCRIPTION
This way, we need not list every value again to create the enum.

N.B.: Enum values are now accessed as `models.NotificationType.FOO`,
instead of `models.Notification.FOO`.
