### PR TITLE
Add STATIC_ROOT to .env.example to fix CSS loading issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ DEFAULT_LANGUAGE="English"
 # Probably only necessary in development.
 # PORT=1333
 
+STATIC_ROOT=static/
 MEDIA_ROOT=images/
 
 # Database configuration


### PR DESCRIPTION

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

This pull request adds `STATIC_ROOT=static/` to the `.env.example` file to prevent CSS and other static resources from not loading properly. Specifically, this change addresses an issue where, without a proper `STATIC_ROOT` configuration, the website's CSS fails to load correctly, especially after logging in. This causes a poor user experience as stylesheets are missing or not applied.

**Technical Details**:

-   Added `STATIC_ROOT=static/` to `.env.example`.
    
-   Ensured that the static files are properly collected into the `static/` directory using `collectstatic`.
    
-   This adjustment complements existing Nginx configurations, ensuring that both static and media files are accessible.
    
**Additional context**:

[I](https://github.com/Guanchishan) recently migrated my service to the current environment, and I ensured that all recommended update procedures outlined in [the BookWyrm documentation](https://docs.joinbookwyrm.com/updating.html) were strictly followed.

Initially, after properly configuring Nginx, the CSS for the site appeared normal for users who were not logged in. However, upon logging in, the CSS became disorganized. This issue was only resolved after configuring STATIC_ROOT=static/.

Interestingly, although this was not directly related to the issue, I also found that after configuring Nginx, other images on the website displayed correctly, but the site icon did not appear. It was only after adding MEDIA_ROOT=images/ that the site icon became visible. This was an intriguing discovery.

- Related Issue #3449
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [x] I have not written tests and need help to write them
