### PR TITLE
Force https on embed urls

### DIFF
--- a/bookwyrm/views/list/list.py
+++ b/bookwyrm/views/list/list.py
@@ -1,5 +1,6 @@
 """ book list views"""
 from typing import Optional
+from urllib.parse import urlparse, urlunparse
 
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
@@ -57,6 +58,9 @@ class List(View):
         embed_key = str(book_list.embed_key.hex)
         embed_url = reverse("embed-list", args=[book_list.id, embed_key])
         embed_url = request.build_absolute_uri(embed_url)
+        # NOTE: this forces https even on localhost
+        https_url = urlparse(embed_url)._replace(scheme="https")
+        embed_url = urlunparse(https_url)
 
         if request.GET:
             embed_url = f"{embed_url}?{request.GET.urlencode()}"


### PR DESCRIPTION
As per #3648, embed code URLs are http if a proxy server is being used. This fix forces them to always use https.

- Closes #3648

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `black`, `pylint`, and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
