### PR TITLE
fix `bw-dev setup` failing and remove `--build` from `bw-dev up`

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -81,7 +81,7 @@ set -x
 
 case "$CMD" in
     up)
-        $DOCKER_COMPOSE up --build "$@"
+        $DOCKER_COMPOSE up "$@"
         ;;
     down)
         $DOCKER_COMPOSE down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
   db:
     image: postgres:13
     env_file: .env
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:
@@ -29,9 +35,13 @@ services:
       - media_volume:/app/images
       - exports_volume:/app/exports
     depends_on:
-      - db
-      - celery_worker
-      - redis_activity
+      db:
+        condition: service_healthy
+        restart: true
+      celery_worker:
+        condition: service_started
+      redis_activity:
+        condition: service_started
     networks:
       - main
     ports:


### PR DESCRIPTION
Running `setup` and `resetdb` often fails because the database hasn't finished starting up yet. 

This fixes that by waiting for a sucessful healthcheck before starting the web container. Also removes `--build` from `bw-dev up` - devs can just run `bw-dev --build` if that's what they want to do, but usually it isn't.

fixes #3100

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #3100

## What type of Pull Request is this?
<!-- Check all that apply -->

- [ ] Bug Fix
- [ ] Enhancement
- [x] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
