### PR TITLE
Do not create a set for already-distinct query result

### DIFF
--- a/bookwyrm/book_search.py
+++ b/bookwyrm/book_search.py
@@ -137,7 +137,7 @@ def search_title_author(
 
     # filter out multiple editions of the same work
     list_results = []
-    for work_id in set(editions_of_work[:30]):
+    for work_id in editions_of_work[:30]:
         result = (
             results.filter(parent_work=work_id)
             .order_by("-rank", "-edition_rank")

--- a/bookwyrm/tests/test_book_search.py
+++ b/bookwyrm/tests/test_book_search.py
@@ -26,10 +26,10 @@ class BookSearch(TestCase):
             parent_work=self.work,
             isbn_10="1111111111",
             openlibrary_key="hello",
+            pages=150,
         )
-
         self.third_edition = models.Edition.objects.create(
-            title="Edition with annoying ISBN",
+            title="Another Edition with annoying ISBN",
             parent_work=self.work,
             isbn_10="022222222X",
         )
@@ -76,16 +76,21 @@ class BookSearch(TestCase):
 
     def test_search_title_author(self):
         """search by unique identifiers"""
-        results = book_search.search_title_author("Another", min_confidence=0)
+        results = book_search.search_title_author("annoying", min_confidence=0)
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0], self.second_edition)
+        self.assertEqual(results[0], self.third_edition)
 
     def test_search_title_author_return_first(self):
-        """search by unique identifiers"""
-        results = book_search.search_title_author(
+        """sorts by edition rank"""
+        result = book_search.search_title_author(
             "Another", min_confidence=0, return_first=True
         )
-        self.assertEqual(results, self.second_edition)
+        self.assertEqual(result, self.second_edition)  # highest edition rank
+
+    def test_search_title_author_one_edition_per_work(self):
+        """at most one edition per work"""
+        results = book_search.search_title_author("Edition", 0)
+        self.assertEqual(results, [self.first_edition])  # highest edition rank
 
     def test_format_search_result(self):
         """format a search result"""


### PR DESCRIPTION
I found this while looking at #2955.

It doesn't fix every case¹, but I l tested locally that we indeed can lose ordering from the database while switching to work ids.

I wrote a test for this but the ranks were numerically the same for all the title pairs I could think of. (Seemingly due to the composite SearchQuery object; if I limit it to English, I could get different rankings and replicate the bug in a test).

The issue can be closed later by hand later, re-checking the search in bookwyrm.social after the next release.

 (¹) For example, for _The Blade Itself_ it might be more about the fact that its search vector is just `'blade':2`.