### PR TITLE
Display custom page on 413 errors

### DIFF
--- a/bookwyrm/middleware/__init__.py
+++ b/bookwyrm/middleware/__init__.py
@@ -1,3 +1,4 @@
 """ look at all this nice middleware! """
 from .timezone_middleware import TimezoneMiddleware
 from .ip_middleware import IPBlocklistMiddleware
+from .file_too_big import FileTooBig

--- a/bookwyrm/middleware/file_too_big.py
+++ b/bookwyrm/middleware/file_too_big.py
@@ -1,0 +1,30 @@
+"""Middleware to display a custom 413 error page"""
+
+from django.http import HttpResponse
+from django.shortcuts import render
+from django.core.exceptions import RequestDataTooBig
+
+
+class FileTooBig:
+    """Middleware to display a custom page when a
+    RequestDataTooBig exception is thrown"""
+
+    def __init__(self, get_response):
+        """boilerplate __init__ from Django docs"""
+
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """If RequestDataTooBig is thrown, render the 413 error page"""
+
+        try:
+            body = request.body  # pylint: disable=unused-variable
+
+        except RequestDataTooBig:
+
+            rendered = render(request, "413.html")
+            response = HttpResponse(rendered)
+            return response
+
+        response = self.get_response(request)
+        return response

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -119,6 +119,7 @@ MIDDLEWARE = [
     "bookwyrm.middleware.IPBlocklistMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "bookwyrm.middleware.FileTooBig",
 ]
 
 ROOT_URLCONF = "bookwyrm.urls"

--- a/bookwyrm/templates/413.html
+++ b/bookwyrm/templates/413.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "File too large" %}{% endblock %}
+
+{% block content %}
+<div class="block">
+    <h1 class="title">{% trans "File too large" %}</h1>
+    <p class="content">{% trans "The file you are uploading is too large." %}</p>
+    <p class="content">
+        {% blocktrans %}
+        You you can try using a smaller file, or ask your BookWyrm server administrator to increase the <code>DATA_UPLOAD_MAX_MEMORY_SIZE</code> setting.
+        {% endblocktrans %}
+    </p>
+</div>
+{% endblock %}


### PR DESCRIPTION
When a `RequestDataTooBig` exception is thrown, users are largely in the dark about what happened and how it can be fixed. This PR resolves this by inserting middleware to redirect the request to a custom 413 error page.

This exception is thrown when `DATA_UPLOAD_MAX_MEMORY_SIZE` is exceeded. The default value is 2.5MB, but admins can set any value (in bytes).

Fixes #2340
Fixes #2633

Somewhat addresses #2914