### PR TITLE
dev-tools: ensure we install Node from upstream

### DIFF
--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -6,6 +6,7 @@ ENV PYTHONUNBUFFERED=1
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 ENV PIP_ROOT_USER_ACTION=ignore PIP_DISABLE_PIP_VERSION_CHECK=1
 
+COPY nodejs.pref /etc/apt/preferences.d/
 COPY nodejs.sources /etc/apt/sources.list.d/
 COPY package.json requirements.txt .stylelintrc.js .stylelintignore /app/dev-tools/
 

--- a/dev-tools/nodejs.pref
+++ b/dev-tools/nodejs.pref
@@ -1,0 +1,4 @@
+Package: nodejs
+Pin: origin deb.nodesource.com
+Pin-Priority: 995
+Explanation: prefer upstream packaging over Debian's


### PR DESCRIPTION
Fixes: #3173 ("`bw-dev build` fails")