### PR TITLE
fix(i18n): add missing translation block for group members heading

### DIFF
--- a/bookwyrm/templates/groups/members.html
+++ b/bookwyrm/templates/groups/members.html
@@ -3,7 +3,7 @@
 {% load humanize %}
 {% load group_tags %}
 
-<h2 class="title is-5">Group Members</h2>
+<h2 class="title is-5">{% trans "Group Members" %}</h2>
 {% if group.user == request.user %}
 <div class="block">
     <form class="field has-addons" method="get" action="{% url 'group-find-users' group.id %}">


### PR DESCRIPTION
## Summary

Fixes #3870 — The "Group Members" heading in the group members template is missing a translation block.

## Root Cause

`bookwyrm/templates/groups/members.html:6` has a hardcoded English string `<h2 class="title is-5">Group Members</h2>` without `{% trans %}` wrapping.

## Fix

Wrap the string in Django's `{% trans %}` template tag to make it translatable.

## Changes

- `bookwyrm/templates/groups/members.html` (+1 -1): Added `{% trans %}` around "Group Members"

## Testing

- [x] Template loads without error ✅
- [x] String appears in `{% trans %}` block ✅
- [x] `makemessages` will now discover this string ✅