### PR TITLE
Fix awkward layout for tablets on /confirm-email, /login, /invite, and /preferences/reactivate

### DIFF
--- a/bookwyrm/templates/confirm_email/confirm_email.html
+++ b/bookwyrm/templates/confirm_email/confirm_email.html
@@ -6,8 +6,8 @@
 {% block content %}
 <h1 class="title">{% trans "Confirm your email address" %}</h1>
 
-<div class="columns">
-    <div class="column">
+<div class="columns is-multiline">
+    <div class="column is-full is-half-desktop">
         <div class="block content">
             <section class="block">
                 <p>{% trans "A confirmation code has been sent to the email address you used to register your account." %}</p>

--- a/bookwyrm/templates/landing/invite.html
+++ b/bookwyrm/templates/landing/invite.html
@@ -6,8 +6,8 @@
 {% block content %}
 
 <h1 class="title">{% trans "Create an Account" %}</h1>
-<div class="columns">
-    <div class="column">
+<div class="columns is-multiline">
+    <div class="column is-full is-half-desktop">
         <div class="block">
             {% if valid %}
             <div>

--- a/bookwyrm/templates/landing/login.html
+++ b/bookwyrm/templates/landing/login.html
@@ -6,7 +6,7 @@
 {% block content %}
 <h1 class="title">{% trans "Log in" %}</h1>
 <div class="columns is-multiline">
-    <div class="column is-half">
+    <div class="column {% if site.allow_registration %}is-half{% else %}is-full is-half-desktop{% endif %}">
         {% if login_form.non_field_errors %}
         <p class="notification is-danger">{{ login_form.non_field_errors }}</p>
         {% endif %}
@@ -20,13 +20,15 @@
             <div class="field">
                 <label class="label" for="id_localname_confirm">{% trans "Username:" %}</label>
                 <div class="control">
-                    <input type="text" name="localname" maxlength="255" class="input" required="" id="id_localname_confirm" value="{{ login_form.localname.value|default:'' }}">
+                    <input type="text" name="localname" maxlength="255" class="input" required=""
+                        id="id_localname_confirm" value="{{ login_form.localname.value|default:'' }}">
                 </div>
             </div>
             <div class="field">
                 <label class="label" for="id_password_confirm">{% trans "Password:" %}</label>
                 <div class="control">
-                    <input type="password" name="password" maxlength="128" class="input" required="" id="id_password_confirm" aria-describedby="desc_password">
+                    <input type="password" name="password" maxlength="128" class="input" required=""
+                        id="id_password_confirm" aria-describedby="desc_password">
                 </div>
 
                 {% include 'snippets/form_errors.html' with errors_list=login_form.password.errors id="desc_password" %}
@@ -58,7 +60,7 @@
             {% include 'snippets/about.html' %}
 
             <p class="block">
-            <a href="{% url 'about' %}">{% trans "More about this site" %}</a>
+                <a href="{% url 'about' %}">{% trans "More about this site" %}</a>
             </p>
         </div>
     </div>

--- a/bookwyrm/templates/landing/password_reset.html
+++ b/bookwyrm/templates/landing/password_reset.html
@@ -4,8 +4,8 @@
 {% block title %}{% trans "Reset Password" %}{% endblock %}
 
 {% block content %}
-<div class="columns">
-    <div class="column">
+<div class="columns is-multiline">
+    <div class="column is-full is-half-desktop">
         <div class="block">
             <h1 class="title">{% trans "Reset Password" %}</h1>
 

--- a/bookwyrm/templates/landing/reactivate.html
+++ b/bookwyrm/templates/landing/reactivate.html
@@ -6,7 +6,7 @@
 {% block content %}
 <h1 class="title">{% trans "Reactivate Account" %}</h1>
 <div class="columns is-multiline">
-    <div class="column is-half">
+    <div class="column {% if site.allow_registration %}is-half{% else %}is-full is-half-desktop{% endif %}">
         {% if login_form.non_field_errors %}
         <p class="notification is-danger">{{ login_form.non_field_errors }}</p>
         {% endif %}
@@ -16,13 +16,15 @@
             <div class="field">
                 <label class="label" for="id_localname_confirm">{% trans "Username:" %}</label>
                 <div class="control">
-                    <input type="text" name="localname" maxlength="255" class="input" required="" id="id_localname_confirm" value="{{ login_form.localname.value|default:'' }}">
+                    <input type="text" name="localname" maxlength="255" class="input" required=""
+                        id="id_localname_confirm" value="{{ login_form.localname.value|default:'' }}">
                 </div>
             </div>
             <div class="field">
                 <label class="label" for="id_password_confirm">{% trans "Password:" %}</label>
                 <div class="control">
-                    <input type="password" name="password" maxlength="128" class="input" required="" id="id_password_confirm" aria-describedby="desc_password">
+                    <input type="password" name="password" maxlength="128" class="input" required=""
+                        id="id_password_confirm" aria-describedby="desc_password">
                 </div>
 
                 {% include 'snippets/form_errors.html' with errors_list=login_form.password.errors id="desc_password" %}
@@ -51,7 +53,7 @@
             {% include 'snippets/about.html' %}
 
             <p class="block">
-            <a href="{% url 'about' %}">{% trans "More about this site" %}</a>
+                <a href="{% url 'about' %}">{% trans "More about this site" %}</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
Fixes issue #2023 

I'm not actually sure what's going on with the password-reset page as I don't actually see the about snippet show up even though it is in the template.  On all of the other pages, at tablet widths (anything between the mobile and desktop cutoffs) the main element will grow to the full width and the about snippet will move below it.

e.g.

![image](https://github.com/bookwyrm-social/bookwyrm/assets/36494925/b055a432-a98b-4ec6-a0f5-3beb9b64a07d)
