### PR TITLE
Support DATA_UPLOAD_MAX_SIZE_MiB in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,7 @@ TWO_FACTOR_LOGIN_MAX_SECONDS=60
 # and AWS_S3_CUSTOM_DOMAIN (if used) are added by default.
 # Value should be a comma-separated list of host names.
 CSP_ADDITIONAL_HOSTS=
-# The last number here means "megabytes"
+
 # Increase if users are having trouble uploading BookWyrm export files.
-DATA_UPLOAD_MAX_MEMORY_SIZE = (1024**2 * 100)
+# Default value is 2.5MB, this value is 100MB
+DATA_UPLOAD_MAX_MEMORY_SIZE=104857600

--- a/.env.example
+++ b/.env.example
@@ -138,9 +138,9 @@ TWO_FACTOR_LOGIN_MAX_SECONDS=60
 # Value should be a comma-separated list of host names.
 CSP_ADDITIONAL_HOSTS=
 
-# Increase if users are having trouble uploading BookWyrm export files.
-# Default value is 100MB
-DATA_UPLOAD_MAX_MEMORY_SIZE=104857600
-
 # Time before being logged out (in seconds)
 # SESSION_COOKIE_AGE=2592000   # current default: 30 days
+
+# Maximum allowed memory for file uploads (increase if users are having trouble
+# uploading BookWyrm export files).
+# DATA_UPLOAD_MAX_MEMORY_MiB=100

--- a/.env.example
+++ b/.env.example
@@ -139,5 +139,5 @@ TWO_FACTOR_LOGIN_MAX_SECONDS=60
 CSP_ADDITIONAL_HOSTS=
 
 # Increase if users are having trouble uploading BookWyrm export files.
-# Default value is 2.5MB, this value is 100MB
+# Default value is 100MB
 DATA_UPLOAD_MAX_MEMORY_SIZE=104857600

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -443,4 +443,4 @@ if HTTP_X_FORWARDED_PROTO:
 # user with the same username - in which case you should change it!
 INSTANCE_ACTOR_USERNAME = "bookwyrm.instance.actor"
 
-DATA_UPLOAD_MAX_MEMORY_SIZE = env.int("DATA_UPLOAD_MAX_MEMORY_SIZE", (1024**2 * 100))
+DATA_UPLOAD_MAX_MEMORY_SIZE = env.int("DATA_UPLOAD_MAX_MEMORY_SIZE", 104857600)

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -446,4 +446,6 @@ if HTTP_X_FORWARDED_PROTO:
 # user with the same username - in which case you should change it!
 INSTANCE_ACTOR_USERNAME = "bookwyrm.instance.actor"
 
-DATA_UPLOAD_MAX_MEMORY_SIZE = env.int("DATA_UPLOAD_MAX_MEMORY_SIZE", 104857600)
+# We only allow specifying DATA_UPLOAD_MAX_MEMORY_SIZE in MiB from .env
+# (note the difference in variable names).
+DATA_UPLOAD_MAX_MEMORY_SIZE = env.int("DATA_UPLOAD_MAX_MEMORY_MiB", 100) << 20

--- a/bookwyrm/templates/preferences/export-user.html
+++ b/bookwyrm/templates/preferences/export-user.html
@@ -14,31 +14,29 @@
         <p> {% trans "You can create an export file here. This will allow you to migrate your data to another BookWyrm account." %}</p>
     </div>
         <div class="block mx-5 columns">
-            {% blocktrans trimmed %}
             <div class="column is-half">
-                <h2 class="is-size-5">Your file will include:</h2>
+                <h2 class="is-size-5">{% trans "Your file will include:" %}</h2>
                 <ul>
-                    <li>User profile</li>
-                    <li>Most user settings</li>
-                    <li>Reading goals</li>
-                    <li>Shelves</li>
-                    <li>Reading history</li>
-                    <li>Book reviews</li>
-                    <li>Statuses</li>
-                    <li>Your own lists and saved lists</li>
-                    <li>Which users you follow and block</li>
+                    <li>{% trans "User profile" %}</li>
+                    <li>{% trans "Most user settings" %}</li>
+                    <li>{% trans "Reading goals" %}</li>
+                    <li>{% trans "Shelves" %}</li>
+                    <li>{% trans "Reading history" %}</li>
+                    <li>{% trans "Book reviews" %}</li>
+                    <li>{% trans "Statuses" %}</li>
+                    <li>{% trans "Your own lists and saved lists" %}</li>
+                    <li>{% trans "Which users you follow and block" %}</li>
                 </ul>
             </div>
             <div class="column is-half">
-                <h2 class="is-size-5">Your file will not include:</h2>
+                <h2 class="is-size-5">{% trans "Your file will not include:" %}</h2>
                 <ul>
