### PR TITLE
Alters get_description code for inventaire queries

### DIFF
--- a/bookwyrm/connectors/inventaire.py
+++ b/bookwyrm/connectors/inventaire.py
@@ -222,9 +222,10 @@ class Connector(AbstractConnector):
     def get_description(self, links: JsonDict) -> str:
         """grab an extracted excerpt from wikipedia"""
         link = links.get("enwiki")
-        if not link:
+        if not link or not link.get("title"):
             return ""
-        url = f"{self.base_url}/api/data?action=wp-extract&lang=en&title={link}"
+        title = link.get("title")
+        url = f"{self.base_url}/api/data?action=wp-extract&lang=en&title={title}"
         try:
             data = get_data(url)
         except ConnectorException:

--- a/bookwyrm/tests/connectors/test_inventaire_connector.py
+++ b/bookwyrm/tests/connectors/test_inventaire_connector.py
@@ -273,7 +273,9 @@ class Inventaire(TestCase):
             json={"extract": "hi hi"},
         )
 
-        extract = self.connector.get_description({"enwiki": "test_path"})
+        extract = self.connector.get_description(
+            {"enwiki": {"title": "test_path", "badges": "hello"}}
+        )
         self.assertEqual(extract, "hi hi")
 
     def test_remote_id_from_model(self):


### PR DESCRIPTION
<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->
We are malforming requests to inventaire by sending json blobs as strings. This fixed that.

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #3491

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
