### PR TITLE
fix saved list pagination

### DIFF
--- a/bookwyrm/views/list/lists.py
+++ b/bookwyrm/views/list/lists.py
@@ -59,7 +59,7 @@ class SavedLists(View):
         data = {
             "lists": paginated.get_page(request.GET.get("page")),
             "list_form": forms.ListForm(),
-            "path": "/list",
+            "path": "/list/saved",
         }
         return TemplateResponse(request, "lists/lists.html", data)
 


### PR DESCRIPTION
The `SavedLists` view was passing through an incorrect "path" value. Now it's not.

fixes #3041 