### PR TITLE
Improve OpenGraph tags for status and book pages

### DIFF
--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -190,6 +190,15 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         """description of the page in meta tags when only this status is shown"""
         return None
 
+    @property
+    def page_image(self):
+        """image to use as preview in meta tags when only this status is shown"""
+        if self.mention_books.exists():
+            book = self.mention_books.first()
+            return book.preview_image
+        else:
+            return self.user.preview_image
+
     def to_replies(self, **kwargs):
         """helper function for loading AP serialized replies to a status"""
         return self.to_ordered_collection(
@@ -312,6 +321,10 @@ class BookStatus(Status):
         """not a real model, sorry"""
 
         abstract = True
+
+    @property
+    def page_image(self):
+        return self.book.preview_image or super().page_image
 
 
 class Comment(BookStatus):

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -196,8 +196,7 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         if self.mention_books.exists():
             book = self.mention_books.first()
             return book.preview_image or book.cover
-        else:
-            return self.user.preview_image
+        return self.user.preview_image
 
     def to_replies(self, **kwargs):
         """helper function for loading AP serialized replies to a status"""

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -195,7 +195,7 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
         """image to use as preview in meta tags when only this status is shown"""
         if self.mention_books.exists():
             book = self.mention_books.first()
-            return book.preview_image
+            return book.preview_image or book.cover
         else:
             return self.user.preview_image
 
@@ -324,7 +324,7 @@ class BookStatus(Status):
 
     @property
     def page_image(self):
-        return self.book.preview_image or super().page_image
+        return self.book.preview_image or self.book.cover or super().page_image
 
 
 class Comment(BookStatus):

--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -9,7 +9,8 @@
 {% block title %}{{ book|book_title }}{% endblock %}
 
 {% block opengraph %}
-    {% include 'snippets/opengraph.html' with title=book.title description=book|book_description image=book.preview_image %}
+    {% firstof book.preview_image book.cover as book_image %}
+    {% include 'snippets/opengraph.html' with title=book.title description=book|book_description image=book_image %}
 {% endblock %}
 
 {% block content %}

--- a/bookwyrm/templates/feed/status.html
+++ b/bookwyrm/templates/feed/status.html
@@ -2,13 +2,11 @@
 {% load feed_page_tags %}
 {% load i18n %}
 
+{% block title %}{{ title }}{% endblock %}
+
+
 {% block opengraph %}
-    {% firstof status.book status.mention_books.first as book %}
-    {% if book %}
-        {% include 'snippets/opengraph.html' with image=preview %}
-    {% else %}
-        {% include 'snippets/opengraph.html' %}
-    {% endif %}
+    {% include 'snippets/opengraph.html' with image=preview %}
 {% endblock %}
 
 

--- a/bookwyrm/templates/feed/status.html
+++ b/bookwyrm/templates/feed/status.html
@@ -6,7 +6,7 @@
 
 
 {% block opengraph %}
-    {% include 'snippets/opengraph.html' with image=preview %}
+    {% include 'snippets/opengraph.html' with image=page_image %}
 {% endblock %}
 
 

--- a/bookwyrm/templates/snippets/opengraph.html
+++ b/bookwyrm/templates/snippets/opengraph.html
@@ -1,24 +1,25 @@
 {% load static %}
 
-{% if preview_images_enabled is True %}
+{% firstof image site.preview_image as page_image %}
+{% if page_image %}
     <meta name="twitter:card" content="summary_large_image">
-    {% if image %}
-        <meta name="twitter:image" content="{{ media_full_url }}{{ image }}">
-        <meta name="og:image" content="{{ media_full_url }}{{ image }}">
-    {% else %}
-        <meta name="twitter:image" content="{{ media_full_url }}{{ site.preview_image }}">
-        <meta name="og:image" content="{{ media_full_url }}{{ site.preview_image }}">
-    {% endif %}
+    <meta name="twitter:image" content="{{ media_full_url }}{{ page_image }}">
+    <meta name="og:image" content="{{ media_full_url }}{{ page_image }}">
+{% elif site.logo %}
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:image" content="{{ media_full_url }}{{ site.logo }}">
+    <meta name="twitter:image:alt" content="{{ site.name }} Logo">
+    <meta name="og:image" content="{{ media_full_url }}{{ site.logo }}">
 {% else %}
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:image" content="{% if site.logo %}{{ media_full_url }}{{ site.logo }}{% else %}{% static "images/logo.png" %}{% endif %}">
-    <meta name="og:image" content="{% if site.logo %}{{ media_full_url }}{{ site.logo }}{% else %}{% static "images/logo.png" %}{% endif %}">
+    <meta name="twitter:image" content="{% static "images/logo.png" %}">
+    <meta name="twitter:image:alt" content="BookWyrm Logo">
+    <meta name="og:image" content="{% static "images/logo.png" %}">
 {% endif %}
-
-<meta name="twitter:image:alt" content="BookWyrm Logo">
 
 <meta name="twitter:title" content="{% if title %}{{ title }} - {% endif %}{{ site.name }}">
 <meta name="og:title" content="{% if title %}{{ title }} - {% endif %}{{ site.name }}">
 
-<meta name="twitter:description" content="{% if description %}{{ description }}{% else %}{{ site.instance_tagline }}{% endif %}">
-<meta name="og:description" content="{% if description %}{{ description }}{% else %}{{ site.instance_tagline }}{% endif %}">
+{% firstof description site.instance_tagline as description %}
+<meta name="twitter:description" content="{{ description }}">
+<meta name="og:description" content="{{ description }}">

--- a/bookwyrm/views/feed.py
+++ b/bookwyrm/views/feed.py
@@ -185,12 +185,6 @@ class Status(View):
             params=[status.id, visible_thread, visible_thread],
         )
 
