### PR TITLE
Fix post dates being inconsistent

### DIFF
--- a/bookwyrm/templatetags/status_display.py
+++ b/bookwyrm/templatetags/status_display.py
@@ -1,6 +1,7 @@
 """ template filters """
 from dateutil.relativedelta import relativedelta
 from django import template
+from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime, naturalday
 from django.template.loader import select_template
 from django.utils import timezone
@@ -61,7 +62,7 @@ def get_published_date(date):
     if delta.years:
         return naturalday(date)
     if delta.days or delta.months:
-        return naturalday(date, "M j")
+        return naturalday(date, settings.MONTH_DAY_FORMAT)
     return naturaltime(date)
 
 

--- a/bookwyrm/templatetags/status_display.py
+++ b/bookwyrm/templatetags/status_display.py
@@ -60,7 +60,7 @@ def get_published_date(date):
     delta = relativedelta(now, date)
     if delta.years:
         return naturalday(date)
-    if delta.days:
+    if delta.days or delta.months:
         return naturalday(date, "M j")
     return naturaltime(date)
 

--- a/bookwyrm/tests/templatetags/test_status_display.py
+++ b/bookwyrm/tests/templatetags/test_status_display.py
@@ -110,3 +110,11 @@ class StatusDisplayTags(TestCase):
             )
             result = status_display.get_published_date(date)
         self.assertEqual(result, "January 1")
+
+        with patch("django.utils.timezone.now") as timezone_mock:
+            timezone_mock.return_value = datetime.datetime(
+                # bookwyrm-social#3365: bug with exact month deltas
+                2022, 3, 1, 0, 0, tzinfo=datetime.timezone.utc
+            )
+            result = status_display.get_published_date(date)
+        self.assertEqual(result, "January 1")

--- a/bookwyrm/tests/templatetags/test_status_display.py
+++ b/bookwyrm/tests/templatetags/test_status_display.py
@@ -114,7 +114,12 @@ class StatusDisplayTags(TestCase):
         with patch("django.utils.timezone.now") as timezone_mock:
             timezone_mock.return_value = datetime.datetime(
                 # bookwyrm-social#3365: bug with exact month deltas
-                2022, 3, 1, 0, 0, tzinfo=datetime.timezone.utc
+                2022,
+                3,
+                1,
+                0,
+                0,
+                tzinfo=datetime.timezone.utc,
             )
             result = status_display.get_published_date(date)
         self.assertEqual(result, "January 1")

--- a/bookwyrm/tests/templatetags/test_status_display.py
+++ b/bookwyrm/tests/templatetags/test_status_display.py
@@ -109,4 +109,4 @@ class StatusDisplayTags(TestCase):
                 2022, 1, 8, 0, 0, tzinfo=datetime.timezone.utc
             )
             result = status_display.get_published_date(date)
-        self.assertEqual(result, "Jan 1")
+        self.assertEqual(result, "January 1")


### PR DESCRIPTION
Makes all dates fixed except if in the last day, in which case they are relative times.

Prior to this if a post was published on the same day of the month as today, the date was shown as relative (e.g. "10 months ago").

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #3365

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
