### PR TITLE
Faster tests with setUpTestData

### DIFF
--- a/bookwyrm/tests/activitypub/test_author.py
+++ b/bookwyrm/tests/activitypub/test_author.py
@@ -6,7 +6,8 @@ from bookwyrm import models
 class Author(TestCase):
     """serialize author tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """initial data"""
         self.book = models.Edition.objects.create(
             title="Example Edition",

--- a/bookwyrm/tests/activitypub/test_base_activity.py
+++ b/bookwyrm/tests/activitypub/test_base_activity.py
@@ -28,8 +28,8 @@ from bookwyrm import models
 class BaseActivity(TestCase):
     """the super class for model-linked activitypub dataclasses"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we're probably going to re-use this so why copy/paste"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -40,6 +40,7 @@ class BaseActivity(TestCase):
         self.user.remote_id = "http://example.com/a/b"
         self.user.save(broadcast=False, update_fields=["remote_id"])
 
+    def setUp(self):
         datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_user.json")
         self.userdata = json.loads(datafile.read_bytes())
         # don't try to load the user icon

--- a/bookwyrm/tests/activitypub/test_note.py
+++ b/bookwyrm/tests/activitypub/test_note.py
@@ -10,8 +10,8 @@ from bookwyrm import models
 class Note(TestCase):
     """the model-linked ActivityPub dataclass for Note-based types"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create a shared user"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/activitypub/test_quotation.py
+++ b/bookwyrm/tests/activitypub/test_quotation.py
@@ -10,7 +10,8 @@ from bookwyrm import activitypub, models
 class Quotation(TestCase):
     """we have hecka ways to create statuses"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """model objects we'll need"""
         with patch("bookwyrm.models.user.set_remote_server.delay"):
             self.user = models.User.objects.create_user(
@@ -26,6 +27,9 @@ class Quotation(TestCase):
             title="Example Edition",
             remote_id="https://example.com/book/1",
         )
+
+    def setUp(self):
+        """other test data"""
         datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_quotation.json")
         self.status_data = json.loads(datafile.read_bytes())
 

--- a/bookwyrm/tests/activitystreams/test_abstractstream.py
+++ b/bookwyrm/tests/activitystreams/test_abstractstream.py
@@ -15,7 +15,8 @@ from bookwyrm import activitystreams, models
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """use a test csv"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -42,6 +43,9 @@ class Activitystreams(TestCase):
             )
         work = models.Work.objects.create(title="test work")
         self.book = models.Edition.objects.create(title="test book", parent_work=work)
+
+    def setUp(self):
+        """per-test setUp"""
 
         class TestStream(activitystreams.ActivityStream):
             """test stream, don't have to do anything here"""

--- a/bookwyrm/tests/activitystreams/test_booksstream.py
+++ b/bookwyrm/tests/activitystreams/test_booksstream.py
@@ -14,7 +14,8 @@ from bookwyrm import activitystreams, models
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """use a test csv"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/activitystreams/test_homestream.py
+++ b/bookwyrm/tests/activitystreams/test_homestream.py
@@ -12,7 +12,8 @@ from bookwyrm import activitystreams, models
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """use a test csv"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/activitystreams/test_localstream.py
+++ b/bookwyrm/tests/activitystreams/test_localstream.py
@@ -12,7 +12,8 @@ from bookwyrm import activitystreams, models
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """use a test csv"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/activitystreams/test_signals.py
+++ b/bookwyrm/tests/activitystreams/test_signals.py
@@ -14,16 +14,14 @@ from bookwyrm import activitystreams, models
 class ActivitystreamsSignals(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """use a test csv"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
             self.local_user = models.User.objects.create_user(
                 "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            self.another_user = models.User.objects.create_user(
-                "fish", "fish@fish.fish", "password", local=True, localname="fish"
             )
         with patch("bookwyrm.models.user.set_remote_server.delay"):
             self.remote_user = models.User.objects.create_user(
@@ -35,8 +33,6 @@ class ActivitystreamsSignals(TestCase):
                 inbox="https://example.com/users/rat/inbox",
                 outbox="https://example.com/users/rat/outbox",
             )
-        work = models.Work.objects.create(title="test work")
-        self.book = models.Edition.objects.create(title="test book", parent_work=work)
 
     def test_add_status_on_create_ignore(self, *_):
         """a new statuses has entered"""

--- a/bookwyrm/tests/activitystreams/test_tasks.py
+++ b/bookwyrm/tests/activitystreams/test_tasks.py
@@ -7,8 +7,8 @@ from bookwyrm import activitystreams, models
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """use a test csv"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/connectors/test_abstract_connector.py
+++ b/bookwyrm/tests/connectors/test_abstract_connector.py
@@ -12,9 +12,10 @@ from bookwyrm.settings import DOMAIN
 class AbstractConnector(TestCase):
     """generic code for connecting to outside data sources"""
 
-    def setUp(self):
-        """we need an example connector"""
-        self.connector_info = models.Connector.objects.create(
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """we need an example connector in the database"""
+        models.Connector.objects.create(
             identifier="example.com",
             connector_file="openlibrary",
             base_url="https://example.com",
@@ -22,19 +23,27 @@ class AbstractConnector(TestCase):
             covers_url="https://example.com/covers",
             search_url="https://example.com/search?q=",
         )
+        self.book = models.Edition.objects.create(
+            title="Test Book",
+            remote_id="https://example.com/book/1234",
+            openlibrary_key="OL1234M",
+        )
+
+    def setUp(self):
+        """test data"""
         work_data = {
             "id": "abc1",
             "title": "Test work",
             "type": "work",
             "openlibraryKey": "OL1234W",
         }
-        self.work_data = work_data
         edition_data = {
             "id": "abc2",
             "title": "Test edition",
             "type": "edition",
             "openlibraryKey": "OL1234M",
         }
+        self.work_data = work_data
         self.edition_data = edition_data
 
         class TestConnector(abstract_connector.AbstractConnector):
@@ -69,12 +78,6 @@ class AbstractConnector(TestCase):
             Mapping("title"),
             Mapping("openlibraryKey"),
         ]
-
-        self.book = models.Edition.objects.create(
-            title="Test Book",
-            remote_id="https://example.com/book/1234",
-            openlibrary_key="OL1234M",
-        )
 
     def test_abstract_connector_init(self):
         """barebones connector for search with defaults"""

--- a/bookwyrm/tests/connectors/test_abstract_minimal_connector.py
+++ b/bookwyrm/tests/connectors/test_abstract_minimal_connector.py
@@ -9,8 +9,9 @@ from bookwyrm.connectors.abstract_connector import Mapping
 class AbstractConnector(TestCase):
     """generic code for connecting to outside data sources"""
 
-    def setUp(self):
-        """we need an example connector"""
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """we need an example connector in the database"""
         self.connector_info = models.Connector.objects.create(
             identifier="example.com",
             connector_file="openlibrary",
@@ -20,6 +21,9 @@ class AbstractConnector(TestCase):
             search_url="https://example.com/search?q=",
             isbn_search_url="https://example.com/isbn?q=",
         )
+
+    def setUp(self):
+        """instantiate example connector"""
 
         class TestConnector(abstract_connector.AbstractMinimalConnector):
             """nothing added here"""

--- a/bookwyrm/tests/connectors/test_bookwyrm_connector.py
+++ b/bookwyrm/tests/connectors/test_bookwyrm_connector.py
@@ -11,8 +11,9 @@ from bookwyrm.connectors.bookwyrm_connector import Connector
 class BookWyrmConnector(TestCase):
     """this connector doesn't do much, just search"""
 
-    def setUp(self):
-        """create the connector"""
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """create bookwrym_connector in the database"""
         models.Connector.objects.create(
             identifier="example.com",
             connector_file="bookwyrm_connector",
@@ -21,6 +22,9 @@ class BookWyrmConnector(TestCase):
             covers_url="https://example.com/images/covers",
             search_url="https://example.com/search?q=",
         )
