### PR TITLE
Use setUpTestData for Import/Export job tests

### DIFF
--- a/bookwyrm/tests/models/test_bookwyrm_export_job.py
+++ b/bookwyrm/tests/models/test_bookwyrm_export_job.py
@@ -15,7 +15,8 @@ from bookwyrm.utils.tar import BookwyrmTarFile
 class BookwyrmExportJob(TestCase):
     """testing user export functions"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """lots of stuff to set up for a user export"""
         with (
             patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),

--- a/bookwyrm/tests/models/test_bookwyrm_import_job.py
+++ b/bookwyrm/tests/models/test_bookwyrm_import_job.py
@@ -18,7 +18,8 @@ from bookwyrm.models import bookwyrm_import_job
 class BookwyrmImport(TestCase):  # pylint: disable=too-many-public-methods
     """testing user import functions"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(self):  # pylint: disable=bad-classmethod-argument
         """setting stuff up"""
         with (
             patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),


### PR DESCRIPTION
This is a follow-up to #3146. It greatly improves the speed of these tests, going down from 50 seconds on my machine, to 15 seconds.

The pylint disable I intend to address when resolving conflicts with my own https://github.com/dato/bookwyrm/pull/23.

