### PR TITLE
Narrowed is_authenticated check in verfication_modal to only restrict…

### DIFF
--- a/bookwyrm/templates/book/file_links/verification_modal.html
+++ b/bookwyrm/templates/book/file_links/verification_modal.html
@@ -21,9 +21,10 @@ Is that where you'd like to go?
 <div class="is-flex-grow-1">
     <a href="{% url 'report-link' link.id %}">{% trans "Report spam" %}</a>
 </div>
+{% endif %}
 
 <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
 <a href="{{ link.url }}" target="_blank" rel="nofollow noopener noreferrer" noreferrer" class="button is-primary">{% trans "Continue" %}</a>
-{% endif %}
+
 
 {% endblock %}


### PR DESCRIPTION
… report button

## Description
This PR makes a minor change to the is_authenticated check in the template for the external  book link verification modal so that only the "Report Spam" button is locked behind login.

- Closes #3371

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)
N/A

## Documentation
N/A

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [x] I have not written tests and need help to write them

I could not find any tests currently exercising this modal, although there are tests for the book and links view in general. I don't know if this change necessarily _requires_ new tests since it just shifts a bit of content in the template, but I'd be happy to try and figure it out if needed.