### PR TITLE
Removed login_required from viewing public lists from user profiles

### DIFF
--- a/bookwyrm/tests/views/lists/test_lists.py
+++ b/bookwyrm/tests/views/lists/test_lists.py
@@ -160,7 +160,7 @@ class ListViews(TestCase):
         self.assertIsInstance(result, TemplateResponse)
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
-        
+
     def test_lists_create(self):
         """create list view"""
         view = views.Lists.as_view()

--- a/bookwyrm/tests/views/lists/test_lists.py
+++ b/bookwyrm/tests/views/lists/test_lists.py
@@ -145,12 +145,22 @@ class ListViews(TestCase):
     def test_user_lists_page_logged_out(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.UserLists.as_view()
+        with (
+            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
+            patch("bookwyrm.lists_stream.remove_list_task.delay"),
+        ):
+            models.List.objects.create(name="Public list", user=self.local_user)
+            models.List.objects.create(
+                name="Private list", privacy="direct", user=self.local_user
+            )
         request = self.factory.get("")
         request.user = self.anonymous_user
 
         result = view(request, self.local_user.username)
-        self.assertEqual(result.status_code, 302)
-
+        self.assertIsInstance(result, TemplateResponse)
+        validate_html(result.render())
+        self.assertEqual(result.status_code, 200)
+        
     def test_lists_create(self):
         """create list view"""
         view = views.Lists.as_view()

--- a/bookwyrm/views/list/lists.py
+++ b/bookwyrm/views/list/lists.py
@@ -11,6 +11,7 @@ from bookwyrm.lists_stream import ListsStream
 from bookwyrm.views.helpers import get_user_from_username
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 # pylint: disable=no-self-use
@@ -71,7 +72,7 @@ class UserLists(View):
 
     def get(self, request, username):
         """display a book list"""
-        
+
         user = get_user_from_username(request.user, username)
         lists = models.List.privacy_filter(request.user).filter(user=user)
         paginated = Paginator(lists, 12)

--- a/bookwyrm/views/list/lists.py
+++ b/bookwyrm/views/list/lists.py
@@ -10,6 +10,8 @@ from bookwyrm import forms, models
 from bookwyrm.lists_stream import ListsStream
 from bookwyrm.views.helpers import get_user_from_username
 
+import logging
+logger = logging.getLogger(__name__)
 
 # pylint: disable=no-self-use
 class Lists(View):
@@ -64,12 +66,12 @@ class SavedLists(View):
         return TemplateResponse(request, "lists/lists.html", data)
 
 
-@method_decorator(login_required, name="dispatch")
 class UserLists(View):
     """a user's book list page"""
 
     def get(self, request, username):
         """display a book list"""
+        
         user = get_user_from_username(request.user, username)
         lists = models.List.privacy_filter(request.user).filter(user=user)
         paginated = Paginator(lists, 12)


### PR DESCRIPTION
<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->
This pull request removes the `login_required` requirement for public and unlisted lists viewed directly from the user profile. As noted in #3482 , today you can see public lists from the server-level page and you can view user profiles while logged out, but if you try to view a user's public/unlisted lists from their profile you are prompted to log in. This change makes those behaviors consistent.

I created lists of all four visibility types in my dev environment and confirmed that, while logged out, I could only see the Public and Unlisted lists on the user's profile and that Followers and Private lists still required authentication which is consistent with the server lists behavior.

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #3482 

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [x ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
