### PR TITLE
Update postgres to 13.16

### DIFF
--- a/postgres-docker/Dockerfile
+++ b/postgres-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13.0
+FROM postgres:13.16
 
 # crontab
 RUN mkdir /backups
@@ -15,6 +15,6 @@ RUN touch /var/log/cron.log
 # We need to start the cron service the first time it runs, when it's still being run
 # as the root user. We're going to add a check that looks at the first argument and
 # if it's 'cron', starts the service and then removes that argument.
-RUN awk '$0 ~ /^\t_main "\$@"$/ { print "\tif [[ $1 == cron ]]; then\n\t\techo \"POSTGRES_DB=${POSTGRES_DB}\" > /backups/.env\n\t\techo \"POSTGRES_USER=${POSTGRES_USER}\" >> /backups/.env\n\t\tservice cron start\n\t\tshift\n\tfi" }{ print }' docker-entrypoint.sh > bookwyrm-entrypoint.sh
+RUN awk '$0 ~ /^\t_main "\$@"$/ { print "\tif [[ $1 == cron ]]; then\n\t\techo \"POSTGRES_DB=${POSTGRES_DB}\" > /backups/.env\n\t\techo \"POSTGRES_USER=${POSTGRES_USER}\" >> /backups/.env\n\t\tservice cron start\n\t\tshift\n\tfi" }{ print }' /usr/local/bin/docker-entrypoint.sh > bookwyrm-entrypoint.sh
 RUN chown postgres /bookwyrm-entrypoint.sh
 RUN chmod u=rwx,go=r /bookwyrm-entrypoint.sh


### PR DESCRIPTION
<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->

Updates postgres from 13.0 to 13.16. Currently, when starting BookWyrm with `./bw-dev up`, the postgres step fails as http://apt.postgresql.org/pub/repos/apt no longer hosts repositories for Debian Buster, which instead uses Debian Bookworm and is still supported. The postgres docker also moved the location of its entrypoint, so the PR also updates `docker-entrypoint.sh` to `/usr/local/bin/docker-entrypoint.sh` 


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Closes #3439

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

Upgrades postgres from postgres:13.0 to postgres:13.16 (not breaking in my testing, but a configuration change nonetheless)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
