### PR TITLE
Fix label and input association for shelves filter

### DIFF
--- a/bookwyrm/templates/shelf/shelves_filter_field.html
+++ b/bookwyrm/templates/shelf/shelves_filter_field.html
@@ -3,7 +3,7 @@
 
 {% block filter %}
   <div class="control">
-    <label class="label" for="filter_query">{% trans 'Filter by keyword' %}</label>
-    <input aria-label="Filter by keyword" id="my-books-filter" class="input" type="text" name="filter" placeholder="{% trans 'Enter text here' %}" value="{{ shelves_filter_query|default:'' }}" spellcheck="false" />
+    <label class="label" for="my-books-filter">{% trans 'Filter by keyword' %}</label>
+    <input id="my-books-filter" class="input" type="text" name="filter" placeholder="{% trans 'Enter text here' %}" value="{{ shelves_filter_query|default:'' }}" spellcheck="false" />
   </div>
 {% endblock %}


### PR DESCRIPTION
This PR correctly associates label and text input of the shelves
filter via for- and id-attributes. With the association in place,
the aria-label can be removed (the label will be announced by
assistive software when the input is focused). This also fixes the
issue that the aria-label was not translated, whereas the label is.
