### PR TITLE
Order user shelf previews by book shelved date

### DIFF
--- a/bookwyrm/views/user.py
+++ b/bookwyrm/views/user.py
@@ -55,7 +55,9 @@ class User(View):
                 {
                     "name": user_shelf.name,
                     "local_path": user_shelf.local_path,
-                    "books": user_shelf.books.all()[:3],
+                    "books": user_shelf.books.order_by(
+                        "-shelfbook__shelved_date"
+                    ).all()[:3],
                     "size": user_shelf.books.count(),
                 }
             )


### PR DESCRIPTION
<!--
Thanks for contributing!

Please ensure the name of your PR is written in imperative present tense. For example:

- "fix color contrast on submit buttons"
- "add 'favourite food' value to Author model"

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->

## Are you finished?

### Linters


- [x] I have checked my code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them

## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

## Description
Orders the list of books shown on the user page shelf previews to show the most recently shelved first. This matches the order shown on the feeds screen.

Before:
![Screenshot 2024-07-21 at 12 26 21](https://github.com/user-attachments/assets/371d8489-42a4-4e0a-88ff-ff69a626fcdf)

After:
![Screenshot 2024-07-21 at 12 26 04](https://github.com/user-attachments/assets/44885a08-6bf2-4da1-a092-765777b9ccf2)

NB: I am extremely NOT a Python/Django developer, so if there's a different / better way to do or test this I'm all ears.

## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

