### PR TITLE
Revert "docker-compose.yml: make all bind mounts read only"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - main
     volumes:
-      - ./nginx:/etc/nginx/conf.d:ro
+      - ./nginx:/etc/nginx/conf.d
       - static_volume:/app/static
       - media_volume:/app/images
   db:
@@ -26,7 +26,7 @@ services:
     env_file: .env
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - .:/app:ro
+      - .:/app
       - static_volume:/app/static
       - media_volume:/app/images
     depends_on:
@@ -41,7 +41,7 @@ services:
     image: redis:7.2.1
     command: redis-server --requirepass ${REDIS_ACTIVITY_PASSWORD} --appendonly yes --port ${REDIS_ACTIVITY_PORT}
     volumes:
-      - ./redis.conf:/etc/redis/redis.conf:ro
+      - ./redis.conf:/etc/redis/redis.conf
       - redis_activity_data:/data
     env_file: .env
     networks:
@@ -51,7 +51,7 @@ services:
     image: redis:7.2.1
     command: redis-server --requirepass ${REDIS_BROKER_PASSWORD} --appendonly yes --port ${REDIS_BROKER_PORT}
     volumes:
-      - ./redis.conf:/etc/redis/redis.conf:ro
+      - ./redis.conf:/etc/redis/redis.conf
       - redis_broker_data:/data
     env_file: .env
     networks:
@@ -64,7 +64,7 @@ services:
       - main
     command: celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority,streams,images,suggested_users,email,connectors,lists,inbox,imports,import_triggered,broadcast,misc
     volumes:
-      - .:/app:ro
+      - .:/app
       - static_volume:/app/static
       - media_volume:/app/images
     depends_on:
@@ -78,7 +78,7 @@ services:
       - main
     command: celery -A celerywyrm beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
     volumes:
-      - .:/app:ro
+      - .:/app
       - static_volume:/app/static
       - media_volume:/app/images
     depends_on:
@@ -89,7 +89,7 @@ services:
     command: celery -A celerywyrm flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD} --url_prefix=flower
     env_file: .env
     volumes:
-      - .:/app:ro
+      - .:/app
       - static_volume:/app/static
     networks:
       - main
@@ -102,7 +102,7 @@ services:
     env_file: .env
     volumes:
       - /app/dev-tools/
-      - .:/app:rw
+      - .:/app
     profiles:
       - tools
 volumes:


### PR DESCRIPTION
This reverts commit 864304f128fc897348342ba83506441469e8fe53.

Some of the (management) commands that are run in the `web` container actually do need read-write access to the source directory. Revert for now.