### PR TITLE
auto-create new issue in documentation repo when `needs-docs` label in PR

### DIFF
--- a/.github/workflows/trigger_docs_issue.yml
+++ b/.github/workflows/trigger_docs_issue.yml
@@ -1,0 +1,30 @@
+name: Repository Dispatch
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  dispatch:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'needs-docs')
+    runs-on: ubuntu-latest
+    steps:
+      - name: authenticate
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v3
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - name: dispatch
+        uses: peter-evans/repository-dispatch@v3
+        env:
+          DOCS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+        with:
+          token: ${{ env.DOCS_TOKEN }}
+          repository: bookwyrm-social/documentation
+          event-type: docs-needed
+          client-payload: |-
+            {
+              "title": "${{ github.event.pull_request.title }}",
+              "body": ${{ toJson(github.event.pull_request.body) }},
+              "number": "${{ github.event.number }}"
+            }


### PR DESCRIPTION
This commit adds one of a pair of GitHub Actions to create a new issue in the documentation repository when a PR with a `needs-docs` label is merged in the main repository. This is intended to support improved documentation.

## Additional steps required

1. In order to work, [the related PR in the documentation repository](https://github.com/bookwyrm-social/documentation/pull/133) will also need to be merged, as it contains a job that actually creates the issue. The action in this repository simply triggers an alert and passes information to the other repository.

2. I have created a GitHub bot with the sole purpose of enabling the use of authorisation tokens with tightly-scoped permissions owned by the organization rather than an individual. We need this because we're triggering an action in one repository to do trigger another action in a different repository. Ownership will be transferred to `bookwyrm-social` assuming this PR is welcomed. A new private key needs to be generated, and the `APPLICATION_ID` and `APPLICATION_PRIVATE_KEY` (i.e.the key just generated) need to be added to the main repository's _Action_ `SECRETS`. Both repositories (or "All repositories") must be granted access, in the Bot configuration screen.

3. In the main repository settings, _Actions - General_ permissions must be set to _Allow all actions and reusable workflows_.