### PR TITLE
Security: Ineffective File Size Middleware

### DIFF
--- a/bookwyrm/middleware/file_too_big.py
+++ b/bookwyrm/middleware/file_too_big.py
@@ -18,12 +18,10 @@ class FileTooBig:
         """If RequestDataTooBig is thrown, render the 413 error page"""
 
         try:
-            body = request.body
+            response = self.get_response(request)
 
         except RequestDataTooBig:
             rendered = render(request, "413.html")
             response = HttpResponse(rendered)
-            return response
 
-        response = self.get_response(request)
         return response


### PR DESCRIPTION
## Summary

Security: Ineffective File Size Middleware

## Problem

**Severity**: `Medium` | **File**: `bookwyrm/middleware/file_too_big.py:L21`

The FileTooBig middleware in bookwyrm/middleware/file_too_big.py attempts to read request.body to trigger RequestDataTooBig exception. However, reading the body actually loads it into memory, defeating the purpose of preventing large uploads and potentially causing DoS by loading large files into memory.

## Solution

Remove the body reading attempt. Django's upload handlers should handle size limits automatically. Instead, catch RequestDataTooBig exception that may be raised during request processing, or configure DATA_UPLOAD_MAX_MEMORY_SIZE and FILE_UPLOAD_MAX_MEMORY_SIZE in settings.

## Changes

- `bookwyrm/middleware/file_too_big.py` (modified)