### PR TITLE
Do not create AggregateRating if review_count is zero

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -181,6 +181,9 @@
 
         <div class="column is-three-fifths">
             <div class="block">
+                {% if not review_count %}
+                <div class="field is-grouped">
+                {% else %}
                 <div
                     class="field is-grouped"
                     itemprop="aggregateRating"
@@ -189,6 +192,7 @@
                 >
                     <meta itemprop="ratingValue" content="{{ rating|floatformat }}">
                     <meta itemprop="reviewCount" content="{{ review_count }}">
+                {% endif %}
 
                     <span>
                         {% include 'snippets/stars.html' with rating=rating %}


### PR DESCRIPTION
This is a follow-up to #3036 ("Minor vocabulary fixes and structured data improvements"), where @jaschaurbach suggested including this fix.