### PR TITLE
Prevent users being added when signature validated

### DIFF
--- a/bookwyrm/management/commands/purge_remote_deleted_users.py
+++ b/bookwyrm/management/commands/purge_remote_deleted_users.py
@@ -1,0 +1,96 @@
+"""Remove remove delted users from the database"""
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count, F
+from bookwyrm import models
+
+
+class Command(BaseCommand):
+    """command-line options"""
+
+    help = "Remove users that were only added because they were deleted"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--confirm",
+            action="store_true",
+            help="Delete identified users from database",
+        )
+
+    def handle(self, *args, **options):
+        """Find and report on user accounts that can be purged"""
+
+        targets = models.User.objects.filter(
+            local=False,
+            is_deleted=True,
+            is_active=False,
+            bookwyrm_user=False,
+            status=None,
+            favorites=None,
+        ).filter(date_joined__date=F("last_active_date__date"))
+
+        target_ids = targets.values_list("id", flat=True)
+
+        statuses = models.Status.objects.filter(user__in=target_ids)
+        followers = models.User.objects.filter(local=True, followers__in=target_ids)
+        followed = models.User.objects.filter(local=True, following__in=target_ids)
+        favorites = models.Favorite.objects.filter(user__in=target_ids)
+
+        servers = (
+            models.FederatedServer.objects.filter(user__in=target_ids)
+            .annotate(total_users=Count("user"))
+            .order_by("-total_users")
+        )
+
+        if options["confirm"]:
+            """This time for real"""
+
+            try:
+                self.stdout.write(
+                    f"\nPurging {targets.count()} users from {servers.count()} instances:\n\n"
+                )
+                server_list = [(s.server_name, s.total_users) for s in servers.all()]
+                for name, total in server_list:
+                    self.stdout.write(f"{name}: {total}")
+                self.stdout.write("\nDeleting...")
+
+                # this is a bulk operation so it bypasses the overridden method and actually deletes
+                # see https://docs.djangoproject.com/en/5.2/topics/db/queries/#topics-db-queries-delete
+                targets.delete()
+
+                self.stdout.write("User deletion completed.")
+                self.stdout.write(
+                    "Thankyou for being a BookWyrm administrator, happy reading!\n\n"
+                )
+
+            except Exception as e:
+                self.stdout.write(f"User deletion failed with error:\n\n{e}")
+
+        else:
+            self.stdout.write(
+                f"\nYour database has {targets.count()} candidates for deletion from {servers.count()} instances.\n"
+            )
+            self.stdout.write("Values associated with these users:\n\n")
+            self.stdout.write("------------------------------------------------")
+            self.stdout.write(f"Statuses:         {statuses.count()}")
+            self.stdout.write(f"Favorites:        {favorites.count()}")
+            self.stdout.write(f"Local followers:  {followers.count()}")
+            self.stdout.write(f"Locals following: {followed.count()}")
+            self.stdout.write("------------------------------------------------\n\n")
+            associated_models_count = (
+                statuses.count()
+                + followers.count()
+                + followed.count()
+                + favorites.count()
+            )
+
+            if associated_models_count == 0:
+                self.stdout.write("It is safe to delete these users.")
+                self.stdout.write(
+                    "To do so, run the command again with the --confirm flag\n\n"
+                )
+            else:
+                self.stdout.write("It is NOT SAFE to delete all these users.")
+                self.stdout.write(
+                    "Please log an issue at https://github.com/bookwyrm-social/bookwyrm/issues with this output\n\n"
+                )

--- a/bookwyrm/tests/test_signing.py
+++ b/bookwyrm/tests/test_signing.py
@@ -15,7 +15,7 @@ from django.test import TestCase, Client
 from django.utils.http import http_date
 
 from bookwyrm import models
-from bookwyrm.activitypub import Follow
+from bookwyrm.activitypub import Follow, parse
 from bookwyrm.settings import DOMAIN, NETLOC
 from bookwyrm.signatures import create_key_pair, make_signature, make_digest
 
@@ -130,13 +130,17 @@ class Signature(TestCase):
             status=200,
         )
 
-        with patch("bookwyrm.models.user.get_remote_reviews.delay"):
-            with patch(
-                "bookwyrm.models.relationship.UserFollowRequest.accept"
-            ) as accept_mock:
-                response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(accept_mock.called)
+        with patch(
+            "bookwyrm.views.inbox.activity_task.apply_async",
+            side_effect=parse(get_follow_activity(self.fake_remote, self.rat)).action(),
+        ):
+            with patch("bookwyrm.models.user.get_remote_reviews.delay"):
+                with patch(
+                    "bookwyrm.models.relationship.UserFollowRequest.accept"
+                ) as accept_mock:
+                    response = self.send_test_request(sender=self.fake_remote)
+                self.assertEqual(response.status_code, 200)
+                self.assertTrue(accept_mock.called)
 
     @responses.activate
     def test_key_needs_refresh(self):
@@ -158,13 +162,21 @@ class Signature(TestCase):
         data["publicKey"]["publicKeyPem"] = key_pair.public_key
         responses.add(responses.GET, self.fake_remote.remote_id, json=data, status=200)
 
-        with patch("bookwyrm.models.user.get_remote_reviews.delay"):
+        with (
+            patch("bookwyrm.models.user.get_remote_reviews.delay"),
+            patch(
+                "bookwyrm.views.inbox.activity_task.apply_async",
+                side_effect=parse(
+                    get_follow_activity(self.fake_remote, self.rat)
+                ).action(),
+            ),
+        ):
             # Key correct:
             with patch(
                 "bookwyrm.models.relationship.UserFollowRequest.accept"
             ) as accept_mock:
                 response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 200)  # BUG this is 401
+            self.assertEqual(response.status_code, 200)
             self.assertTrue(accept_mock.called)
 
             # Old key is cached, so still works:

--- a/bookwyrm/views/inbox.py
+++ b/bookwyrm/views/inbox.py
@@ -137,8 +137,8 @@ def has_valid_signature(request, activity):
     try:
         signature = Signature.parse(request)
         remote_user = activitypub.resolve_remote_id(
-            activity.get("actor"), model=models.User
-        )
+            activity.get("actor"), model=models.User, save=False
+        )  # don't save the actor unless we actually need to import them
         if not remote_user:
             return False
 


### PR DESCRIPTION
## Description

The inbox method `has_valid_signature` currently uses the default kwarg values. This includes 'save', which defaults to `True`. The consequence is that _every actor who ever sends anything to a BookWyrm inbox is saved to the database_.

This was most apparent for 'Delete' activities, which are sent by Mastodon to every instance it knows about, just in case. BookWyrm instances have therefore been filling up with deleted mastodon users who otherwise were unknown.

This commit:

* sets `save` to `False` in `has_valid_signature`
* provides a management command, `purge_remote_deleted_users` to:
    * report on candidates for purging (remote, deleted, not bookwyrm users, no statuses, no favorites)
    * with a `--confirm` flag, bulk-delete such users from the database
* adjusts a couple of tests that no longer passed because they now rely on a side effect from an async celery task

The command also reports how many users and from which instances they were deleted.


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #3762

## What type of Pull Request is this?
<!-- Check all that apply -->

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [x] New or amended documentation will be required if this PR is merged
- [x] New functionality should be noted in release notes
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