-        preview = None
-        if hasattr(status, "book"):
-            preview = status.book.preview_image
-        elif status.mention_books.exists():
-            preview = status.mention_books.first().preview_image
-
         data = {
             **feed_page_data(request.user),
             **{
@@ -199,7 +193,7 @@ class Status(View):
                 "ancestors": ancestors,
                 "title": status.page_title,
                 "description": status.page_description,
-                "preview": preview,
+                "page_image": status.page_image,
             },
         }
         return TemplateResponse(request, "feed/status.html", data)

--- a/bookwyrm/views/feed.py
+++ b/bookwyrm/views/feed.py
@@ -197,6 +197,8 @@ class Status(View):
                 "status": status,
                 "children": children,
                 "ancestors": ancestors,
+                "title": status.page_title,
+                "description": status.page_description,
                 "preview": preview,
             },
         }


### PR DESCRIPTION
- [x] Generate an appropriate OpenGraph title, description and image for each type of status
- [x] Also use that title for the `<title>` tag of the status page
- [x] Fall back on book cover as OpenGraph image when book preview image is not available
  - For status page as well as book page

Example for `http://localhost:1333/user/Minnozz/reviewrating/5` on my development instance:

## Before
```html
<title>Updates - BookWyrm</title>
<meta name="twitter:card" content="summary">
<meta name="twitter:image" content="/static/images/logo.png">
<meta name="og:image" content="/static/images/logo.png">
<meta name="twitter:image:alt" content="BookWyrm Logo">
<meta name="twitter:title" content="BookWyrm">
<meta name="og:title" content="BookWyrm">
<meta name="twitter:description" content="Social Reading and Reviewing">
<meta name="og:description" content="Social Reading and Reviewing">
```

## After
```html
<title>Minnozz's review of Honor Among Enemies - BookWyrm</title>
<meta name="twitter:card" content="summary_large_image">
<meta name="twitter:image" content="http://bookwyrm-dev.minnozz.com/images/covers/d88c0916-2f91-4315-80ea-bbcffc909109.jpeg">
<meta name="og:image" content="http://bookwyrm-dev.minnozz.com/images/covers/d88c0916-2f91-4315-80ea-bbcffc909109.jpeg">
<meta name="twitter:title" content="Minnozz's review of Honor Among Enemies - BookWyrm">
<meta name="og:title" content="Minnozz's review of Honor Among Enemies - BookWyrm">
<meta name="twitter:description" content="Minnozz rated Honor Among Enemies: 4.5 stars">
<meta name="og:description" content="Minnozz rated Honor Among Enemies: 4.5 stars">
```

This is my first contribution; feedback on the implementation as well as the texts themselves is of course welcome!

Fixes #3235 
Fixes #2565