### PR TITLE
Make nginx config safer

### DIFF
--- a/nginx/development
+++ b/nginx/development
@@ -64,7 +64,7 @@ server {
     # directly serve static files from the
     # bookwyrm filesystem using sendfile.
     # make the logs quieter by not reporting these requests
-    location ~ ^/static/ {
+    location /static/ {
         root /app;
         try_files $uri =404;
         add_header X-Cache-Status STATIC;
@@ -72,15 +72,14 @@ server {
     }
 
     # same with image files not in static folder
-    location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|webp)$ {
-        root /app;
-        try_files $uri =404;
-        add_header X-Cache-Status STATIC;
-        access_log off;
-    }
-
-    # block access to any non-image files from images
-    location ~ ^/images/ {
+    location /images/ {
+        location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|webp)$ {
+            root /app;
+            try_files $uri =404;
+            add_header X-Cache-Status STATIC;
+            access_log off;
+        }
+        # block access to any non-image files from images
         return 403;
     }
 

--- a/nginx/production
+++ b/nginx/production
@@ -96,23 +96,22 @@ server {
 #     # directly serve static files from the
 #     # bookwyrm filesystem using sendfile.
 #     # make the logs quieter by not reporting these requests
-#     location ~ ^/static/ {
+#     location /static/ {
 #         root /app;
 #         try_files $uri =404;
 #         add_header X-Cache-Status STATIC;
 #         access_log off;
 #     }
-
+#
 #     # same with image files not in static folder
-#     location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|webp)$ {
-#         root /app;
-#         try_files $uri =404;
-#         add_header X-Cache-Status STATIC;
-#         access_log off;
-#     }
-
-#     # block access to any non-image files from images
-#     location ~ ^/images/ {
+#     location /images/ {
+#         location ~ \.(bmp|ico|jpg|jpeg|png|svg|tif|tiff|webp)$ {
+#             root /app;
+#             try_files $uri =404;
+#             add_header X-Cache-Status STATIC;
+#             access_log off;
+#         }
+#         # block access to any non-image files from images
 #         return 403;
 #     }
 #


### PR DESCRIPTION
Instead of allowing all image files anywhere, and disallowing non-image file under `/images/`, only allow image files under `/images/` and don't match non-image files elsewhere. They get proxied to web instead and result in a 404 there.

For example, the old config allowed `/exports/foo.jpg` to be served, while the new config does not.