### PR TITLE
caching: set cache expire to 0 in debug mode

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -112,6 +112,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.cache.UpdateCacheMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -125,6 +126,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "bookwyrm.middleware.FileTooBig",
     "bookwyrm.middleware.ForceLogoutMiddleware",
+    "django.middleware.cache.FetchFromCacheMiddleware",
 ]
 
 ROOT_URLCONF = "bookwyrm.urls"
@@ -146,6 +148,7 @@ TEMPLATES = [
     },
 ]
 
+CACHE_MIDDLEWARE_SECONDS = 0 if DEBUG else env.int("CACHE_MIDDLEWARE_SECONDS", 60)
 LOG_LEVEL = env("LOG_LEVEL", "INFO").upper()
 # Override aspects of the default handler to our taste
 # See https://docs.djangoproject.com/en/3.2/topics/logging/#default-logging-configuration

--- a/nginx/locations
+++ b/nginx/locations
@@ -21,7 +21,7 @@ add_header X-Cache-Status $upstream_cache_status;
 
 # ignore the set cookie header when deciding to
 # store a response in the cache
-proxy_ignore_headers Cache-Control Set-Cookie Expires;
+proxy_ignore_headers Set-Cookie;
 
 # PUT requests always bypass the cache
 # logged in sessions also do not populate the cache


### PR DESCRIPTION

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->

Change the caching flow so that nginx listens caching headers from django and django sets expire times to 60 seconds by default and 0 if it is in debug mode.

This should resolve, at least partially, the caching template issue in debug mode, as nginx was also caching the template output for non-logged in users.


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #3828 
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [ ] Bug Fix
- [X] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them

I tested this locally in dev-flow and outside of it, but it is possible that I have missed some case of caching fully.