### PR TITLE
pytest.ini: define ALLOWED_HOSTS

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ env =
     DEBUG = false
     USE_HTTPS = true
     DOMAIN = your.domain.here
+    ALLOWED_HOSTS = your.domain.here
     BOOKWYRM_DATABASE_BACKEND = postgres
     MEDIA_ROOT = images/
     CELERY_BROKER = ""


### PR DESCRIPTION
This fixes running `./bw-dev pytest` locally when having a different value defined for `ALLOWED_HOSTS` in `.env`.

Partially fixes #3308