### PR TITLE
handle 410 http responses

### DIFF
--- a/bookwyrm/activitypub/__init__.py
+++ b/bookwyrm/activitypub/__init__.py
@@ -2,6 +2,8 @@
 import inspect
 import sys
 
+from requests import HTTPError
+
 from .base_activity import ActivityEncoder, Signature, naive_parse
 from .base_activity import Link, Mention, Hashtag
 from .base_activity import (
@@ -34,3 +36,10 @@ activity_objects = {c[0]: c[1] for c in cls_members if hasattr(c[1], "to_model")
 def parse(activity_json):
     """figure out what activity this is and parse it"""
     return naive_parse(activity_objects, activity_json)
+
+
+# pylint: disable=unnecessary-pass
+class UserIsGoneError(HTTPError):
+    """error class for when a user is banned or deleted"""
+
+    pass

--- a/bookwyrm/tests/activitypub/test_base_activity.py
+++ b/bookwyrm/tests/activitypub/test_base_activity.py
@@ -5,7 +5,9 @@ from unittest.mock import patch
 
 from dataclasses import dataclass
 from django.test import TestCase
+from requests.exceptions import HTTPError
 import responses
+
 
 from bookwyrm import activitypub
 from bookwyrm.activitypub.base_activity import (
@@ -13,6 +15,7 @@ from bookwyrm.activitypub.base_activity import (
     resolve_remote_id,
     set_related_field,
     get_representative,
+    get_activitypub_data,
 )
 from bookwyrm.activitypub import ActivitySerializerError
 from bookwyrm import models
@@ -315,3 +318,54 @@ class BaseActivity(TestCase):
 
         self.assertIsInstance(status.attachments.first(), models.Image)
         self.assertIsNotNone(status.attachments.first().image)
+
+    @responses.activate
+    def test_do_not_raise_error_on_410(self, *_):
+        """test that 410 errors are merely logged as a warning"""
+
+        # mock a 410 response
+        responses.add(
+            responses.GET,
+            "https://example.com/user/mouse",
+            json=self.userdata,
+            status=410,
+        )
+
+        # let's check that we actually do get an error in the underlying function
+        with self.assertRaises(HTTPError):
+            get_activitypub_data("https://example.com/user/mouse")
+
+        # should log a warning
+        with self.assertLogs(level="DEBUG") as logger:
+            resolved = resolve_remote_id("https://example.com/user/mouse")
+            self.assertEqual(
+                logger.output,
+                [
+                    "WARNING:bookwyrm.activitypub.base_activity:request for object dropped because it is gone (410) - remote_id: https://example.com/user/mouse"  # pylint: disable=line-too-long
+                ],
+            )
+
+            # should not raise an exception
+            self.assertEqual(resolved, None)
+
+        # should log nothing if we only want to log errors
+        with self.assertNoLogs(logger=None, level="ERROR") as logger:
+            resolved = resolve_remote_id("https://example.com/user/mouse")
+
+    @responses.activate
+    def test_delete_user_if_gone(self, *_):
+        """test that users are deleted when their remote id returns a 410"""
+
+        responses.add(
+            responses.GET,
+            self.user.remote_id,
+            json=self.userdata,
+            status=410,
+        )
+
+        self.assertFalse(self.user.deleted)
+
+        resolve_remote_id(self.user.remote_id)
+
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.deleted)

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -5,7 +5,7 @@ import logging
 
 import requests
 
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, HttpResponseForbidden, Http404
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
@@ -40,8 +40,12 @@ class Inbox(View):
         except json.decoder.JSONDecodeError:
             raise BadRequest()
 
-        # let's be extra sure we didn't block this domain
-        raise_is_blocked_activity(activity_json)
+        try:
+            # let's be extra sure we didn't block this domain
+            raise_is_blocked_activity(activity_json)
+        except activitypub.UserIsGoneError:
+            # banned or deleted users are not allowed to send us Activities
+            return HttpResponseForbidden()
 
         if (
             not "object" in activity_json
@@ -86,12 +90,13 @@ def raise_is_blocked_activity(activity_json):
         # well I guess it's not even a valid activity so who knows
         return
 
-    # check if the user is banned/deleted
+    # check if the user is banned/deleted in our database
     existing = models.User.find_existing_by_remote_id(actor)
     if existing and existing.deleted:
         logger.debug("%s is banned/deleted, denying request based on actor", actor)
-        raise PermissionDenied()
+        raise activitypub.UserIsGoneError()
 
+    # check if we have blocked the whole server
     if models.FederatedServer.is_blocked(actor):
         logger.debug("%s is blocked, denying request based on actor", actor)
         raise PermissionDenied()


### PR DESCRIPTION
If an inbound Inbox item fails because `raise_is_blocked_activity` identifies the sender has been deleted or blocked on their server, then it is clearer to send an `HttpResponseForbidden` back to them, rather than ambiguously raising a `PermissionDenied` error implying we did something wrong at our end.

Additionally, when any ActivityPub request returns a `410` (regardless of the object type) we should log this only as a `WARNING` rather than an exception, since it is not really an error that a system admin can do anything about.

This PR changes behaviour in three places:

If there is an `HTTPError`, we now:

* check to see whether the status code is `410`
* log a warning (instead of an exception)
* `delete()` the user locally if they are not already marked as deleted

When identifying that the sending user has been deleted, instead of raising `PermissionDenied()` we raise a new custom error – `UserIsGoneError()`

When calling `raise_is_blocked_activity()` we now use a try..catch block that catches any `UserIsGoneError.` If `UserIsGoneError` is identified, we return `HttpResponseForbidden()` (previously this was `PermissionDenied()` passing through from `raise_is_blocked_activity`)

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #3552

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [x] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
