### PR TITLE
Fix CSS path prefix when S3 storage is used

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -404,6 +404,13 @@ if USE_S3:
                 "default_acl": "public-read",
             },
         },
+        "sass_processor": {
+            "BACKEND": "storages.backends.s3.S3Storage",
+            "OPTIONS": {
+                "location": "static",
+                "default_acl": "public-read",
+            },
+        },
         "exports": {
             "BACKEND": "storages.backends.s3.S3Storage",
             "OPTIONS": {


### PR DESCRIPTION
<!--
Thanks for contributing!

Please ensure the name of your PR is written in imperative present tense. For example:

- "fix color contrast on submit buttons"
- "add 'favourite food' value to Author model"

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->

## Are you finished?

### Linters
<!--
Please run linters on your code before submitting your PR.
If you miss this step it is likely that the GitHub task runners will fail.
-->

- [x] I have checked my code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

## Description

<!--
Describe what your pull request does here.

For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

django-sass-processor 1.4 looks up OPTIONS using `sass_processor` instead of `staticfiles`.
Add `sass_processor` field to `STORAGES` config, in order to let django-sass-processor 1.4 look up the `OPTIONS`.
This change will fix CSS path to have `/static` prefix.

- Closes #3383

## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

