### PR TITLE
Enable IPv6 for the main network so federation with IPv6-only instances is possible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,3 +185,4 @@ volumes:
   redis_activity_data:
 networks:
   main:
+    enable_ipv6: true


### PR DESCRIPTION

## Description
<!--
Describe what your pull request does here
-->
This change enables IPv6 on the docker network, so (outbound) federation over IPv6 becomes possible. This is necessary, since even though the web server hosting an instance may support IPv6, docker will by default not enable IPv6 on the network.

This causes issues when federating with IPv6-only instances, like the Mastodon instance https://ipv6.camp

Federation to this instance is currently not possible from bookwyrm.social. My instance has this IPv6 setting enabled, making federation possible: https://wyrm.nl/user/alyx@ipv6.camp

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->



## What type of Pull Request is this?
<!-- Check all that apply -->

- [X] Bug Fix
- [ ] Enhancement
- [X] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [X] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [X] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

This PR requires a one time restart of the network (docker-compose down and up --build). I could not test whether this breaks anything on IPv4-only instances, although I expect docker to fall-back to IPv4 in those cases.

## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
