### PR TITLE
Trim search whitespace

### DIFF
--- a/bookwyrm/views/search.py
+++ b/bookwyrm/views/search.py
@@ -53,7 +53,7 @@ class Search(View):
 
 def api_book_search(request):
     """Return books via API response"""
-    query = request.GET.get("q")
+    query = request.GET.get("q").strip()
     query = isbn_check_and_format(query)
     min_confidence = request.GET.get("min_confidence", 0)
     # only return local book results via json so we don't cascade
@@ -65,7 +65,7 @@ def api_book_search(request):
 
 def book_search(request):
     """the real business is elsewhere"""
-    query = request.GET.get("q")
+    query = request.GET.get("q").strip()
     # check if query is isbn
     query = isbn_check_and_format(query)
     min_confidence = request.GET.get("min_confidence", 0)
@@ -123,8 +123,7 @@ def author_search(request):
 def user_search(request):
     """user search: search for a user"""
     viewer = request.user
-    query = request.GET.get("q")
-    query = query.strip()
+    query = request.GET.get("q").strip()
     data = {"type": "user", "query": query}
 
     # use webfinger for mastodon style account@domain.com username to load the user if
@@ -162,7 +161,7 @@ def user_search(request):
 
 def list_search(request):
     """any relevent lists?"""
-    query = request.GET.get("q")
+    query = request.GET.get("q").strip()
     data = {"query": query, "type": "list"}
     results = (
         models.List.privacy_filter(


### PR DESCRIPTION
## Description
This PR updates the search GET request handler and associated functions to trim leading and trailing whitespace from the query value (e.g. the ISBN).

- Closes #3390

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)
N/A

## Documentation
N/A

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
