### PR TITLE
add GitHub templates for PRs and releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,78 @@
+<!--
+Thanks for contributing!
+
+Please ensure the name of your PR is written in imperative present tense. For example:
+
+- "fix color contrast on submit buttons"
+- "add 'favourite food' value to Author model"
+
+To check (tick) a list item, replace the space between square brackets with an x, like this:
+
+- [x] I have checked the box
+
+You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
+-->
+
+## Are you finished?
+
+### Linters
+<!--
+Please run linters on your code before submitting your PR.
+If you miss this step it is likely that the GitHub task runners will fail.
+-->
+
+- [ ] I have checked my code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
+
+### Tests
+<!-- Check one -->
+
+- [ ] My changes do not need new tests
+- [ ] All tests I have added are passing
+- [ ] I have written tests but need help to make them pass
+- [ ] I have not written tests and need help to write them
+
+## What type of Pull Request is this?
+<!-- Check all that apply -->
+
+- [ ] Bug Fix
+- [ ] Enhancement
+- [ ] Plumbing / Internals / Dependencies
+- [ ] Refactor
+
+## Does this PR change settings or dependencies, or break something?
+<!-- Check all that apply -->
+
+- [ ] This PR changes or adds default settings, configuration, or .env values
+- [ ] This PR changes or adds dependencies
+- [ ] This PR introduces other breaking changes
+
+### Details of breaking or configuration changes (if any of above checked)
+
+## Description
+
+<!--
+Describe what your pull request does here.
+
+For pull requests that relate or close an issue, please include them
+below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+For example having the text: "closes #1234" would connect the current pull
+request to issue 1234.  And when we merge the pull request, Github will
+automatically close the issue.
+-->
+
+- Related Issue #
+- Closes #
+
+## Documentation
+<!--
+Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
+Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
+-->
+
+<!-- Check all that apply -->
+
+- [ ] New or amended documentation will be required if this PR is merged
+- [ ] I have created a matching pull request in the Documentation repository
+- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged
+

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: ‼️ Breaking Changes & New Settings ⚙️
+      labels:
+        - breaking-change
+        - config-change
+    - title: Updated Dependencies 🧸
+      labels:
+        - dependencies
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - fix
+        - bug
+    - title: Internals/Plumbing 👩‍🔧
+        - plumbing
+        - tests
+        - deployment
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This PR adds:

1. a release template for GitHub releases.
2. a pull request template to help contributors and maintainers to understand and merge PRs faster, and label them correctly.

When using GitHub automated release notes, PRs will be split into sections based on the following labels:

- `breaking-change` or `config-change`
- `dependencies`
- `enhancement`
- `fix` or `bug`
- `plumbing`, `tests` or `deployment`
- all other PRs

Any labels not currently in use will be added once this PR is finalised and merged.

Note that PRs can only be in one category and will be placed in the order they are identified (i.e. a PR labelled both `enhancement` and `config-change` will appear in the first category (`breaking-change` or `config-change`).