### PR TITLE
Fix detection of `unlisted` posts

### DIFF
--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -260,12 +260,12 @@ class PrivacyField(ActivitypubFieldMixin, models.CharField):
 
         if to == [self.public]:
             setattr(instance, self.name, "public")
+        elif self.public in cc:
+            setattr(instance, self.name, "unlisted")
         elif to == [user.followers_url]:
             setattr(instance, self.name, "followers")
         elif cc == []:
             setattr(instance, self.name, "direct")
-        elif self.public in cc:
-            setattr(instance, self.name, "unlisted")
         else:
             setattr(instance, self.name, "followers")
         return original == getattr(instance, self.name)


### PR DESCRIPTION
If `followers_url` is found in `to`, the post may still be _unlisted_ if `"https://www.w3.org/ns/activitystreams#Public"` appears in `cc`. Hence this should be checked earlier.