### PR TITLE
Update .gitignore to exclude QNAP NAS temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ nginx/default.conf
 #macOS
 **/.DS_Store
 
+#QTS (system in QNAP NAS)
+**/.@__thumb/
+
 # Docker
 docker-compose.override.yml


### PR DESCRIPTION
Adds entries for QTS-generated temporary files like .@__thumb/ to prevent them from being tracked by Git.

## Description
This pull request updates the `.gitignore` file to include entries for temporary files generated by QNAP NAS (QTS operating system). Specifically, it adds `/.@__thumb/` to prevent these system-generated folders and their contents from being accidentally committed to the repository. This helps keep the repository clean and free from irrelevant temporary files.

- Related Issue #
- Closes #

## What type of Pull Request is this?
- [ ] Bug Fix
- [x] Enhancement
- [x] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

### Tests
- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them