### PR TITLE
Fix #3632: Add anchor link to scroll to reviews section

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -194,7 +194,10 @@
                 >
                     <meta itemprop="ratingValue" content="{{ rating|floatformat }}">
                     <meta itemprop="reviewCount" content="{{ review_count }}">
-
+                    
+                    {% if review_count > 0 %}
+                    <a href="#reviews" class="has-text-link">
+                    {% endif %}
                     <span>
                         {% include 'snippets/stars.html' with rating=rating %}
 
@@ -204,6 +207,9 @@
                             ({{ review_count }} reviews)
                         {% endblocktrans %}
                     </span>
+                    {% if review_count > 0 %}
+                    </a>
+                    {% endif %}
                 </div>
 
                 {% with full=book|book_description itemprop='abstract' %}


### PR DESCRIPTION

## Description
<!--
This PR adds an anchor link on the aggregate rating section that scrolls the user down to the reviews section on the book page. It improves navigation by making it easier for users to jump directly to reviews.
- The review count text is clickable only when there are one or more reviews.
- When there are zero reviews, the text is shown but not clickable to avoid misleading users.
-->

- Related Issue #3632
- Closes #3632

## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)
None

## Documentation

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
