### PR TITLE
Fix: services.web.depends_on.db Additional property restart is not al…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-        restart: true
       celery_worker:
         condition: service_started
       redis_activity:


### PR DESCRIPTION
…lowed

Fix issue #3771

## Description
Gets rid of restart property at services.web.depends_on.db


- Related Issue #3771
- Closes #3771

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
