### PR TITLE
Add `as:Hashtag` to activitypub context

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -250,7 +250,10 @@ class ActivityObject:
                 pass
         data = {k: v for (k, v) in data.items() if v is not None and k not in omit}
         if "@context" not in omit:
-            data["@context"] = "https://www.w3.org/ns/activitystreams"
+            data["@context"] = [
+                "https://www.w3.org/ns/activitystreams",
+                {"Hashtag": "as:Hashtag"},
+            ]
         return data
 
 

--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -327,6 +327,7 @@ class User(OrderedCollectionPageMixin, AbstractUser):
             "https://w3id.org/security/v1",
             {
                 "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+                "Hashtag": "as:Hashtag",
                 "schema": "http://schema.org#",
                 "PropertyValue": "schema:PropertyValue",
                 "value": "schema:value",

--- a/bookwyrm/tests/models/test_user_model.py
+++ b/bookwyrm/tests/models/test_user_model.py
@@ -95,6 +95,7 @@ class User(TestCase):
                     "PropertyValue": "schema:PropertyValue",
                     "alsoKnownAs": {"@id": "as:alsoKnownAs", "@type": "@id"},
                     "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+                    "Hashtag": "as:Hashtag",
                     "movedTo": {"@id": "as:movedTo", "@type": "@id"},
                     "schema": "http://schema.org#",
                     "value": "schema:value",


### PR DESCRIPTION
At some point, mastodon got more strict about validating the context of incoming federated messages. Currently, it appears that hashtags don't federate correctly to mastodon when `Note` objects (and probably also `Article`, `Person`, etc.) contain a `tag` array with elements of type `Hashtag`, but *don't* define `Hashtag` in the `@context`.

I've verified that hashtags do *not* federate correctly (meaning: they're treated as normal links, posts with those hashtags don't show up in the hashtag search, etc.) from reading.taks.garden (bookwyrm 0.7.2) to either mastodon.gamedev.place (mastodon 4.2.8) or glitch.taks.garden (glitch-soc 4.3.0-alpha) before this change, and that they *do* federate correctly to both places after applying this change to reading.taks.garden.

**Note**: This only applies to objects that are federated "normally" (e.g. if a mastodon user follows a bookwyrm user), and you will *not* see the broken behavior if you "force" a note to be imported, e.g. by pasting a bookwyrm comment url into the mastodon search box

There was a previous discussion about this (over a year ago! 😱) at https://matrix.to/#/!zoxBMxLlvIyeEKkHuB:matrix.org/$1nDA0WY_s9NgaUFpki3GvX1yhV4KSF_8R1GFTwIQT4g?via=matrix.org&via=tchncs.de&via=mozilla.org