+
+    def setUp(self):
+        """test data"""
         self.connector = Connector("example.com")
 
     def test_get_or_create_book_existing(self):

--- a/bookwyrm/tests/connectors/test_connector_manager.py
+++ b/bookwyrm/tests/connectors/test_connector_manager.py
@@ -10,7 +10,8 @@ from bookwyrm.connectors.bookwyrm_connector import Connector as BookWyrmConnecto
 class ConnectorManager(TestCase):
     """interface between the app and various connectors"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we'll need some books and a connector info entry"""
         self.work = models.Work.objects.create(title="Example Work")
 

--- a/bookwyrm/tests/connectors/test_inventaire_connector.py
+++ b/bookwyrm/tests/connectors/test_inventaire_connector.py
@@ -14,8 +14,9 @@ from bookwyrm.connectors.connector_manager import ConnectorException
 class Inventaire(TestCase):
     """test loading data from inventaire.io"""
 
-    def setUp(self):
-        """creates the connector we'll use"""
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """creates the connector in the database"""
         models.Connector.objects.create(
             identifier="inventaire.io",
             name="Inventaire",
@@ -26,6 +27,9 @@ class Inventaire(TestCase):
             search_url="https://inventaire.io/search?q=",
             isbn_search_url="https://inventaire.io/isbn",
         )
+
+    def setUp(self):
+        """connector instance"""
         self.connector = Connector("inventaire.io")
 
     @responses.activate

--- a/bookwyrm/tests/connectors/test_openlibrary_connector.py
+++ b/bookwyrm/tests/connectors/test_openlibrary_connector.py
@@ -18,8 +18,9 @@ from bookwyrm.connectors.connector_manager import ConnectorException
 class Openlibrary(TestCase):
     """test loading data from openlibrary.org"""
 
-    def setUp(self):
-        """creates the connector we'll use"""
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """creates the connector in the database"""
         models.Connector.objects.create(
             identifier="openlibrary.org",
             name="OpenLibrary",
@@ -30,6 +31,9 @@ class Openlibrary(TestCase):
             search_url="https://openlibrary.org/search?q=",
             isbn_search_url="https://openlibrary.org/isbn",
         )
+
+    def setUp(self):
+        """connector instance and other test data"""
         self.connector = Connector("openlibrary.org")
 
         work_file = pathlib.Path(__file__).parent.joinpath("../data/ol_work.json")

--- a/bookwyrm/tests/importers/test_calibre_import.py
+++ b/bookwyrm/tests/importers/test_calibre_import.py
@@ -16,12 +16,15 @@ from bookwyrm.models.import_job import handle_imported_book
 class CalibreImport(TestCase):
     """importing from Calibre csv"""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """use a test csv"""
         self.importer = CalibreImporter()
         datafile = pathlib.Path(__file__).parent.joinpath("../data/calibre.csv")
         self.csv = open(datafile, "r", encoding=self.importer.encoding)
+
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """populate database"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/importers/test_goodreads_import.py
+++ b/bookwyrm/tests/importers/test_goodreads_import.py
@@ -23,12 +23,15 @@ def make_date(*args):
 class GoodreadsImport(TestCase):
     """importing from goodreads csv"""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """use a test csv"""
         self.importer = GoodreadsImporter()
         datafile = pathlib.Path(__file__).parent.joinpath("../data/goodreads.csv")
         self.csv = open(datafile, "r", encoding=self.importer.encoding)
+
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """populate database"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/importers/test_importer.py
+++ b/bookwyrm/tests/importers/test_importer.py
@@ -26,13 +26,15 @@ def make_date(*args):
 class GenericImporter(TestCase):
     """importing from csv"""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """use a test csv"""
-
         self.importer = Importer()
         datafile = pathlib.Path(__file__).parent.joinpath("../data/generic.csv")
         self.csv = open(datafile, "r", encoding=self.importer.encoding)
+
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """populate database"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/importers/test_librarything_import.py
+++ b/bookwyrm/tests/importers/test_librarything_import.py
@@ -23,7 +23,6 @@ def make_date(*args):
 class LibrarythingImport(TestCase):
     """importing from librarything tsv"""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """use a test tsv"""
         self.importer = LibrarythingImporter()
@@ -31,6 +30,10 @@ class LibrarythingImport(TestCase):
 
         # Librarything generates latin encoded exports...
         self.csv = open(datafile, "r", encoding=self.importer.encoding)
+
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """populate database"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/importers/test_openlibrary_import.py
+++ b/bookwyrm/tests/importers/test_openlibrary_import.py
@@ -23,12 +23,15 @@ def make_date(*args):
 class OpenLibraryImport(TestCase):
     """importing from openlibrary csv"""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """use a test csv"""
         self.importer = OpenLibraryImporter()
         datafile = pathlib.Path(__file__).parent.joinpath("../data/openlibrary.csv")
         self.csv = open(datafile, "r", encoding=self.importer.encoding)
+
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """populate database"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/importers/test_storygraph_import.py
+++ b/bookwyrm/tests/importers/test_storygraph_import.py
@@ -23,12 +23,15 @@ def make_date(*args):
 class StorygraphImport(TestCase):
     """importing from storygraph csv"""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """use a test csv"""
         self.importer = StorygraphImporter()
         datafile = pathlib.Path(__file__).parent.joinpath("../data/storygraph.csv")
         self.csv = open(datafile, "r", encoding=self.importer.encoding)
+
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """populate database"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/lists_stream/test_signals.py
+++ b/bookwyrm/tests/lists_stream/test_signals.py
@@ -8,8 +8,9 @@ from bookwyrm import lists_stream, models
 class ListsStreamSignals(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
-        """use a test csv"""
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """database setup"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/lists_stream/test_stream.py
+++ b/bookwyrm/tests/lists_stream/test_stream.py
@@ -15,8 +15,9 @@ from bookwyrm import lists_stream, models
 class ListsStream(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
-        """use a test csv"""
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """database setup"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/lists_stream/test_tasks.py
+++ b/bookwyrm/tests/lists_stream/test_tasks.py
@@ -10,8 +10,9 @@ from bookwyrm import lists_stream, models
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
-        """use a test csv"""
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """database setup"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/management/test_populate_lists_streams.py
+++ b/bookwyrm/tests/management/test_populate_lists_streams.py
@@ -12,7 +12,8 @@ from bookwyrm.management.commands.populate_lists_streams import populate_lists_s
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need some stuff"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/management/test_populate_streams.py
+++ b/bookwyrm/tests/management/test_populate_streams.py
@@ -10,7 +10,8 @@ from bookwyrm.management.commands.populate_streams import populate_streams
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need some stuff"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/models/test_activitypub_mixin.py
+++ b/bookwyrm/tests/models/test_activitypub_mixin.py
@@ -26,7 +26,8 @@ from bookwyrm.settings import PAGE_LENGTH
 class ActivitypubMixins(TestCase):
     """functionality shared across models"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """shared data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -47,6 +48,8 @@ class ActivitypubMixins(TestCase):
                 outbox="https://example.com/users/rat/outbox",
             )
 
+    def setUp(self):
+        """test data"""
         self.object_mock = {
             "to": "to field",
             "cc": "cc field",

--- a/bookwyrm/tests/models/test_automod.py
+++ b/bookwyrm/tests/models/test_automod.py
@@ -14,10 +14,9 @@ from bookwyrm.models.antispam import automod_task
 class AutomodModel(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -29,6 +28,9 @@ class AutomodModel(TestCase):
                 localname="mouse",
                 is_superuser=True,
             )
+
+    def setUp(self):
+        self.factory = RequestFactory()
 
     def test_automod_task_no_rules(self, *_):
         """nothing to see here"""

--- a/bookwyrm/tests/models/test_base_model.py
+++ b/bookwyrm/tests/models/test_base_model.py
@@ -12,7 +12,8 @@ from bookwyrm.settings import DOMAIN
 class BaseModel(TestCase):
     """functionality shared across models"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """shared data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -31,6 +32,7 @@ class BaseModel(TestCase):
                 outbox="https://example.com/users/rat/outbox",
             )
 
