### PR TITLE
 Fix: services.web.depends_on.db Additional property restart is not allowed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      celery_worker:
-        condition: service_started
       redis_activity:
         condition: service_started
     networks:


### PR DESCRIPTION

Fix issue #3771

## Description
Gets rid of restart property at services.web.depends_on.db

- Related Issue #3771
- Closes #3771

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes
