### PR TITLE
Re-enable stylelint disables after using them

### DIFF
--- a/bookwyrm/static/css/bookwyrm/components/_shelving.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_shelving.scss
@@ -4,7 +4,9 @@
 /** @todo Replace icons with SVG symbols.
     @see https://www.youtube.com/watch?v=9xXBYcWgCHA */
 .shelf-option:disabled > *::after {
-    font-family: icomoon; /* stylelint-disable font-family-no-missing-generic-family-keyword */
+    /* stylelint-disable font-family-no-missing-generic-family-keyword */
+    font-family: icomoon;
+    /* stylelint-enable font-family-no-missing-generic-family-keyword */
     content: "\e919"; /* icon-check */
     margin-left: 0.5em;
 }

--- a/bookwyrm/static/css/bookwyrm/components/_stars.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_stars.scss
@@ -35,6 +35,7 @@
 .form-rate-stars input.half:checked + input + .icon:hover::before {
     content: "\e9d8" !important; /* icon-star-half */
 }
+/* stylelint-enable no-descending-specificity */
 
 /* Icons directly following half check inputs that follow the checked input are emptied. */
 .form-rate-stars input.half:checked + input + .icon ~ .icon::before {

--- a/bookwyrm/static/css/bookwyrm/components/_status.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_status.scss
@@ -24,7 +24,9 @@
 
 .quote > blockquote::before,
 .quote > blockquote::after {
-    font-family: icomoon; /* stylelint-disable font-family-no-missing-generic-family-keyword */
+    /* stylelint-disable font-family-no-missing-generic-family-keyword */
+    font-family: icomoon;
+    /* stylelint-enable font-family-no-missing-generic-family-keyword */
     position: absolute;
 }
 


### PR DESCRIPTION
This avoids errors like:


    bookwyrm/static/css/themes/bookwyrm-dark.css
     8442:3  ✖  "font-family-no-missing-generic-family-keyword"
                 has already been disabled       CssSyntaxError

which aborts the stylelint run and without showing the actual list of (other) issues.

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## What type of Pull Request is this?
<!-- Check all that apply -->

- [ ] Bug Fix
- [ ] Enhancement
- [x] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