+    def setUp(self):
         class BookWyrmTestModel(base_model.BookWyrmModel):
             """just making it not abstract"""
 

--- a/bookwyrm/tests/models/test_book_model.py
+++ b/bookwyrm/tests/models/test_book_model.py
@@ -18,7 +18,8 @@ from bookwyrm.settings import ENABLE_THUMBNAIL_GENERATION
 class Book(TestCase):
     """not too much going on in the books model but here we are"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we'll need some books"""
         self.work = models.Work.objects.create(
             title="Example Work", remote_id="https://example.com/book/1"

--- a/bookwyrm/tests/models/test_group.py
+++ b/bookwyrm/tests/models/test_group.py
@@ -9,7 +9,8 @@ from bookwyrm import models
 class Group(TestCase):
     """some activitypub oddness ahead"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """Set up for tests"""
 
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(

--- a/bookwyrm/tests/models/test_import_model.py
+++ b/bookwyrm/tests/models/test_import_model.py
@@ -16,7 +16,8 @@ from bookwyrm.connectors import connector_manager
 class ImportJob(TestCase):
     """this is a fancy one!!!"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """data is from a goodreads export of The Raven Tower"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -24,6 +25,8 @@ class ImportJob(TestCase):
             self.local_user = models.User.objects.create_user(
                 "mouse", "mouse@mouse.mouse", "password", local=True
             )
+
+    def setUp(self):
         self.job = models.ImportJob.objects.create(user=self.local_user, mappings={})
 
     def test_isbn(self):

--- a/bookwyrm/tests/models/test_link.py
+++ b/bookwyrm/tests/models/test_link.py
@@ -9,17 +9,6 @@ from bookwyrm import models
 class Link(TestCase):
     """some activitypub oddness ahead"""
 
-    def setUp(self):
-        """look, a list"""
-        with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
-            "bookwyrm.activitystreams.populate_stream_task.delay"
-        ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
-            self.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
-        work = models.Work.objects.create(title="hello")
-        self.book = models.Edition.objects.create(title="hi", parent_work=work)
-
     def test_create_domain(self, _):
         """generated default name"""
         domain = models.LinkDomain.objects.create(domain="beep.com")

--- a/bookwyrm/tests/models/test_list.py
+++ b/bookwyrm/tests/models/test_list.py
@@ -11,7 +11,8 @@ from bookwyrm import models, settings
 class List(TestCase):
     """some activitypub oddness ahead"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """look, a list"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/models/test_notification.py
+++ b/bookwyrm/tests/models/test_notification.py
@@ -7,7 +7,8 @@ from bookwyrm import models
 class Notification(TestCase):
     """let people know things"""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """useful things for creating a notification"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -197,7 +198,8 @@ class Notification(TestCase):
 class NotifyInviteRequest(TestCase):
     """let admins know of invite requests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """ensure there is one admin"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/models/test_readthrough_model.py
+++ b/bookwyrm/tests/models/test_readthrough_model.py
@@ -11,7 +11,8 @@ from bookwyrm import models
 class ReadThrough(TestCase):
     """some activitypub oddness ahead"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """look, a shelf"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/models/test_relationship_models.py
+++ b/bookwyrm/tests/models/test_relationship_models.py
@@ -14,7 +14,8 @@ from bookwyrm import models
 class Relationship(TestCase):
     """following, blocking, stuff like that"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need some users for this"""
         with patch("bookwyrm.models.user.set_remote_server.delay"):
             self.remote_user = models.User.objects.create_user(

--- a/bookwyrm/tests/models/test_shelf_model.py
+++ b/bookwyrm/tests/models/test_shelf_model.py
@@ -15,7 +15,8 @@ from bookwyrm import models, settings
 class Shelf(TestCase):
     """some activitypub oddness ahead"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """look, a shelf"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/models/test_site.py
+++ b/bookwyrm/tests/models/test_site.py
@@ -12,7 +12,8 @@ from bookwyrm import models, settings
 class SiteModels(TestCase):
     """tests for site models"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -24,8 +24,8 @@ from bookwyrm import activitypub, models, settings
 class Status(TestCase):
     """lotta types of statuses"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """useful things for creating a status"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -45,6 +45,10 @@ class Status(TestCase):
             )
         self.book = models.Edition.objects.create(title="Test Edition")
 
+    def setUp(self):
+        """individual test setup"""
+        self.anonymous_user = AnonymousUser
+        self.anonymous_user.is_authenticated = False
         image_file = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
         )
@@ -53,9 +57,6 @@ class Status(TestCase):
         with patch("bookwyrm.models.Status.broadcast"):
             image.save(output, format=image.format)
             self.book.cover.save("test.jpg", ContentFile(output.getvalue()))
-
-        self.anonymous_user = AnonymousUser
-        self.anonymous_user.is_authenticated = False
 
     def test_status_generated_fields(self, *_):
         """setting remote id"""

--- a/bookwyrm/tests/models/test_user_model.py
+++ b/bookwyrm/tests/models/test_user_model.py
@@ -18,8 +18,8 @@ class User(TestCase):
 
     protocol = "https://" if USE_HTTPS else "http://"
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):

--- a/bookwyrm/tests/templatetags/test_book_display_tags.py
+++ b/bookwyrm/tests/templatetags/test_book_display_tags.py
@@ -13,7 +13,8 @@ from bookwyrm.templatetags import book_display_tags
 class BookDisplayTags(TestCase):
     """lotta different things here"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/templatetags/test_feed_page_tags.py
+++ b/bookwyrm/tests/templatetags/test_feed_page_tags.py
@@ -12,7 +12,8 @@ from bookwyrm.templatetags import feed_page_tags
 class FeedPageTags(TestCase):
     """lotta different things here"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/templatetags/test_interaction.py
+++ b/bookwyrm/tests/templatetags/test_interaction.py
@@ -12,7 +12,8 @@ from bookwyrm.templatetags import interaction
 class InteractionTags(TestCase):
     """lotta different things here"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/templatetags/test_notification_page_tags.py
+++ b/bookwyrm/tests/templatetags/test_notification_page_tags.py
@@ -12,7 +12,8 @@ from bookwyrm.templatetags import notification_page_tags
 class NotificationPageTags(TestCase):
     """lotta different things here"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/templatetags/test_rating_tags.py
+++ b/bookwyrm/tests/templatetags/test_rating_tags.py
@@ -12,7 +12,8 @@ from bookwyrm.templatetags import rating_tags
 class RatingTags(TestCase):
     """lotta different things here"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/templatetags/test_shelf_tags.py
+++ b/bookwyrm/tests/templatetags/test_shelf_tags.py
@@ -15,9 +15,9 @@ from bookwyrm.templatetags import shelf_tags
 class ShelfTags(TestCase):
     """lotta different things here"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -40,6 +40,10 @@ class ShelfTags(TestCase):
             title="Test Book",
             parent_work=models.Work.objects.create(title="Test work"),
         )
+
+    def setUp(self):
+        """test data"""
+        self.factory = RequestFactory()
 
     def test_get_is_book_on_shelf(self, *_):
         """check if a book is on a shelf"""

--- a/bookwyrm/tests/templatetags/test_status_display.py
+++ b/bookwyrm/tests/templatetags/test_status_display.py
@@ -14,7 +14,8 @@ from bookwyrm.templatetags import status_display
 class StatusDisplayTags(TestCase):
     """lotta different things here"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/templatetags/test_utilities.py
+++ b/bookwyrm/tests/templatetags/test_utilities.py
@@ -14,8 +14,8 @@ from bookwyrm.templatetags import utilities
 class UtilitiesTags(TestCase):
     """lotta different things here"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create some filler objects"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/test_book_search.py
