### PR TITLE
Fix creation of quotations with no end position

### DIFF
--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -392,7 +392,7 @@ class Quotation(BookStatus):
     def _format_position(self) -> Optional[str]:
         """serialize page position"""
         beg = self.position
-        end = self.endposition or 0
+        end = self.endposition
         if self.position_mode != "PG" or not beg:
             return None
         return f"pp. {beg}-{end}" if end else f"p. {beg}"

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -395,7 +395,7 @@ class Quotation(BookStatus):
         end = self.endposition or 0
         if self.position_mode != "PG" or not beg:
             return None
-        return f"pp. {beg}-{end}" if end > beg else f"p. {beg}"
+        return f"pp. {beg}-{end}" if end else f"p. {beg}"
 
     @property
     def pure_content(self):

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -341,6 +341,7 @@ class Status(TestCase):
         """serialization of quotation page position"""
         tests = [
             ("single pos", "7", "", "p. 7"),
+            ("missing beg", "", "10", None),
             ("page range", "7", "10", "pp. 7-10"),
             ("page range roman", "xv", "xvi", "pp. xv-xvi"),
             ("page range reverse", "14", "10", "pp. 14-10"),
@@ -357,10 +358,11 @@ class Status(TestCase):
                     position_mode="PG",
                 )
                 activity = status.to_activity(pure=True)
-                self.assertRegex(
-                    activity["content"],
-                    f'^<p>"my quote"</p> <p>— <a .+</a>, {pages}</p>$',
-                )
+                if pages:
+                    expect_re = f'^<p>"my quote"</p> <p>— <a .+</a>, {pages}</p>$'
+                else:
+                    expect_re = '^<p>"my quote"</p> <p>— <a .+</a></p>$'
+                self.assertRegex(activity["content"], expect_re)
 
     def test_review_to_activity(self, *_):
         """subclass of the base model version with a "pure" serializer"""

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -359,7 +359,8 @@ class Status(TestCase):
                 )
                 activity = status.to_activity(pure=True)
                 if pages:
-                    expect_re = f'^<p>"my quote"</p> <p>— <a .+</a>, {pages}</p>$'
+                    pages_re = re.escape(pages)
+                    expect_re = f'^<p>"my quote"</p> <p>— <a .+</a>, {pages_re}</p>$'
                 else:
                     expect_re = '^<p>"my quote"</p> <p>— <a .+</a></p>$'
                 self.assertRegex(activity["content"], expect_re)

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -1,4 +1,5 @@
 """ testing models """
+from unittest import expectedFailure
 from unittest.mock import patch
 import pathlib
 import re
@@ -337,11 +338,14 @@ class Status(TestCase):
             activity["attachment"][0]["name"], "Author Name: Test Edition (worm)"
         )
 
+    @expectedFailure
     def test_quotation_page_serialization(self, *_):
         """serialization of quotation page position"""
         tests = [
-            ("single pos", 7, None, "p. 7"),
-            ("page range", 7, 10, "pp. 7-10"),
+            ("single pos", "7", "", "p. 7"),
+            ("page range", "7", "10", "pp. 7-10"),
+            ("page range roman", "xv", "xvi", "pp. xv-xvi"),
+            ("page range reverse", "14", "10", "pp. 14-10"),
         ]
         for desc, beg, end, pages in tests:
             with self.subTest(desc):

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -1,5 +1,4 @@
 """ testing models """
-from unittest import expectedFailure
 from unittest.mock import patch
 import pathlib
 import re
@@ -338,7 +337,6 @@ class Status(TestCase):
             activity["attachment"][0]["name"], "Author Name: Test Edition (worm)"
         )
 
-    @expectedFailure
     def test_quotation_page_serialization(self, *_):
         """serialization of quotation page position"""
         tests = [


### PR DESCRIPTION
Follow-up to #3273, "Allow page numbers to be text, instead of integers".

Fixes: #3352