### PR TITLE
Fix IntegrityError when resolve_remote_id returns None

### DIFF
--- a/bookwyrm/models/fields.py
+++ b/bookwyrm/models/fields.py
@@ -355,13 +355,13 @@ class ManyToManyField(ActivitypubFieldMixin, models.ManyToManyField):
                 validate_remote_id(remote_id)
             except ValidationError:
                 continue
-            items.append(
-                activitypub.resolve_remote_id(
-                    remote_id,
-                    model=self.related_model,
-                    allow_external_connections=allow_external_connections,
-                )
+            item = activitypub.resolve_remote_id(
+                remote_id,
+                model=self.related_model,
+                allow_external_connections=allow_external_connections,
             )
+            if item is not None:
+                items.append(item)
         return items
 
 
@@ -419,13 +419,13 @@ class TagField(ManyToManyField):
                 items.append(hashtag)
             else:
                 # for other tag types we fetch them remotely
-                items.append(
-                    activitypub.resolve_remote_id(
-                        link.href,
-                        model=self.related_model,
-                        allow_external_connections=allow_external_connections,
-                    )
+                item = activitypub.resolve_remote_id(
+                    link.href,
+                    model=self.related_model,
+                    allow_external_connections=allow_external_connections,
                 )
+                if item is not None:
+                    items.append(item)
         return items
 
 


### PR DESCRIPTION
## Description

  When `resolve_remote_id` fails to fetch a remote resource (connection error, 404, timeout, etc.), it returns `None`. The code was appending this `None` directly to the items list, which later causes an `IntegrityError` when Django tries to create the many-to-many relationship with a null foreign key.

  This fix checks for `None` before appending in both `ManyToManyField.field_from_activity()` and `TagField.field_from_activity()`.

  - Related Issue #
  - Closes #3739

  ## What type of Pull Request is this?

  - [x] Bug Fix
  - [ ] Enhancement
  - [ ] Plumbing / Internals / Dependencies
  - [ ] Refactor

  ## Does this PR change settings or dependencies, or break something?

  - [ ] This PR changes or adds default settings, configuration, or .env values
  - [ ] This PR changes or adds dependencies
  - [ ] This PR introduces other breaking changes

  ### Details of breaking or configuration changes (if any of above checked)


  ## Documentation

  - [ ] New or amended documentation will be required if this PR is merged
  - [ ] I have created a matching pull request in the Documentation repository
  - [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

  ### Tests

  - [x] My changes do not need new tests
  - [ ] All tests I have added are passing
  - [ ] I have written tests but need help to make them pass
  - [ ] I have not written tests and need help to write them