### PR TITLE
Add redis automatic rewrite configuration.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -2,6 +2,9 @@ bind 127.0.0.1 ::1
 protected-mode yes
 port 6379
 
+auto-aof-rewrite-percentage 50
+auto-aof-rewrite-min-size 128mb
+
 rename-command FLUSHDB ""
 rename-command FLUSHALL ""
 rename-command DEBUG ""


### PR DESCRIPTION
This should hopefully prevent the AOF file from growing too large.

Should be tried out on b.s prod before we merge this.