### PR TITLE
Remove deprecated use from duplicate link check 

### DIFF
--- a/bookwyrm/forms/links.py
+++ b/bookwyrm/forms/links.py
@@ -30,22 +30,26 @@ class FileLinkForm(CustomForm):
         if models.LinkDomain.objects.filter(domain=domain).exists():
             status = models.LinkDomain.objects.get(domain=domain).status
             if status == "blocked":
-                # pylint: disable=line-too-long
                 self.add_error(
                     "url",
                     _(
-                        "This domain is blocked. Please contact your administrator if you think this is an error."
+                        "This domain is blocked. "
+                        "Please contact your administrator if you think "
+                        "this is an error."
                     ),
                 )
-        if (
-            models.FileLink.objects.filter(url=url, book=book, filetype=filetype)
-            .exclude(pk=self.instance)
-            .exists()
-        ):
-            # pylint: disable=line-too-long
-            self.add_error(
-                "url",
-                _(
-                    "This link with file type has already been added for this book. If it is not visible, the domain is still pending."
-                ),
-            )
+                return
+        if current_links := models.FileLink.objects.filter(
+            url=url, book=book, filetype=filetype
+        ).all():
+            for link in current_links:
+                if link == self.instance:
+                    continue
+                self.add_error(
+                    "url",
+                    _(
+                        "This link with file type has already been added for this book."
+                        " If it is not visible, the domain is still pending."
+                    ),
+                )
+                break


### PR DESCRIPTION
<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->

Rework how duplicate-link check is done and add unit-test for it, with `exclude(pk=self.instance)` we might get default FileLink instance that is not saved to db, and Django 5.0+ fails in such cases instead of just warning about it.

Splitted out from https://github.com/bookwyrm-social/bookwyrm/pull/3616

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [X] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [X] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
