### PR TITLE
Fix reading progress `start_date` bug

### DIFF
--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -1,6 +1,5 @@
 """ test for app action functionality """
 import json
-from unittest import expectedFailure
 from unittest.mock import patch
 import dateutil
 from django.core.exceptions import PermissionDenied
@@ -170,7 +169,6 @@ class StatusViews(TestCase):
         self.assertEqual(status.rating, 4.0)
         self.assertIsNone(status.edited_date)
 
-    @expectedFailure  # https://github.com/bookwyrm-social/bookwyrm/issues/3164
     def test_create_status_progress(self, *_):
         """create a status that updates a readthrough"""
         start_date = timezone.make_aware(dateutil.parser.parse("2024-07-27"))
@@ -200,7 +198,7 @@ class StatusViews(TestCase):
         readthrough.refresh_from_db()
 
         self.assertEqual(1, readthrough.progress)
-        self.assertEqual(start_date, readthrough.start_date)
+        self.assertEqual(start_date, readthrough.start_date)  # not overwritten
 
     def test_create_status_wrong_user(self, *_):
         """You can't compose statuses for someone else"""

--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -1,9 +1,12 @@
 """ test for app action functionality """
 import json
+from unittest import expectedFailure
 from unittest.mock import patch
+import dateutil
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase, TransactionTestCase
 from django.test.client import RequestFactory
+from django.utils import timezone
 
 from bookwyrm import forms, models, views
 from bookwyrm.views.status import find_mentions, find_or_create_hashtags
@@ -166,6 +169,38 @@ class StatusViews(TestCase):
         self.assertEqual(status.book, self.book)
         self.assertEqual(status.rating, 4.0)
         self.assertIsNone(status.edited_date)
+
+    @expectedFailure  # https://github.com/bookwyrm-social/bookwyrm/issues/3164
+    def test_create_status_progress(self, *_):
+        """create a status that updates a readthrough"""
+        start_date = timezone.make_aware(dateutil.parser.parse("2024-07-27"))
+        readthrough = models.ReadThrough.objects.create(
+            book=self.book, user=self.local_user, start_date=start_date
+        )
+
+        self.assertEqual(start_date, readthrough.start_date)
+        self.assertIsNone(readthrough.progress)
+
+        view = views.CreateStatus.as_view()
+        form = forms.CommentForm(
+            {
+                "progress": 1,
+                "progress_mode": "PG",
+                "content": "I started the book",
+                "id": readthrough.id,
+                "book": self.book.id,
+                "user": self.local_user.id,
+                "privacy": "public",
+            }
+        )
+        request = self.factory.post("", form.data)
+        request.user = self.local_user
+
+        view(request, "comment")
+        readthrough.refresh_from_db()
+
+        self.assertEqual(1, readthrough.progress)
+        self.assertEqual(start_date, readthrough.start_date)
 
     def test_create_status_wrong_user(self, *_):
         """You can't compose statuses for someone else"""

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -201,12 +201,11 @@ def edit_readthrough(request):
     # TODO: remove this, it duplicates the code in the ReadThrough view
     readthrough = get_object_or_404(models.ReadThrough, id=request.POST.get("id"))
 
-    readthrough.start_date = load_date_in_user_tz_as_utc(
-        request.POST.get("start_date"), request.user
-    )
-    readthrough.finish_date = load_date_in_user_tz_as_utc(
-        request.POST.get("finish_date"), request.user
-    )
+    if start_date := request.POST.get("start_date"):
+        readthrough.start_date = load_date_in_user_tz_as_utc(start_date, request.user)
+
+    if finish_date := request.POST.get("finish_date"):
+        readthrough.finish_date = load_date_in_user_tz_as_utc(finish_date, request.user)
 
     progress = request.POST.get("progress")
     try:


### PR DESCRIPTION
- 812221456b7ce37f2344f8c2c3da613b1a6378f5 Add failing test case for comment progress clobbering start_date
- 041f2fc41304ccbd8199f57c297a9858cfe9e218 edit_readthrough: set start_date/finish_date iff present in request

-----

- Closes: #3164 
- Related issue (?): #3397
- [x] All tests I have added are passing
- [x] I have checked my code with `black`, `pylint`, and `mypy`
