### PR TITLE
Pass correct user id in Move notification

### DIFF
--- a/bookwyrm/templates/moved.html
+++ b/bookwyrm/templates/moved.html
@@ -23,7 +23,7 @@
 
           <div class="notification is-warning">
             <p>
-                {% id_to_username request.user.moved_to  as username %}
+                {% id_to_username request.user.moved_to as username %}
                 {% blocktrans trimmed with moved_to=user.moved_to %}
                     <strong>You have moved your account</strong> to <a href="{{ moved_to }}">{{ username }}</a>
                 {% endblocktrans %}

--- a/bookwyrm/templates/notifications/items/move_user.html
+++ b/bookwyrm/templates/notifications/items/move_user.html
@@ -14,7 +14,7 @@
 
 {% block description %}
     {% if related_user_moved_to %}
-        {% id_to_username request.user.moved_to  as username %}
+        {% id_to_username related_user_moved_to as username %}
         {% blocktrans trimmed %}
         {{ related_user }} has moved to <a href="{{ related_user_moved_to }}">{{ username }}</a>
         {% endblocktrans %}

--- a/bookwyrm/templatetags/utilities.py
+++ b/bookwyrm/templatetags/utilities.py
@@ -125,7 +125,8 @@ def id_to_username(user_id):
         name = parts[-1]
         value = f"{name}@{domain}"
 
-    return value
+        return value
+    return "a new user account"
 
 
 @register.filter(name="get_file_size")


### PR DESCRIPTION
We were passing the *requesting* user's `moved_to` value to the Move notification template, instead of the id of the user that they are being notified about. Additionally, the `id_to_username` template tag had no fallback for if the `user_id is` None.

This resolves both problems and removes an unnecessary space in a template for when the logged in user made the move.

Fixes #3196