### PR TITLE
DRAFT Using pre-commit framework 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+        types: [file, text]
+      - id: end-of-file-fixer
+        types: [file, text]
+      - id: check-docstring-first
+      - id: check-case-conflict
+      - id: check-yaml
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+      - id: black
+        types: [python]
+  - repo: local
+    hooks:
+      - id: pylint
+        args: ["--rcfile=.pylintrc"]
+        name: Pylint
+        entry: python -m pylint
+        language: system
+        files: \.py$
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: ./bw-dev pytest
+        language: system
+        files: \.py$

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ pylint==2.14.0
 mypy==1.5.1
 celery-types==0.18.0
 django-stubs[compatible-mypy]==4.2.4
+pre-commit
 types-bleach==6.0.0.4
 types-dataclasses==0.6.6
 types-Markdown==3.4.2.10


### PR DESCRIPTION
I've learnt the hard way that bookwyrm follow a [style guide](https://docs.joinbookwyrm.com/style_guide.html) and has some tests that need to be passed before merging a PR.

This PR is an attempt to install the [Pre-commit framework](https://pre-commit.com), which should implement those tests BEFORE creating a commit. While it may seem redundant, they are not:
- CI tests help noticing any error
- Pre-commit prevents errors from being pushed (this is, provided pre-commit is installed in the environment)

IMHO, having something like pre-commit would speed up the contributing process, as contributors (even new ones like me who would forget about manually running the tests) would immediately know if their code adheres to the style guide.

This is a draft. I can see, at least, the following items that should be addressed before merging:

- [ ] Make sure that it can be installed in other systems
- [ ] Decide what to include in pre-commit, i.e. (but not limited to):
   - [ ] [curlylint](https://www.curlylint.org/)
   - [ ] [stylelint](https://stylelint.io/)
   - [ ] [ESLint](https://eslint.org/)
   - [ ] 


Disclaimer: I've never used pre-commit before. Input is welcome.