### PR TITLE
Fix reading goal year check to respect user's timezone

### DIFF
--- a/bookwyrm/views/feed.py
+++ b/bookwyrm/views/feed.py
@@ -240,7 +240,9 @@ def feed_page_data(user):
     if not user.is_authenticated:
         return {}
 
-    goal = models.AnnualGoal.objects.filter(user=user, year=timezone.now().year).first()
+    goal = models.AnnualGoal.objects.filter(
+        user=user, year=timezone.localtime().year
+    ).first()
     return {
         "goal": goal,
         "goal_form": forms.GoalForm(),

--- a/bookwyrm/views/goal.py
+++ b/bookwyrm/views/goal.py
@@ -27,8 +27,8 @@ class Goal(View):
         if not goal and user != request.user:
             return HttpResponseNotFound()
 
-        current_year = timezone.now().year
-        if not goal and year != timezone.now().year:
+        current_year = timezone.localtime().year
+        if not goal and year != current_year:
             return redirect("user-goal", username, current_year)
 
         if goal:


### PR DESCRIPTION
## Summary
- Uses `timezone.localtime().year` instead of `timezone.now().year` in feed and goal views
- Ensures the year check respects the user's preferred timezone (already activated by `TimezoneMiddleware`) rather than always using UTC
- Fixes the bug where users west of UTC see the new year's goal prompt before their local midnight

Fixes #1743

## Test plan
- Set user preferred timezone to a western timezone (e.g., America/Los_Angeles, UTC-8)
- At UTC midnight on January 1st (4pm Dec 31 Pacific), verify the feed does NOT show the new year's goal prompt
- Verify users in UTC+ timezones who have already entered the new year DO see the prompt