### PR TITLE
normalize rank to be 0..1 from database searches

### DIFF
--- a/bookwyrm/book_search.py
+++ b/bookwyrm/book_search.py
@@ -142,7 +142,7 @@ def search_title_author(
     query = SearchQuery(query, config="simple") | SearchQuery(query, config="english")
     results = (
         books.filter(*filters, search_vector=query)
-        .annotate(rank=SearchRank(F("search_vector"), query))
+        .annotate(rank=SearchRank(F("search_vector"), query, normalization=32))
         .filter(rank__gt=min_confidence)
         .order_by("-rank")
     )

--- a/bookwyrm/tests/importers/test_openreads_import.py
+++ b/bookwyrm/tests/importers/test_openreads_import.py
@@ -110,9 +110,7 @@ class OpenReadsImport(TestCase):
 
         retry_items = models.ImportItem.objects.filter(job=retry).all()
         self.assertEqual(len(retry_items), 2)
-        self.assertEqual(retry_items[0].index, 0)
-        self.assertEqual(import_items[0].data["title"], "Wild Flowers Electric Beasts")
-        self.assertEqual(retry_items[1].index, 1)
+        self.assertEqual(retry_items[0].data["title"], "Wild Flowers Electric Beasts")
         self.assertEqual(retry_items[1].data["title"], "Permanent Record")
 
     def test_handle_imported_book(self, *_):

--- a/bookwyrm/views/books/edit_book.py
+++ b/bookwyrm/views/books/edit_book.py
@@ -189,7 +189,7 @@ def add_authors(request, data):
 
         author_matches = (
             models.Author.objects.annotate(search=vector)
-            .annotate(rank=SearchRank(vector, author))
+            .annotate(rank=SearchRank(vector, author, normalization=32))
             .filter(rank__gt=0.4)
             .order_by("-rank")[:5]
         )

--- a/bookwyrm/views/search.py
+++ b/bookwyrm/views/search.py
@@ -103,7 +103,7 @@ def author_search(request):
 
     results = (
         models.Author.objects.filter(search_vector=search_query)
-        .annotate(rank=SearchRank(F("search_vector"), search_query))
+        .annotate(rank=SearchRank(F("search_vector"), search_query, normalization=32))
         .filter(rank__gt=min_confidence)
         .order_by("-rank")
     )


### PR DESCRIPTION


<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->
This gives the local search ranks in scale of 0..1, same what we assume connector confidence to be.

I'm not sure if this is desired change, as it might rule out some results that were previously found, as now the min_confidence most likely has more relevance that is given as filtering criteria.

value 32 is documented in
https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-RANKING

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [ ] Bug Fix
- [X] Enhancement
- [X] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
