### PR TITLE
search: use default confidence of 0.1 on search instead of disabling min_confidence

### DIFF
--- a/bookwyrm/views/search.py
+++ b/bookwyrm/views/search.py
@@ -57,7 +57,7 @@ def api_book_search(request):
     """Return books via API response"""
     query = request.GET.get("q").strip()
     query = isbn_check_and_format(query)
-    min_confidence = request.GET.get("min_confidence", 0)
+    min_confidence = float(request.GET.get("min_confidence", 0.1))
     # only return local book results via json so we don't cascade
     book_results = search(query, min_confidence=min_confidence)
     return JsonResponse(
@@ -70,7 +70,7 @@ def book_search(request):
     query = request.GET.get("q").strip()
     # check if query is isbn
     query = isbn_check_and_format(query)
-    min_confidence = request.GET.get("min_confidence", 0)
+    min_confidence = float(request.GET.get("min_confidence", 0.1))
     search_remote = request.GET.get("remote", False) and request.user.is_authenticated
 
     # try a local-only search


### PR DESCRIPTION
<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->

0.1 is min_confidence if parameter is not given, but search sets it to 0, so min_confidence was not actually used in connectors/searches.

This also fixes the flow if you give min_confidence as URL parameter. Previously it gave failure as it was trying to compare str to float

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [X] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
