### PR TITLE
Allow S3 Default ACL Override for Backblaze

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,9 @@ S3_SIGNED_URL_EXPIRY=900
 # AWS_S3_URL_PROTOCOL=None        # "http:"
 # AWS_S3_REGION_NAME=None         # "fr-par"
 # AWS_S3_ENDPOINT_URL=None        # "https://s3.fr-par.scw.cloud"
+# AWS_DEFAULT_ACL=""              # AWS_DEFAULT_ACL defaults to public-read, however, not all providers, e.g. BackBlaze, support it.
+                                  # Uncomment and set this value to an empty string (for Back Blaze) or whatever is required by your provider to override it. 
+
 
 # Commented are example values if you use Azure Blob Storage
 # USE_AZURE=true

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -390,7 +390,7 @@ if USE_S3:
     AWS_S3_CUSTOM_DOMAIN = env("AWS_S3_CUSTOM_DOMAIN", None)
     AWS_S3_REGION_NAME = env("AWS_S3_REGION_NAME", "")
     AWS_S3_ENDPOINT_URL = env("AWS_S3_ENDPOINT_URL", None)
-    AWS_DEFAULT_ACL = "public-read"
+    AWS_DEFAULT_ACL = env("AWS_DEFAULT_ACL", "public-read")
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
     AWS_S3_URL_PROTOCOL = env("AWS_S3_URL_PROTOCOL", f"{PROTOCOL}:")
     # Storages

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -399,7 +399,7 @@ if USE_S3:
             "BACKEND": "storages.backends.s3.S3Storage",
             "OPTIONS": {
                 "location": "images",
-                "default_acl": "public-read",
+                "default_acl": AWS_DEFAULT_ACL,
                 "file_overwrite": False,
             },
         },
@@ -407,14 +407,14 @@ if USE_S3:
             "BACKEND": "storages.backends.s3.S3Storage",
             "OPTIONS": {
                 "location": "static",
-                "default_acl": "public-read",
+                "default_acl": AWS_DEFAULT_ACL,
             },
         },
         "sass_processor": {
             "BACKEND": "storages.backends.s3.S3Storage",
             "OPTIONS": {
                 "location": "static",
-                "default_acl": "public-read",
+                "default_acl": AWS_DEFAULT_ACL,
             },
         },
         "exports": {


### PR DESCRIPTION

## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)
Breaking - should be done

## What is this and why
I tried to run Bookwyrm on my server using Backblaze B2 S3 as my S3 storage, but it failed on an ACL permission because because the default value of public-read is not supported. This change uses the `env` fallback for that variable
<img width="1287" height="61" alt="Screenshot 2025-08-15 at 2 27 05 PM" src="https://github.com/user-attachments/assets/1dca3ea3-511a-4da0-aa37-41486fd9c01c" />

This PR switches this variable to use a fallback of `public-read`.

Overriding, set the env variable:
```
AWS_DEFAULT_ACL: ""
```

<!-- Check all that apply -->

- [x] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [x] I intend to create a matching pull request in the Documentation repository after this PR is merged


### Tests
I'm currently running https://bookwyrm.keyboardvagabond.com with it and assets were pushed and are used from S3 as expected.

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