+++ b/bookwyrm/tests/test_book_search.py
@@ -10,7 +10,8 @@ from bookwyrm.connectors.abstract_connector import AbstractMinimalConnector
 class BookSearch(TestCase):
     """look for some books"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
         self.work = models.Work.objects.create(title="Example Work")
 

--- a/bookwyrm/tests/test_context_processors.py
+++ b/bookwyrm/tests/test_context_processors.py
@@ -11,9 +11,9 @@ from bookwyrm.context_processors import site_settings
 class ContextProcessor(TestCase):
     """pages you land on without really trying"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -27,6 +27,10 @@ class ContextProcessor(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
         self.site = models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """other test data"""
+        self.factory = RequestFactory()
 
     def test_theme_unset(self):
         """logged in user, no selected theme"""

--- a/bookwyrm/tests/test_emailing.py
+++ b/bookwyrm/tests/test_emailing.py
@@ -11,10 +11,9 @@ from bookwyrm import emailing, models
 class Emailing(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -26,6 +25,10 @@ class Emailing(TestCase):
                 localname="mouse",
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """other test data"""
+        self.factory = RequestFactory()
 
     def test_invite_email(self, email_mock):
         """load the invite email"""

--- a/bookwyrm/tests/test_signing.py
+++ b/bookwyrm/tests/test_signing.py
@@ -35,8 +35,8 @@ Sender = namedtuple("Sender", ("remote_id", "key_pair"))
 class Signature(TestCase):
     """signature test"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """create users and test data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -54,14 +54,14 @@ class Signature(TestCase):
             self.cat = models.User.objects.create_user(
                 f"cat@{DOMAIN}", "cat@example.com", "", local=True, localname="cat"
             )
+        models.SiteSettings.objects.create()
 
+    def setUp(self):
+        """test data"""
         private_key, public_key = create_key_pair()
-
         self.fake_remote = Sender(
             "http://localhost/user/remote", KeyPair(private_key, public_key)
         )
-
-        models.SiteSettings.objects.create()
 
     def send(self, signature, now, data, digest):
         """test request"""

--- a/bookwyrm/tests/validate_html.py
+++ b/bookwyrm/tests/validate_html.py
@@ -8,6 +8,7 @@ def validate_html(html):
     _, errors = tidy_document(
         html.content,
         options={
+            "doctype": "html5",
             "drop-empty-elements": False,
             "warn-proprietary-attributes": False,
         },

--- a/bookwyrm/tests/views/admin/test_announcements.py
+++ b/bookwyrm/tests/views/admin/test_announcements.py
@@ -11,9 +11,9 @@ from bookwyrm.tests.validate_html import validate_html
 class AnnouncementViews(TestCase):
     """every response to a get request, html or json"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -26,6 +26,10 @@ class AnnouncementViews(TestCase):
             )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_announcements_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_automod.py
+++ b/bookwyrm/tests/views/admin/test_automod.py
@@ -15,10 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class AutomodViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -34,6 +33,10 @@ class AutomodViews(TestCase):
         group = Group.objects.get(name="moderator")
         self.local_user.groups.set([group])
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_automod_rules_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_celery.py
+++ b/bookwyrm/tests/views/admin/test_celery.py
@@ -14,10 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class CeleryStatusViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +32,10 @@ class CeleryStatusViews(TestCase):
         group = Group.objects.get(name="admin")
         self.local_user.groups.set([group])
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_celery_status_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_dashboard.py
+++ b/bookwyrm/tests/views/admin/test_dashboard.py
@@ -14,9 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class DashboardViews(TestCase):
     """every response to a get request, html or json"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +33,10 @@ class DashboardViews(TestCase):
         self.local_user.groups.set([group])
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_dashboard(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_email_blocks.py
+++ b/bookwyrm/tests/views/admin/test_email_blocks.py
@@ -14,9 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class EmailBlocklistViews(TestCase):
     """every response to a get request, html or json"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +33,10 @@ class EmailBlocklistViews(TestCase):
         self.local_user.groups.set([group])
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_blocklist_page_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_email_config.py
+++ b/bookwyrm/tests/views/admin/test_email_config.py
@@ -14,10 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class EmailConfigViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +32,10 @@ class EmailConfigViews(TestCase):
         group = Group.objects.get(name="admin")
         self.local_user.groups.set([group])
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_email_config_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_federation.py
+++ b/bookwyrm/tests/views/admin/test_federation.py
@@ -17,10 +17,9 @@ from bookwyrm.tests.validate_html import validate_html
 class FederationViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -47,6 +46,10 @@ class FederationViews(TestCase):
         self.local_user.groups.set([group])
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_federation_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_imports.py
+++ b/bookwyrm/tests/views/admin/test_imports.py
@@ -14,10 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ImportsAdminViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +32,10 @@ class ImportsAdminViews(TestCase):
         group = Group.objects.get(name="admin")
         self.local_user.groups.set([group])
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_celery_status_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_ip_blocklist.py
+++ b/bookwyrm/tests/views/admin/test_ip_blocklist.py
@@ -14,9 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class IPBlocklistViews(TestCase):
     """every response to a get request, html or json"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +33,10 @@ class IPBlocklistViews(TestCase):
         self.local_user.groups.set([group])
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_blocklist_page_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_link_domains.py
+++ b/bookwyrm/tests/views/admin/test_link_domains.py
@@ -14,9 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class LinkDomainViews(TestCase):
     """every response to a get request, html or json"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -40,6 +40,10 @@ class LinkDomainViews(TestCase):
         )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_domain_page_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_reports.py
+++ b/bookwyrm/tests/views/admin/test_reports.py
@@ -15,10 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ReportViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -41,6 +40,10 @@ class ReportViews(TestCase):
         group = Group.objects.get(name="moderator")
         self.local_user.groups.set([group])
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_reports_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_site.py
+++ b/bookwyrm/tests/views/admin/test_site.py
@@ -14,10 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class SiteSettingsViews(TestCase):
     """Edit site settings"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -34,6 +33,10 @@ class SiteSettingsViews(TestCase):
         self.local_user.groups.set([group])
 
         self.site = models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_site_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_themes.py
+++ b/bookwyrm/tests/views/admin/test_themes.py
@@ -15,10 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class AdminThemesViews(TestCase):
     """Edit site settings"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -42,6 +41,10 @@ class AdminThemesViews(TestCase):
         self.local_user.groups.set([group])
 
         self.site = models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_themes_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/admin/test_user_admin.py
+++ b/bookwyrm/tests/views/admin/test_user_admin.py
@@ -15,9 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class UserAdminViews(TestCase):
     """every response to a get request, html or json"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +33,10 @@ class UserAdminViews(TestCase):
         group = Group.objects.get(name="moderator")
         self.local_user.groups.set([group])
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_user_admin_list_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/books/test_book.py
+++ b/bookwyrm/tests/views/books/test_book.py
@@ -23,9 +23,9 @@ from bookwyrm.tests.validate_html import validate_html
 class BookViews(TestCase):
     """books books books"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -53,6 +53,10 @@ class BookViews(TestCase):
         )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_book_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/books/test_edit_book.py
+++ b/bookwyrm/tests/views/books/test_edit_book.py
@@ -19,9 +19,9 @@ from bookwyrm.tests.views.books.test_book import _setup_cover_url
 class EditBookViews(TestCase):
     """books books books"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -47,10 +47,13 @@ class EditBookViews(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=self.work,
         )
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         # pylint: disable=line-too-long
         self.authors_body = "<?xml version='1.0' encoding='UTF-8' ?><?xml-stylesheet type='text/xsl' href='http://isni.oclc.org/sru/DB=1.2/?xsl=searchRetrieveResponse' ?><srw:searchRetrieveResponse xmlns:srw='http://www.loc.gov/zing/srw/' xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:diag='http://www.loc.gov/zing/srw/diagnostic/' xmlns:xcql='http://www.loc.gov/zing/cql/xcql/'><srw:version>1.1</srw:version><srw:records><srw:record><isniUnformatted>0000000084510024</isniUnformatted></srw:record></srw:records></srw:searchRetrieveResponse>"
-
-        # pylint: disable=line-too-long
         self.author_body = "<?xml version='1.0' encoding='UTF-8' ?><?xml-stylesheet type='text/xsl' href='http://isni.oclc.org/sru/DB=1.2/?xsl=searchRetrieveResponse' ?><srw:searchRetrieveResponse xmlns:srw='http://www.loc.gov/zing/srw/' xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:diag='http://www.loc.gov/zing/srw/diagnostic/' xmlns:xcql='http://www.loc.gov/zing/cql/xcql/'><srw:records><srw:record><srw:recordData><responseRecord><ISNIAssigned><isniUnformatted>0000000084510024</isniUnformatted><isniURI>https://isni.org/isni/0000000084510024</isniURI><dataConfidence>60</dataConfidence><ISNIMetadata><identity><personOrFiction><personalName><surname>Catherine Amy Dawson Scott</surname><nameTitle>poet and novelist</nameTitle><nameUse>public</nameUse><source>VIAF</source><source>WKP</source><subsourceIdentifier>Q544961</subsourceIdentifier></personalName><personalName><forename>C. A.</forename><surname>Dawson Scott</surname><marcDate>1865-1934</marcDate><nameUse>public</nameUse><source>VIAF</source><source>NLP</source><subsourceIdentifier>a28927850</subsourceIdentifier></personalName><sources><codeOfSource>VIAF</codeOfSource><sourceIdentifier>45886165</sourceIdentifier><reference><class>ALL</class><role>CRE</role><URI>http://viaf.org/viaf/45886165</URI></reference></sources><externalInformation><information>Wikipedia</information><URI>https://en.wikipedia.org/wiki/Catherine_Amy_Dawson_Scott</URI></externalInformation></ISNIMetadata></ISNIAssigned></responseRecord></srw:recordData></srw:record></srw:records></srw:searchRetrieveResponse>"
 
         responses.get(
@@ -85,8 +88,6 @@ class EditBookViews(TestCase):
             ],
             body=self.author_body,
         )
-
-        models.SiteSettings.objects.create()
 
     def test_edit_book_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/books/test_editions.py
+++ b/bookwyrm/tests/views/books/test_editions.py
@@ -13,9 +13,9 @@ from bookwyrm.tests.validate_html import validate_html
 class BookViews(TestCase):
     """books books books"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -36,6 +36,10 @@ class BookViews(TestCase):
         )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_editions_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/books/test_links.py
+++ b/bookwyrm/tests/views/books/test_links.py
@@ -15,10 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class LinkViews(TestCase):
     """books books books"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ):
@@ -48,6 +47,10 @@ class LinkViews(TestCase):
         )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_add_link_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/imports/test_import.py
