### PR TITLE
Fix IntegrityError caused by duplicate periodic task creation

### DIFF
--- a/bookwyrm/views/admin/dashboard.py
+++ b/bookwyrm/views/admin/dashboard.py
@@ -83,7 +83,7 @@ class Dashboard(View):
             schedule, _ = IntervalSchedule.objects.get_or_create(
                 **schedule_form.cleaned_data
             )
-            PeriodicTask.objects.get_or_create(
+            PeriodicTask.objects.update_or_create(
                 interval=schedule,
                 name="check-for-updates",
                 task="bookwyrm.models.site.check_for_updates_task",


### PR DESCRIPTION



<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

**Summary**
This PR addresses an issue with the creation of periodic tasks in the `settings-dashboard` view, where using `PeriodicTask.objects.get_or_create()` could lead to an IntegrityError due to duplicate primary keys when the task already exists.

**Technical Details**
The change involves replacing `PeriodicTask.objects.get_or_create()` with `PeriodicTask.objects.update_or_create()`. This modification ensures that if a periodic task with the specified name already exists, it will be updated instead of creating a new entry, thus preventing the IntegrityError that occurs due to a unique constraint violation on the primary key.

**Changes Made**
- Updated `PeriodicTask.objects.get_or_create()` to `PeriodicTask.objects.update_or_create()` to prevent duplicate key errors when the task already exists.

**Testing and Impact**
This change has been tested to verify:
- If the task with the given name already exists, the task is updated without creating duplicate entries.
- If the task does not exist, a new entry is created correctly.

This update helps to prevent issues when multiple attempts are made to create a periodic task, especially in production environments, where such collisions can cause instability.

**Additional Context**
No other changes were made beyond this single line, to minimize potential side effects.

- Related Issue #
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [x] I have not written tests and need help to write them

