### PR TITLE
Escape search query in generated URLs

### DIFF
--- a/bookwyrm/templates/search/book.html
+++ b/bookwyrm/templates/search/book.html
@@ -109,7 +109,7 @@
 <p class="block">
     {% if request.user.is_authenticated %}
         {% if not remote %}
-        <a href="{{ request.path }}?q={{ query }}&type=book&remote=true" id="tour-load-from-other-catalogues">
+        <a href="{{ request.path }}?q={{ query|urlencode }}&type=book&remote=true" id="tour-load-from-other-catalogues">
             {% trans "Load results from other catalogues" %}
         </a>
         {% else %}

--- a/bookwyrm/templates/search/layout.html
+++ b/bookwyrm/templates/search/layout.html
@@ -41,18 +41,18 @@
 <nav class="tabs">
     <ul>
         <li{% if type == "book" %} class="is-active"{% endif %}>
-            <a href="{% url 'search' %}?q={{ query }}&type=book">{% trans "Books" %}</a>
+            <a href="{% url 'search' %}?q={{ query|urlencode }}&type=book">{% trans "Books" %}</a>
         </li>
         <li{% if type == "author" %} class="is-active"{% endif %}>
-            <a href="{% url 'search' %}?q={{ query }}&type=author">{% trans "Authors" %}</a>
+            <a href="{% url 'search' %}?q={{ query|urlencode }}&type=author">{% trans "Authors" %}</a>
         </li>
         {% if request.user.is_authenticated %}
         <li{% if type == "user" %} class="is-active"{% endif %}>
-            <a href="{% url 'search' %}?q={{ query }}&type=user">{% trans "Users" %}</a>
+            <a href="{% url 'search' %}?q={{ query|urlencode }}&type=user">{% trans "Users" %}</a>
         </li>
         {% endif %}
         <li{% if type == "list" %} class="is-active"{% endif %}>
-            <a href="{% url 'search' %}?q={{ query }}&type=list">{% trans "Lists" %}</a>
+            <a href="{% url 'search' %}?q={{ query|urlencode }}&type=list">{% trans "Lists" %}</a>
         </li>
     </ul>
 </nav>


### PR DESCRIPTION
Otherwise, a query containing '&' or other special characters results in a broken URL.

As reported on https://matrix.to/#/#bookwyrm:matrix.org