+++ b/bookwyrm/tests/views/imports/test_import.py
@@ -16,10 +16,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ImportViews(TestCase):
     """goodreads import views"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -31,6 +30,10 @@ class ImportViews(TestCase):
                 localname="mouse",
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_import_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/imports/test_import_review.py
+++ b/bookwyrm/tests/views/imports/test_import_review.py
@@ -11,10 +11,9 @@ from bookwyrm import models, views
 class ImportManualReviewViews(TestCase):
     """goodreads import views"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -34,6 +33,10 @@ class ImportManualReviewViews(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_import_troubleshoot_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/imports/test_import_troubleshoot.py
+++ b/bookwyrm/tests/views/imports/test_import_troubleshoot.py
@@ -12,10 +12,9 @@ from bookwyrm import models, views
 class ImportTroubleshootViews(TestCase):
     """goodreads import views"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -27,6 +26,10 @@ class ImportTroubleshootViews(TestCase):
                 localname="mouse",
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_import_troubleshoot_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/inbox/test_inbox.py
+++ b/bookwyrm/tests/views/inbox/test_inbox.py
@@ -15,12 +15,22 @@ from bookwyrm import models, views
 class Inbox(TestCase):
     """readthrough tests"""
 
-    # pylint: disable=invalid-name
     def setUp(self):
-        """basic user and book data"""
+        """individual test setup"""
         self.client = Client()
         self.factory = RequestFactory()
+        self.create_json = {
+            "id": "hi",
+            "type": "Create",
+            "actor": "hi",
+            "to": ["https://www.w3.org/ns/activitystreams#public"],
+            "cc": ["https://example.com/user/mouse/followers"],
+            "object": {},
+        }
 
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
+        """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -43,14 +53,6 @@ class Inbox(TestCase):
                 inbox="https://example.com/users/rat/inbox",
                 outbox="https://example.com/users/rat/outbox",
             )
-        self.create_json = {
-            "id": "hi",
-            "type": "Create",
-            "actor": "hi",
-            "to": ["https://www.w3.org/ns/activitystreams#public"],
-            "cc": ["https://example.com/user/mouse/followers"],
-            "object": {},
-        }
         models.SiteSettings.objects.create()
 
     def test_inbox_invalid_get(self):

--- a/bookwyrm/tests/views/inbox/test_inbox_add.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_add.py
@@ -11,7 +11,8 @@ from bookwyrm import models, views
 class InboxAdd(TestCase):
     """inbox tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/views/inbox/test_inbox_announce.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_announce.py
@@ -11,7 +11,8 @@ from bookwyrm import models, views
 class InboxActivities(TestCase):
     """inbox tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -44,6 +45,10 @@ class InboxActivities(TestCase):
                     remote_id="https://example.com/status/1",
                 )
 
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
         self.create_json = {
             "id": "hi",
             "type": "Create",
@@ -52,8 +57,6 @@ class InboxActivities(TestCase):
             "cc": ["https://example.com/user/mouse/followers"],
             "object": {},
         }
-
-        models.SiteSettings.objects.create()
 
     @patch("bookwyrm.activitystreams.handle_boost_task.delay")
     def test_boost(self, _):

--- a/bookwyrm/tests/views/inbox/test_inbox_block.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_block.py
@@ -10,7 +10,8 @@ from bookwyrm import models, views
 class InboxBlock(TestCase):
     """inbox tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/views/inbox/test_inbox_create.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_create.py
@@ -9,7 +9,7 @@ from bookwyrm import models, views
 from bookwyrm.activitypub import ActivitySerializerError
 
 
-# pylint: disable=too-many-public-methods, invalid-name
+# pylint: disable=too-many-public-methods
 class TransactionInboxCreate(TransactionTestCase):
     """readthrough tests"""
 
@@ -71,7 +71,8 @@ class TransactionInboxCreate(TransactionTestCase):
 class InboxCreate(TestCase):
     """readthrough tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -96,6 +97,10 @@ class InboxCreate(TestCase):
                 outbox="https://example.com/users/rat/outbox",
             )
 
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
         self.create_json = {
             "id": "hi",
             "type": "Create",
@@ -104,7 +109,6 @@ class InboxCreate(TestCase):
             "cc": ["https://example.com/user/mouse/followers"],
             "object": {},
         }
-        models.SiteSettings.objects.create()
 
     def test_create_status(self, *_):
         """the "it justs works" mode"""

--- a/bookwyrm/tests/views/inbox/test_inbox_delete.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_delete.py
@@ -11,8 +11,8 @@ from bookwyrm import models, views
 class InboxActivities(TestCase):
     """inbox tests"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/views/inbox/test_inbox_follow.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_follow.py
@@ -11,7 +11,8 @@ from bookwyrm import models, views
 class InboxRelationships(TestCase):
     """inbox tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/views/inbox/test_inbox_like.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_like.py
