### PR TITLE
fix upsert_statuses

### DIFF
--- a/bookwyrm/templates/import/import_user.html
+++ b/bookwyrm/templates/import/import_user.html
@@ -13,7 +13,11 @@
         {% trans "Not a valid import file" %}
     </div>
     {% endif %}
-
+    <p class="notification is-warning">
+        {% spaceless %}
+        {% trans "If you wish to migrate any statuses (comments, reviews, or quotes) you must either set this account as an <strong>alias</strong> of the one you are migrating from, or <strong>move</strong> that account to this one, before you import your user data." %}
+        {% endspaceless %}
+    </p>
     {% if not site.imports_enabled %}
     <div class="box notification has-text-centered is-warning m-6 content">
         <p class="mt-5">

--- a/bookwyrm/templates/preferences/export-user.html
+++ b/bookwyrm/templates/preferences/export-user.html
@@ -41,6 +41,11 @@
             {% endblocktrans %}
         </div>
         <p class="block">{% trans "In your new BookWyrm account can choose what to import: you will not have to import everything that is exported." %}</p>
+        <p class="notification is-warning">
+            {% spaceless %}
+            {% trans "If you wish to migrate any statuses (comments, reviews, or quotes) you must either set the account you are moving to as an <strong>alias</strong> of this one, or <strong>move</strong> this account to the new account, before you import your user data." %}
+            {% endspaceless %}
+        </p>
     {% if next_available %}
     <p class="notification is-warning">
         {% blocktrans trimmed %}


### PR DESCRIPTION
- remote_id is now updated on import of statuses
- statuses cannot be imported unless source has target listed in alsoKnownAs or movedTo
- add alert boxes to import and export screens advising of the above
- update tests accordingly