### PR TITLE
json_export: also detect absent "icon" key

### DIFF
--- a/bookwyrm/models/bookwyrm_export_job.py
+++ b/bookwyrm/models/bookwyrm_export_job.py
@@ -80,10 +80,7 @@ def json_export(
     exported_user = user.to_activity()
     # I don't love this but it prevents a JSON encoding error
     # when there is no user image
-    if isinstance(
-        exported_user["icon"],
-        dataclasses._MISSING_TYPE,  # pylint: disable=protected-access
-    ):
+    if exported_user.get("icon") in (None, dataclasses.MISSING):
         exported_user["icon"] = {}
     else:
         # change the URL to be relative to the JSON file


### PR DESCRIPTION
-----
This fixes recent test failures after merging https://github.com/bookwyrm-social/bookwyrm/pull/3096.

(Also, use `dataclasses.MISSING` instead of protected member. @hughrun does this seem right to you?)