@@ -10,7 +10,8 @@ from bookwyrm import models, views
 class InboxActivities(TestCase):
     """inbox tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -43,6 +44,10 @@ class InboxActivities(TestCase):
                     remote_id="https://example.com/status/1",
                 )
 
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
         self.create_json = {
             "id": "hi",
             "type": "Create",
@@ -51,8 +56,6 @@ class InboxActivities(TestCase):
             "cc": ["https://example.com/user/mouse/followers"],
             "object": {},
         }
-
-        models.SiteSettings.objects.create()
 
     def test_handle_favorite(self):
         """fav a status"""

--- a/bookwyrm/tests/views/inbox/test_inbox_remove.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_remove.py
@@ -10,7 +10,8 @@ from bookwyrm import models, views
 class InboxRemove(TestCase):
     """inbox tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"

--- a/bookwyrm/tests/views/inbox/test_inbox_update.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_update.py
@@ -12,7 +12,8 @@ from bookwyrm import models, views
 class InboxUpdate(TestCase):
     """inbox tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
@@ -37,6 +38,10 @@ class InboxUpdate(TestCase):
                 outbox="https://example.com/users/rat/outbox",
             )
 
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
         self.update_json = {
             "id": "hi",
             "type": "Update",
@@ -45,8 +50,6 @@ class InboxUpdate(TestCase):
             "cc": ["https://example.com/user/mouse/followers"],
             "object": {},
         }
-
-        models.SiteSettings.objects.create()
 
     def test_update_list(self):
         """a new list"""

--- a/bookwyrm/tests/views/landing/test_invite.py
+++ b/bookwyrm/tests/views/landing/test_invite.py
@@ -14,10 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class InviteViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -29,6 +28,10 @@ class InviteViews(TestCase):
                 localname="mouse",
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_invite_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/landing/test_landing.py
+++ b/bookwyrm/tests/views/landing/test_landing.py
@@ -14,9 +14,9 @@ from bookwyrm.tests.validate_html import validate_html
 class LandingViews(TestCase):
     """pages you land on without really trying"""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -27,9 +27,13 @@ class LandingViews(TestCase):
                 local=True,
                 localname="mouse",
             )
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        models.SiteSettings.objects.create()
 
     @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
     def test_home_page(self, _):

--- a/bookwyrm/tests/views/landing/test_login.py
+++ b/bookwyrm/tests/views/landing/test_login.py
@@ -17,10 +17,9 @@ from bookwyrm.tests.validate_html import validate_html
 class LoginViews(TestCase):
     """login and password management"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -47,9 +46,13 @@ class LoginViews(TestCase):
                 localname="badger",
                 two_factor_auth=True,
             )
+        models.SiteSettings.objects.create(id=1, require_confirm_email=False)
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        models.SiteSettings.objects.create(id=1, require_confirm_email=False)
 
     def test_login_get(self, *_):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/landing/test_password.py
+++ b/bookwyrm/tests/views/landing/test_password.py
@@ -16,9 +16,9 @@ from bookwyrm.tests.validate_html import validate_html
 class PasswordViews(TestCase):
     """view user and edit profile"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -29,9 +29,13 @@ class PasswordViews(TestCase):
                 local=True,
                 localname="mouse",
             )
+        models.SiteSettings.objects.create(id=1)
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        models.SiteSettings.objects.create(id=1)
 
     def test_password_reset_request(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/landing/test_register.py
+++ b/bookwyrm/tests/views/landing/test_register.py
@@ -20,10 +20,9 @@ from bookwyrm.tests.validate_html import validate_html
 class RegisterViews(TestCase):
     """login and password management"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -34,12 +33,15 @@ class RegisterViews(TestCase):
                 local=True,
                 localname="mouse",
             )
-        self.anonymous_user = AnonymousUser
-        self.anonymous_user.is_authenticated = False
-
         self.settings = models.SiteSettings.objects.create(
             id=1, require_confirm_email=False, allow_registration=True
         )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
+        self.anonymous_user = AnonymousUser
+        self.anonymous_user.is_authenticated = False
 
     def test_get_redirect(self, *_):
         """there's no dedicated registration page"""

--- a/bookwyrm/tests/views/lists/test_curate.py
+++ b/bookwyrm/tests/views/lists/test_curate.py
@@ -15,9 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ListViews(TestCase):
     """list view"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -42,10 +42,14 @@ class ListViews(TestCase):
             self.list = models.List.objects.create(
                 name="Test List", user=self.local_user
             )
-        self.anonymous_user = AnonymousUser
-        self.anonymous_user.is_authenticated = False
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
+        self.anonymous_user = AnonymousUser
+        self.anonymous_user.is_authenticated = False
 
     def test_curate_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/lists/test_embed.py
+++ b/bookwyrm/tests/views/lists/test_embed.py
@@ -15,9 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ListViews(TestCase):
     """list view"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -42,10 +42,14 @@ class ListViews(TestCase):
             self.list = models.List.objects.create(
                 name="Test List", user=self.local_user
             )
-        self.anonymous_user = AnonymousUser
-        self.anonymous_user.is_authenticated = False
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
+        self.anonymous_user = AnonymousUser
+        self.anonymous_user.is_authenticated = False
 
     def test_embed_call_without_key(self):
         """there are so many views, this just makes sure it DOESN’T load"""

--- a/bookwyrm/tests/views/lists/test_list.py
+++ b/bookwyrm/tests/views/lists/test_list.py
@@ -18,9 +18,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ListViews(TestCase):
     """list view"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -71,10 +71,14 @@ class ListViews(TestCase):
             self.list = models.List.objects.create(
                 name="Test List", user=self.local_user
             )
-        self.anonymous_user = AnonymousUser
-        self.anonymous_user.is_authenticated = False
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
+        self.anonymous_user = AnonymousUser
+        self.anonymous_user.is_authenticated = False
 
     def test_list_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/lists/test_list_item.py
+++ b/bookwyrm/tests/views/lists/test_list_item.py
@@ -12,9 +12,9 @@ from bookwyrm import models, views
 class ListItemViews(TestCase):
     """list view"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -40,6 +40,10 @@ class ListItemViews(TestCase):
             )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_add_list_item_notes(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/lists/test_lists.py
+++ b/bookwyrm/tests/views/lists/test_lists.py
@@ -15,10 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ListViews(TestCase):
     """lists of lists"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,10 +32,14 @@ class ListViews(TestCase):
             self.another_user = models.User.objects.create_user(
                 "rat@local.com", "rat@rat.com", "ratword", local=True, localname="rat"
             )
-        self.anonymous_user = AnonymousUser
-        self.anonymous_user.is_authenticated = False
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
+        self.anonymous_user = AnonymousUser
+        self.anonymous_user.is_authenticated = False
 
     @patch("bookwyrm.lists_stream.ListsStream.get_list_stream")
     def test_lists_page(self, _):

--- a/bookwyrm/tests/views/preferences/test_block.py
+++ b/bookwyrm/tests/views/preferences/test_block.py
@@ -13,9 +13,9 @@ from bookwyrm.tests.validate_html import validate_html
 class BlockViews(TestCase):
     """view user and edit profile"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -38,6 +38,10 @@ class BlockViews(TestCase):
             )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_block_get(self, _):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/preferences/test_change_password.py
