### PR TITLE
Fix isbn search, matching the regular search

### DIFF
--- a/bookwyrm/connectors/openlibrary.py
+++ b/bookwyrm/connectors/openlibrary.py
@@ -181,17 +181,19 @@ class Connector(AbstractConnector):
             )
 
     def parse_isbn_search_data(self, data: JsonDict) -> Iterator[SearchResult]:
-        for search_result in list(data.values()):
+        for search_result in list(data.get("docs", [])):
             # build the remote id from the openlibrary key
             key = self.books_url + search_result["key"]
-            authors = search_result.get("authors") or [{"name": "Unknown"}]
-            author_names = [author.get("name") for author in authors]
+            authors = search_result.get("author_name") or ["Unknown"]
+            cover_blob = search_result.get("cover_i")
+            cover = self.get_cover_url([cover_blob], size="M") if cover_blob else None
             yield SearchResult(
                 title=search_result.get("title"),
                 key=key,
-                author=", ".join(author_names),
+                author=", ".join(authors),
                 connector=self,
-                year=search_result.get("publish_date"),
+                year=search_result.get("first_publish_year"),
+                cover=cover,
             )
 
     def load_edition_data(self, olkey: str) -> JsonDict:


### PR DESCRIPTION
<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->
I noticed on my instance that looking for ISBN directly was always resulting in an "Oops" page. This only happens if the isbn-like search does not have local results (otherwise the local results are displayed).

I tried matching the ISBN results to the regular search results, I guess one method was changed and the other wasn't.

I haven't written any tests, though probably some should be written to avoid this method to get out-of-sync again in the future.

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [X] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [x] I have not written tests and need help to write them
