### PR TITLE
Add timeouts to requests.get

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -423,6 +423,7 @@ def get_activitypub_data(url):
                 "Date": now,
                 "Signature": make_signature("get", sender, url, now),
             },
+            timeout=15
         )
     except requests.RequestException:
         raise ConnectorException()

--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -423,7 +423,7 @@ def get_activitypub_data(url):
                 "Date": now,
                 "Signature": make_signature("get", sender, url, now),
             },
-            timeout=15
+            timeout=15,
         )
     except requests.RequestException:
         raise ConnectorException()

--- a/bookwyrm/isbn/isbn.py
+++ b/bookwyrm/isbn/isbn.py
@@ -26,7 +26,7 @@ class IsbnHyphenator:
 
     def update_range_message(self) -> None:
         """Download the range message xml file and save it locally"""
-        response = requests.get(self.__range_message_url)
+        response = requests.get(self.__range_message_url, timeout=15)
         with open(self.__range_file_path, "w", encoding="utf-8") as file:
             file.write(response.text)
         self.__element_tree = None


### PR DESCRIPTION
Two instances of requests.get are currently missing timeouts. Without an explicit timeout, requests.get will never time out, which can cause code to hang. 

Some instances of requests.get in other parts of the code did have timeouts, in one instance configurable and in all others 15. The missing instances felt more analogous to the place where it was already 15 than the configurable one, so this PR adds timeouts of 15 in the two places that currently lack a timeout.

The phildini/bookwyrm fork is already successfully running with these changes in production, but we've done a bunch of infrastructure stuff recently as well, so I made a new fork to submit a cleaner PR to yall. 