-                    <li>Direct messages</li>
-                    <li>Replies to your statuses</li>
-                    <li>Groups</li>
-                    <li>Favorites</li>
+                    <li>{% trans "Direct messages" %}</li>
+                    <li>{% trans "Replies to your statuses" %}</li>
+                    <li>{% trans "Groups" %}</li>
+                    <li>{% trans "Favorites" %}</li>
                 </ul>
             </div>
-            {% endblocktrans %}
         </div>
         <p class="block">{% trans "In your new BookWyrm account can choose what to import: you will not have to import everything that is exported." %}</p>
         <p class="notification is-warning">
@@ -50,11 +48,11 @@
     <p class="notification is-danger">
         {% trans "New user exports are currently disabled." %}
         {% if perms.bookwyrm.edit_instance_settings %}
-        {% spaceless %}
-        {% blocktrans%}
-            <br/>User exports settings can be changed from <a href="/settings/imports">the Imports page</a> in the Admin dashboard.
+        <br/>
+        {% url 'settings-imports' as url %}
+        {% blocktrans trimmed %}
+            User exports settings can be changed from <a href="{{ url }}">the Imports page</a> in the Admin dashboard.
         {% endblocktrans %}
-        {% endspaceless %}
     {% endif%}
     </p>
     {% elif next_available %}

--- a/bookwyrm/templates/preferences/export-user.html
+++ b/bookwyrm/templates/preferences/export-user.html
@@ -49,6 +49,13 @@
     {% if not site.user_exports_enabled %}
     <p class="notification is-danger">
         {% trans "New user exports are currently disabled." %}
+        {% if perms.bookwyrm.edit_instance_settings %}
+        {% spaceless %}
+        {% blocktrans%}
+            <br/>User exports settings can be changed from <a href="/settings/imports">the Imports page</a> in the Admin dashboard.
+        {% endblocktrans %}
+        {% endspaceless %}
+    {% endif%}
     </p>
     {% elif next_available %}
     <p class="notification is-warning">

--- a/bookwyrm/templatetags/utilities.py
+++ b/bookwyrm/templatetags/utilities.py
@@ -126,7 +126,7 @@ def id_to_username(user_id):
         value = f"{name}@{domain}"
 
         return value
-    return "a new user account"
+    return _("a new user account")
 
 
 @register.filter(name="get_file_size")

--- a/nginx/development
+++ b/nginx/development
@@ -61,17 +61,25 @@ server {
         proxy_pass http://web;
     }
 
-    # directly serve images and static files from the
+    # directly serve static files from the
     # bookwyrm filesystem using sendfile.
     # make the logs quieter by not reporting these requests
-    location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|ttf|webp|css|js)$ {
+    location ~ ^/static/ {
         root /app;
         try_files $uri =404;
         add_header X-Cache-Status STATIC;
         access_log off;
     }
 
-    # block access to any non-image files from images or static
+    # same with image files not in static folder
+    location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|webp)$ {
+        root /app;
+        try_files $uri =404;
+        add_header X-Cache-Status STATIC;
+        access_log off;
+    }
+
+    # block access to any non-image files from images
     location ~ ^/images/ {
         return 403;
     }

--- a/nginx/production
+++ b/nginx/production
@@ -93,19 +93,27 @@ server {
 #         proxy_pass http://web;
 #     }
 #
-#     # directly serve images and static files from the
+#     # directly serve static files from the
 #     # bookwyrm filesystem using sendfile.
 #     # make the logs quieter by not reporting these requests
-#     location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|ttf|webp|css|js)$ {
+#     location ~ ^/static/ {
 #         root /app;
 #         try_files $uri =404;
 #         add_header X-Cache-Status STATIC;
 #         access_log off;
 #     }
 
-#     # block access to any non-image files from images or static
+#     # same with image files not in static folder
+#     location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|webp)$ {
+#         root /app;
+#         try_files $uri =404;
+#         add_header X-Cache-Status STATIC;
+#         access_log off;
+#     }
+
+#     # block access to any non-image files from images
 #     location ~ ^/images/ {
-#          return 403;
+#         return 403;
 #     }
 #
 #     # monitor the celery queues with flower, no caching enabled


### PR DESCRIPTION
Since arithmetic is not allowed in .env files, a change in unit for the variable seems most usable.

-----

I missed #3226 during review, but while I was editing .env.example for another PR, I noticed the `(1024**2 * 100)` syntax, which I don't think would be allowed in the actual `.env`file and hence could lead to confusion?

In cases like this, I think it's best to overshadow Django's own setting with a Bookwyrm-specific variable name, in another unit (MB in this case). Thoughts?

NOTE: I mark this PR as draft because, as implemented, it's not strictly backwards compatible (if, following .env.example, an admin set `DATA_UPLOAD_MAX_MEMORY_SIZE` in the environment for 0.7.2, this would no longer be honored). I do believe this will merit a mention in the release notes, but I don't think it would make sense to allow two variables in different units, from .env.