### PR TITLE
Removes part of migration causing upgrade issues

### DIFF
--- a/bookwyrm/migrations/0184_auto_20231106_0421.py
+++ b/bookwyrm/migrations/0184_auto_20231106_0421.py
@@ -22,17 +22,6 @@ def update_deleted_users(apps, schema_editor):
     ).update(is_deleted=True)
 
 
-def erase_deleted_user_data(apps, schema_editor):
-    """Retroactively clear user data"""
-    for user in User.objects.filter(is_deleted=True):
-        user.erase_user_data()
-        user.save(
-            broadcast=False,
-            update_fields=["email", "avatar", "preview_image", "summary", "name"],
-        )
-        user.erase_user_statuses(broadcast=False)
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -42,8 +31,5 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(
             update_deleted_users, reverse_code=migrations.RunPython.noop
-        ),
-        migrations.RunPython(
-            erase_deleted_user_data, reverse_code=migrations.RunPython.noop
         ),
     ]


### PR DESCRIPTION
This part of the migration caused issues when upgrading from 0.6.6 that didn't show up in testing. 

```
django.db.utils.ProgrammingError: column bookwyrm_notification.related_user_export_id does not exist
LINE 1: ...id", "bookwyrm_notification"."related_import_id", "bookwyrm_...
```

I'm removing it from the migration, and going to add it as a management command so that it can be run separately, and asynchronously.