### PR TITLE
Avoid empty <title> in templates

### DIFF
--- a/bookwyrm/templates/ostatus/remote_follow.html
+++ b/bookwyrm/templates/ostatus/remote_follow.html
@@ -3,7 +3,9 @@
 {% load utilities %}
 
 {% block heading %}
+{% block title %}
 {% blocktrans with username=user.localname sitename=site.name %}Follow {{ username }} on the fediverse{% endblocktrans %}
+{% endblock %}
 {% endblock %}
 
 {% block content %}

--- a/bookwyrm/templates/ostatus/success.html
+++ b/bookwyrm/templates/ostatus/success.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% load utilities %}
 
+{% block title %}
+{% blocktrans with display_name=user.display_name %}You are now following {{ display_name }}!{% endblocktrans %}
+{% endblock %}
+
 {% block content %}
 <div class="block card">
     <div class="card-content">


### PR DESCRIPTION
Newer versions of tidylib complain about this.
