### PR TITLE
possible fix for #3372 - user export timeouts

### DIFF
--- a/bookwyrm/models/bookwyrm_export_job.py
+++ b/bookwyrm/models/bookwyrm_export_job.py
@@ -7,7 +7,6 @@ from boto3.session import Session as BotoSession
 from s3_tar import S3Tar
 
 from django.db.models import BooleanField, FileField, JSONField
-from django.db.models import Q
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.files.base import ContentFile
 from django.core.files.storage import storages

--- a/bookwyrm/models/bookwyrm_export_job.py
+++ b/bookwyrm/models/bookwyrm_export_job.py
@@ -315,19 +315,28 @@ def export_book(user: User, edition: Edition):
 
 
 def get_books_for_user(user):
-    """Get all the books and editions related to a user"""
+    """
+    Get all the books and editions related to a user.
 
-    editions = (
-        Edition.objects.select_related("parent_work")
-        .filter(
-            Q(shelves__user=user)
-            | Q(readthrough__user=user)
-            | Q(review__user=user)
-            | Q(list__user=user)
-            | Q(comment__user=user)
-            | Q(quotation__user=user)
-        )
-        .distinct()
+    We use union() instead of Q objects because it creates
+    multiple simple queries in stead of a much more complex DB query
+    that can time out.
+
+    """
+
+    shelf_eds = Edition.objects.select_related("parent_work").filter(shelves__user=user)
+    rt_eds = Edition.objects.select_related("parent_work").filter(
+        readthrough__user=user
     )
+    review_eds = Edition.objects.select_related("parent_work").filter(review__user=user)
+    list_eds = Edition.objects.select_related("parent_work").filter(list__user=user)
+    comment_eds = Edition.objects.select_related("parent_work").filter(
+        comment__user=user
+    )
+    quote_eds = Edition.objects.select_related("parent_work").filter(
+        quotation__user=user
+    )
+
+    editions = shelf_eds.union(rt_eds, review_eds, list_eds, comment_eds, quote_eds)
 
     return editions


### PR DESCRIPTION
<!--
Thanks for contributing!

Please ensure the name of your PR is written in imperative present tense. For example:

- "fix color contrast on submit buttons"
- "add 'favourite food' value to Author model"

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->

## Are you finished?

### Linters
<!--
Please run linters on your code before submitting your PR.
If you miss this step it is likely that the GitHub task runners will fail.
-->

- [ ] I have checked my code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

## Description

This definitely needs to be tested on a large DB but I believe it may fix the timeouts b.s. gets when running user exports.

Instead of a gigantic single DB query with heaps of joins, we instead just do a series of simple queries and then use `union()` to pull them into a de-duped queryset.

If I understand the results from `explain()` correctly, this is a massive reduction in DB work:

`Unique  (cost=195899.15..198201.71 rows=11808 width=19220)`

vs

`Unique  (cost=150.28..153.44 rows=16 width=19220)`

- Related Issue #
- Closes #3372

## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

