### PR TITLE
Refactor settings and run pytest CI in Docker container

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,5 @@
+# overrides for .env.example for CI
+SECRET_KEY=beepbeep
+USE_DUMMY_CACHE=true
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=

--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -7,64 +7,17 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: "docker-compose.yml:docker-compose.ci.yml"
+      COMPOSE_ENV_FILES: ".env.example:.env.ci"
 
-    runs-on: ubuntu-20.04
-    services:
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: hunter2
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Check migrations up-to-date
-      run: |
-        python ./manage.py makemigrations --check
-      env:
-        SECRET_KEY: beepbeep
-        DOMAIN: your.domain.here
-        EMAIL_HOST: ""
-        EMAIL_HOST_USER: ""
-        EMAIL_HOST_PASSWORD: ""
-    - name: Run Tests
-      env:
-        SECRET_KEY: beepbeep
-        DEBUG: false
-        USE_HTTPS: true
-        DOMAIN: your.domain.here
-        BOOKWYRM_DATABASE_BACKEND: postgres
-        MEDIA_ROOT: images/
-        POSTGRES_PASSWORD: hunter2
-        POSTGRES_USER: postgres
-        POSTGRES_DB: github_actions
-        POSTGRES_HOST: 127.0.0.1
-        CELERY_BROKER: ""
-        REDIS_BROKER_PORT: 6379
-        REDIS_BROKER_PASSWORD: beep
-        USE_DUMMY_CACHE: true
-        FLOWER_PORT: 8888
-        EMAIL_HOST: "smtp.mailgun.org"
-        EMAIL_PORT: 587
-        EMAIL_HOST_USER: ""
-        EMAIL_HOST_PASSWORD: ""
-        EMAIL_USE_TLS: true
-        ENABLE_PREVIEW_IMAGES: false
-        ENABLE_THUMBNAIL_GENERATION: true
-        HTTP_X_FORWARDED_PROTO: false
-      run: |
-        pytest -n 3
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Build Docker images
+      run: docker-compose build
+    - name: Check if migrations are up-to-date
+      run: docker-compose run web python manage.py makemigrations --check
+    - name: Run pytest
+      run: docker-compose run web pytest -n 3

--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Check if migrations are up-to-date
       run: docker-compose run web python manage.py makemigrations --check
     - name: Run pytest
-      run: docker-compose run web pytest -n 3
+      run: docker-compose run -e GITHUB_ACTIONS=true web pytest -n 3

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -1,4 +1,5 @@
 """ bookwyrm settings and configuration """
+
 import os
 from typing import AnyStr
 
@@ -13,7 +14,6 @@ from django.core.exceptions import ImproperlyConfigured
 # pylint: disable=line-too-long
 
 env = Env()
-env.read_env()
 DOMAIN = env("DOMAIN")
 
 with open("VERSION", encoding="utf-8") as f:

--- a/bookwyrm/wsgi.py
+++ b/bookwyrm/wsgi.py
@@ -8,10 +8,7 @@ https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 """
 
 import os
-from environs import Env
 from django.core.wsgi import get_wsgi_application
-
-Env.read_env()
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bookwyrm.settings")
 

--- a/bw-dev
+++ b/bw-dev
@@ -28,6 +28,7 @@ if docker compose &> /dev/null ; then
 else
 	DOCKER_COMPOSE="docker-compose"
 fi
+DOCKER_COMPOSE_CI="$DOCKER_COMPOSE --env-file .env.example --env-file .env.ci -f docker-compose.yml -f docker-compose.ci.yml"
 
 function clean {
     $DOCKER_COMPOSE stop
@@ -36,6 +37,10 @@ function clean {
 
 function runweb {
     $DOCKER_COMPOSE run --rm web "$@"
+}
+
+function runwebci {
+    $DOCKER_COMPOSE_CI run --rm web "$@"
 }
 
 function execdb {
@@ -126,11 +131,11 @@ case "$CMD" in
         ;;
     pytest)
         prod_error
-        runweb pytest --no-cov-on-fail "$@"
+        runwebci pytest --no-cov-on-fail "$@"
         ;;
     pytest_coverage_report)
         prod_error
-        runweb pytest -n 3 --cov-report term-missing "$@"
+        runwebci pytest -n 3 --cov-report term-missing "$@"
         ;;
     compile_themes)
         runweb python manage.py compile_themes

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,38 @@
+version: '3'
+
+# Pass the variables defined in .env.example and .env.ci to the containers
+# instead of .env (which is ignored).
+
+services:
+  db:
+    env_file:
+      - .env.example
+      - .env.ci
+  web:
+    env_file:
+      - .env.example
+      - .env.ci
+  redis_activity:
+    env_file:
+      - .env.example
+      - .env.ci
+  redis_broker:
+    env_file:
+      - .env.example
+      - .env.ci
+  celery_worker:
+    env_file:
+      - .env.example
+      - .env.ci
+  celery_beat:
+    env_file:
+      - .env.example
+      - .env.ci
+  flower:
+    env_file:
+      - .env.example
+      - .env.ci
+  dev-tools:
+    env_file:
+      - .env.example
+      - .env.ci

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  db:
+    env_file:
+      - .env
+  web:
+    env_file:
+      - .env
+  redis_activity:
+    env_file:
+      - .env
+  redis_broker:
+    env_file:
+      - .env
+  celery_worker:
+    env_file:
+      - .env
+  celery_beat:
+    env_file:
+      - .env
+  flower:
+    env_file:
+      - .env
+  dev-tools:
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+# This file is merged with docker-compose.ci.yml for CI, and with
+# docker-compose.override.yml for all other purposes.
+
 services:
   nginx:
     image: nginx:1.25.2
@@ -16,14 +19,12 @@ services:
       - media_volume:/app/images
   db:
     image: postgres:13
-    env_file: .env
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:
       - main
   web:
     build: .
-    env_file: .env
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app
@@ -43,7 +44,6 @@ services:
     volumes:
       - ./redis.conf:/etc/redis/redis.conf
       - redis_activity_data:/data
-    env_file: .env
     networks:
       - main
     restart: on-failure
@@ -53,12 +53,10 @@ services:
     volumes:
       - ./redis.conf:/etc/redis/redis.conf
       - redis_broker_data:/data
-    env_file: .env
     networks:
       - main
     restart: on-failure
   celery_worker:
-    env_file: .env
     build: .
     networks:
       - main
@@ -73,7 +71,6 @@ services:
       - redis_broker
     restart: on-failure
   celery_beat:
-    env_file: .env
     build: .
     networks:
       - main
@@ -88,7 +85,6 @@ services:
   flower:
     build: .
     command: celery -A celerywyrm flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD} --url_prefix=flower
-    env_file: .env
     volumes:
       - .:/app
     networks:
@@ -99,7 +95,6 @@ services:
     restart: on-failure
   dev-tools:
     build: dev-tools
-    env_file: .env
     volumes:
       - /app/dev-tools/
       - .:/app

--- a/manage.py
+++ b/manage.py
@@ -2,10 +2,7 @@
 import os
 import sys
 
-from environs import Env
-
 if __name__ == "__main__":
-    Env.read_env()  # load environment variables from .env
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bookwyrm.settings")
     try:
         from django.core.management import execute_from_command_line

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,25 +4,3 @@ python_files = tests.py test_*.py *_tests.py
 addopts = --cov=bookwyrm --cov-config=.coveragerc
 markers =
     integration: marks tests as requiring external resources (deselect with '-m "not integration"')
-
-env =
-    LANGUAGE_CODE = en-US
-    SECRET_KEY = beepbeep
-    DEBUG = false
-    USE_HTTPS = true
-    DOMAIN = your.domain.here
-    BOOKWYRM_DATABASE_BACKEND = postgres
-    MEDIA_ROOT = images/
-    CELERY_BROKER = ""
-    REDIS_BROKER_PORT = 6379
-    REDIS_BROKER_PASSWORD = beep
-    REDIS_ACTIVITY_PORT = 6379
-    REDIS_ACTIVITY_PASSWORD = beep
-    USE_DUMMY_CACHE = true
-    FLOWER_PORT = 8888
-    EMAIL_HOST = "smtp.mailgun.org"
-    EMAIL_PORT = 587
-    EMAIL_HOST_USER = ""
-    EMAIL_HOST_PASSWORD = ""
-    EMAIL_USE_TLS = true
-    ENABLE_PREVIEW_IMAGES = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ pytest-django==4.1.0
 pytest==6.1.2
 pytest-cov==2.10.1
 pytest-env==0.6.2
+pytest-github-actions-annotate-failures==0.2.0
 pytest-xdist==2.3.0
 pytidylib==0.3.2
 pylint==2.14.0


### PR DESCRIPTION
Pytest should not use the local `.env` file, even if it is present.

This uses [multiple compose files](https://docs.docker.com/compose/multiple-compose-files/) and some environment variables and command line flags to use either `.env` or `.env.example` + `.env.ci`.

Pytest failures should now also appear as annotations on PRs.

Fixes #3308