+++ b/bookwyrm/tests/views/preferences/test_change_password.py
@@ -12,9 +12,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ChangePasswordViews(TestCase):
     """view user and edit profile"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -26,6 +26,10 @@ class ChangePasswordViews(TestCase):
                 localname="mouse",
             )
         models.SiteSettings.objects.create(id=1)
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_password_change_get(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/preferences/test_delete_user.py
+++ b/bookwyrm/tests/views/preferences/test_delete_user.py
@@ -16,10 +16,9 @@ from bookwyrm.tests.validate_html import validate_html
 class DeleteUserViews(TestCase):
     """view user and edit profile"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -50,9 +49,13 @@ class DeleteUserViews(TestCase):
                     shelf=self.local_user.shelf_set.first(),
                 )
 
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        models.SiteSettings.objects.create()
 
     def test_delete_user_page(self, _):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/preferences/test_edit_user.py
+++ b/bookwyrm/tests/views/preferences/test_edit_user.py
@@ -18,9 +18,9 @@ from bookwyrm.tests.validate_html import validate_html
 class EditUserViews(TestCase):
     """view user and edit profile"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -48,6 +48,10 @@ class EditUserViews(TestCase):
                 )
 
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 

--- a/bookwyrm/tests/views/preferences/test_export.py
+++ b/bookwyrm/tests/views/preferences/test_export.py
@@ -17,9 +17,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ExportViews(TestCase):
     """viewing and creating statuses"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ):
@@ -39,6 +39,10 @@ class ExportViews(TestCase):
             isbn_13="9781234567890",
             bnf_id="beep",
         )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def tst_export_get(self, *_):
         """request export"""

--- a/bookwyrm/tests/views/preferences/test_two_factor_auth.py
+++ b/bookwyrm/tests/views/preferences/test_two_factor_auth.py
@@ -17,9 +17,9 @@ from bookwyrm import forms, models, views
 class TwoFactorViews(TestCase):
     """Two Factor Authentication management"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -34,6 +34,10 @@ class TwoFactorViews(TestCase):
                 hotp_secret="DRMNMOU7ZRKH5YPW7PADOEYUF7MRIH46",
                 hotp_count=0,
             )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 

--- a/bookwyrm/tests/views/shelf/test_shelf.py
+++ b/bookwyrm/tests/views/shelf/test_shelf.py
@@ -20,9 +20,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ShelfViews(TestCase):
     """tag views"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -46,6 +46,9 @@ class ShelfViews(TestCase):
             )
         models.SiteSettings.objects.create()
 
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 

--- a/bookwyrm/tests/views/shelf/test_shelf_actions.py
+++ b/bookwyrm/tests/views/shelf/test_shelf_actions.py
@@ -18,9 +18,9 @@ from bookwyrm import forms, models, views
 class ShelfActionViews(TestCase):
     """tag views"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -51,6 +51,10 @@ class ShelfActionViews(TestCase):
                 name="Test Shelf", identifier="test-shelf", user=self.local_user
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_shelve(self, *_):
         """shelve a book"""

--- a/bookwyrm/tests/views/test_annual_summary.py
+++ b/bookwyrm/tests/views/test_annual_summary.py
@@ -21,10 +21,9 @@ def make_date(*args):
 class AnnualSummary(TestCase):
     """views"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -44,12 +43,14 @@ class AnnualSummary(TestCase):
             parent_work=self.work,
             pages=300,
         )
+        models.SiteSettings.objects.create()
 
+    def setUp(self):
+        """individual test setup"""
+        self.year = "2020"
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-
-        self.year = "2020"
-        models.SiteSettings.objects.create()
 
     def test_annual_summary_not_authenticated(self, *_):
         """there are so many views, this just makes sure it DOESN’T LOAD"""

--- a/bookwyrm/tests/views/test_author.py
+++ b/bookwyrm/tests/views/test_author.py
@@ -16,9 +16,9 @@ from bookwyrm.tests.validate_html import validate_html
 class AuthorViews(TestCase):
     """author views"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -44,10 +44,13 @@ class AuthorViews(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=self.work,
         )
+        models.SiteSettings.objects.create()
 
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        models.SiteSettings.objects.create()
 
     def test_author_page(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/test_directory.py
+++ b/bookwyrm/tests/views/test_directory.py
@@ -13,9 +13,9 @@ from bookwyrm.tests.validate_html import validate_html
 class DirectoryViews(TestCase):
     """tag views"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -27,8 +27,11 @@ class DirectoryViews(TestCase):
                 localname="mouse",
                 remote_id="https://example.com/users/mouse",
             )
-
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 

--- a/bookwyrm/tests/views/test_discover.py
+++ b/bookwyrm/tests/views/test_discover.py
@@ -11,10 +11,9 @@ from bookwyrm.tests.validate_html import validate_html
 class DiscoverViews(TestCase):
     """pages you land on without really trying"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -25,9 +24,13 @@ class DiscoverViews(TestCase):
                 local=True,
                 localname="mouse",
             )
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        models.SiteSettings.objects.create()
 
     def test_discover_page_empty(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/test_feed.py
+++ b/bookwyrm/tests/views/test_feed.py
@@ -24,9 +24,9 @@ from bookwyrm.tests.validate_html import validate_html
 class FeedViews(TestCase):
     """activity feed, statuses, dms"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -50,6 +50,10 @@ class FeedViews(TestCase):
             remote_id="https://example.com/book/1",
         )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
     def test_feed(self, *_):

--- a/bookwyrm/tests/views/test_follow.py
+++ b/bookwyrm/tests/views/test_follow.py
@@ -17,10 +17,10 @@ from bookwyrm.tests.validate_html import validate_html
 class FollowViews(TestCase):
     """follows"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
         models.SiteSettings.objects.create()
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -56,6 +56,10 @@ class FollowViews(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=self.work,
         )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_handle_follow_remote(self, *_):
         """send a follow request"""

--- a/bookwyrm/tests/views/test_get_started.py
+++ b/bookwyrm/tests/views/test_get_started.py
@@ -12,9 +12,9 @@ from bookwyrm.tests.validate_html import validate_html
 class GetStartedViews(TestCase):
     """helping new users get oriented"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -38,6 +38,10 @@ class GetStartedViews(TestCase):
             remote_id="https://example.com/book/1",
         )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_profile_view(self, *_):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/test_goal.py
+++ b/bookwyrm/tests/views/test_goal.py
@@ -15,9 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class GoalViews(TestCase):
     """viewing and creating statuses"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -41,10 +41,14 @@ class GoalViews(TestCase):
             title="Example Edition",
             remote_id="https://example.com/book/1",
         )
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.year = timezone.now().year
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        self.year = timezone.now().year
-        models.SiteSettings.objects.create()
 
     def test_goal_page_no_goal(self):
         """view a reading goal page for another's unset goal"""

--- a/bookwyrm/tests/views/test_group.py
+++ b/bookwyrm/tests/views/test_group.py
@@ -16,9 +16,9 @@ from bookwyrm.tests.validate_html import validate_html
 class GroupViews(TestCase):
     """view group and edit details"""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -46,10 +46,13 @@ class GroupViews(TestCase):
         self.membership = models.GroupMember.objects.create(
             group=self.testgroup, user=self.local_user
         )
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-
-        models.SiteSettings.objects.create()
 
     def test_group_get(self, _):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/test_hashtag.py
+++ b/bookwyrm/tests/views/test_hashtag.py
@@ -14,8 +14,8 @@ from bookwyrm.tests.validate_html import validate_html
 class HashtagView(TestCase):
     """hashtag view"""
 
-    def setUp(self):
-        self.factory = RequestFactory()
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -64,9 +64,13 @@ class HashtagView(TestCase):
         for status in self.statuses_bookclub:
             status.mention_hashtags.add(self.hashtag_bookclub)
 
+        models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
-        models.SiteSettings.objects.create()
 
     def test_hashtag_page(self):
         """just make sure it loads"""

--- a/bookwyrm/tests/views/test_helpers.py
+++ b/bookwyrm/tests/views/test_helpers.py
@@ -15,13 +15,12 @@ from bookwyrm.settings import USER_AGENT, DOMAIN
 @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
 @patch("bookwyrm.activitystreams.populate_stream_task.delay")
 @patch("bookwyrm.suggested_users.rerank_user_task.delay")
