### PR TITLE
Fix Safari dropdown arrow

### DIFF
--- a/bookwyrm/static/css/bookwyrm/components/_details.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_details.scss
@@ -3,6 +3,7 @@
 
 details summary {
     cursor: pointer;
+    list-style-type: none;
 }
 
 summary::-webkit-details-marker {


### PR DESCRIPTION
## Summary
- Fixes additional side-facing arrow displayed in Safari on profile dropdown
- Adds `list-style-type: none` to `details summary` selector

## Problem
Safari displays an extra arrow to the left of the user avatar in the profile dropdown, despite existing marker hiding rules (`::marker` and `::-webkit-details-marker`).

## Solution
Added `list-style-type: none` to the `details summary` CSS rule in `_details.scss`. This is a known Safari quirk where the browser requires this additional property to fully suppress the default list marker on `<summary>` elements.

## Changes
- **File modified:** `bookwyrm/static/css/bookwyrm/components/_details.scss`
- **Line 6:** Added `list-style-type: none;` to the `details summary` selector

## Testing
This is a Safari-specific CSS fix. The change should not affect other browsers since they already hide the marker with existing rules. Safari users will see the extra arrow removed.

Fixes #3735