### PR TITLE
Add exports_volume to docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env
 /images/
 /static/
+/exports/
 bookwyrm/static/css/bookwyrm.css
 bookwyrm/static/css/themes/
 !bookwyrm/static/css/themes/bookwyrm-*.scss

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - .:/app
       - static_volume:/app/static
       - media_volume:/app/images
+      - exports_volume:/app/exports
     depends_on:
       - db
       - celery_worker
@@ -67,6 +68,7 @@ services:
       - .:/app
       - static_volume:/app/static
       - media_volume:/app/images
+      - exports_volume:/app/exports
     depends_on:
       - db
       - redis_broker
@@ -81,6 +83,7 @@ services:
       - .:/app
       - static_volume:/app/static
       - media_volume:/app/images
+      - exports_volume:/app/exports
     depends_on:
       - celery_worker
     restart: on-failure
@@ -109,6 +112,7 @@ volumes:
   pgdata:
   static_volume:
   media_volume:
+  exports_volume:
   redis_broker_data:
   redis_activity_data:
 networks:


### PR DESCRIPTION
Exports should be written to a Docker volume instead of to the bind mount (= source directory). This way they are shared between different containers even when they run on different machines.

After updating to the setup using the exports_volume, the following command can be used to copy existing exports that have ended up in the source directory to the new Docker volume:

```sh
docker-compose cp exports web:/app
```