-class ViewsHelpers(TestCase):
+class ViewsHelpers(TestCase):  # pylint: disable=too-many-public-methods
     """viewing and creating statuses"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -53,13 +52,17 @@ class ViewsHelpers(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=self.work,
         )
-        datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_user.json")
-        self.userdata = json.loads(datafile.read_bytes())
-        del self.userdata["icon"]
         with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
             self.shelf = models.Shelf.objects.create(
                 name="Test Shelf", identifier="test-shelf", user=self.local_user
             )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
+        datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_user.json")
+        self.userdata = json.loads(datafile.read_bytes())
+        del self.userdata["icon"]
 
     def test_get_edition(self, *_):
         """given an edition or a work, returns an edition"""

--- a/bookwyrm/tests/views/test_interaction.py
+++ b/bookwyrm/tests/views/test_interaction.py
@@ -12,9 +12,9 @@ from bookwyrm import models, views
 class InteractionViews(TestCase):
     """viewing and creating statuses"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -36,13 +36,16 @@ class InteractionViews(TestCase):
                 inbox="https://example.com/users/rat/inbox",
                 outbox="https://example.com/users/rat/outbox",
             )
-
         work = models.Work.objects.create(title="Test Work")
         self.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_favorite(self, *_):
         """create and broadcast faving a status"""

--- a/bookwyrm/tests/views/test_isbn.py
+++ b/bookwyrm/tests/views/test_isbn.py
@@ -14,9 +14,9 @@ from bookwyrm.settings import DOMAIN
 class IsbnViews(TestCase):
     """tag views"""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -36,6 +36,10 @@ class IsbnViews(TestCase):
             parent_work=self.work,
         )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_isbn_json_response(self):
         """searches local data only and returns book data in json format"""

--- a/bookwyrm/tests/views/test_notifications.py
+++ b/bookwyrm/tests/views/test_notifications.py
@@ -12,9 +12,9 @@ from bookwyrm.tests.validate_html import validate_html
 class NotificationViews(TestCase):
     """notifications"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -33,6 +33,10 @@ class NotificationViews(TestCase):
                 content="hi", user=self.local_user
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_notifications_page_empty(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/test_outbox.py
+++ b/bookwyrm/tests/views/test_outbox.py
@@ -15,9 +15,9 @@ from bookwyrm.settings import USER_AGENT
 class OutboxView(TestCase):
     """sends out activities"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we'll need some data"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -35,6 +35,10 @@ class OutboxView(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_outbox(self, _):
         """returns user's statuses"""

--- a/bookwyrm/tests/views/test_reading.py
+++ b/bookwyrm/tests/views/test_reading.py
@@ -15,9 +15,9 @@ from bookwyrm import models, views
 class ReadingViews(TestCase):
     """viewing and creating statuses"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -45,6 +45,10 @@ class ReadingViews(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=self.work,
         )
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_start_reading(self, *_):
         """begin a book"""

--- a/bookwyrm/tests/views/test_readthrough.py
+++ b/bookwyrm/tests/views/test_readthrough.py
@@ -15,10 +15,9 @@ from bookwyrm import models
 class ReadThrough(TestCase):
     """readthrough tests"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """basic user and book data"""
-        self.client = Client()
-
         self.work = models.Work.objects.create(title="Example Work")
 
         self.edition = models.Edition.objects.create(
@@ -32,6 +31,9 @@ class ReadThrough(TestCase):
                 "cinco", "cinco@example.com", "seissiete", local=True, localname="cinco"
             )
 
+    def setUp(self):
+        """individual test setup"""
+        self.client = Client()
         with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
             self.client.force_login(self.user)
 

--- a/bookwyrm/tests/views/test_report.py
+++ b/bookwyrm/tests/views/test_report.py
@@ -11,10 +11,9 @@ from bookwyrm.tests.validate_html import validate_html
 class ReportViews(TestCase):
     """every response to a get request, html or json"""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -40,6 +39,10 @@ class ReportViews(TestCase):
                 content="Test status",
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_report_modal_view(self):
         """a user reports another user"""

--- a/bookwyrm/tests/views/test_rss_feed.py
+++ b/bookwyrm/tests/views/test_rss_feed.py
@@ -12,7 +12,8 @@ from bookwyrm.views import rss_feed
 class RssFeedView(TestCase):
     """rss feed behaves as expected"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -25,9 +26,11 @@ class RssFeedView(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
-        self.factory = RequestFactory()
-
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_rss_empty(self, *_):
         """load an rss feed"""

--- a/bookwyrm/tests/views/test_search.py
+++ b/bookwyrm/tests/views/test_search.py
@@ -17,9 +17,9 @@ from bookwyrm.tests.validate_html import validate_html
 class Views(TestCase):
     """tag views"""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -38,6 +38,10 @@ class Views(TestCase):
             parent_work=self.work,
         )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_search_json_response(self):
         """searches local data only and returns book data in json format"""

--- a/bookwyrm/tests/views/test_setup.py
+++ b/bookwyrm/tests/views/test_setup.py
@@ -13,10 +13,14 @@ from bookwyrm.tests.validate_html import validate_html
 class SetupViews(TestCase):
     """activity feed, statuses, dms"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         self.site = models.SiteSettings.objects.create(install_mode=True)
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_instance_config_permission_denied(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/test_updates.py
+++ b/bookwyrm/tests/views/test_updates.py
@@ -12,9 +12,9 @@ from bookwyrm import models, views
 class UpdateViews(TestCase):
     """lets the ui check for unread notification"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -26,6 +26,10 @@ class UpdateViews(TestCase):
                 localname="mouse",
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
 
     def test_get_notification_count(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/test_user.py
+++ b/bookwyrm/tests/views/test_user.py
@@ -15,9 +15,9 @@ from bookwyrm.tests.validate_html import validate_html
 class UserViews(TestCase):
     """view user and edit profile"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -44,8 +44,11 @@ class UserViews(TestCase):
                 user=self.local_user,
                 shelf=self.local_user.shelf_set.first(),
             )
-
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 

--- a/bookwyrm/tests/views/test_wellknown.py
+++ b/bookwyrm/tests/views/test_wellknown.py
@@ -13,9 +13,9 @@ from bookwyrm import models, views
 class WellknownViews(TestCase):
     """view user and edit profile"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """we need basic test data and mocks"""
-        self.factory = RequestFactory()
         with patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"), patch(
             "bookwyrm.activitystreams.populate_stream_task.delay"
         ), patch("bookwyrm.lists_stream.populate_lists_task.delay"):
@@ -40,6 +40,10 @@ class WellknownViews(TestCase):
                 outbox="https://example.com/users/rat/outbox",
             )
         models.SiteSettings.objects.create()
+
+    def setUp(self):
+        """individual test setup"""
+        self.factory = RequestFactory()
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ markers =
     integration: marks tests as requiring external resources (deselect with '-m "not integration"')
 
 env =
+    LANGUAGE_CODE = en-US
     SECRET_KEY = beepbeep
     DEBUG = false
     USE_HTTPS = true


### PR DESCRIPTION
Django's [TestCase.setUpTestData()](https://django.readthedocs.io/en/3.2.x/topics/testing/tools.html#django.test.TestCase.setUpTestData) allows us to create database fixtures once per test class, instead of once per test method. This speeds up tests considerably.¹

As per the documentation, database fixtures are created once, and roll'd-back to after each test. (Additionally, it _is_ safe to store the resulting models as class variables, since the Python objects are deepcopy()'d from the original before each test.)

I think this could be a nice addition to the BookWyrm codebase.

(¹) On my old laptop, running the whole test suite goes down from ~20min to ~9min (on my newer desktop, it's down to 2min, which is a joy). It seems to go from ~8min to ~4min in the Github runners.