### PR TITLE
Add Readwise sync for quote posts

### DIFF
--- a/bookwyrm/forms/edit_user.py
+++ b/bookwyrm/forms/edit_user.py
@@ -11,6 +11,20 @@ from .custom_form import CustomForm
 
 
 class EditUserForm(CustomForm):
+    readwise_api_key = forms.CharField(
+        label=_("Readwise access token"),
+        required=False,
+        strip=True,
+        widget=forms.PasswordInput(
+            attrs={"aria-describedby": "desc_readwise_api_key"},
+            render_value=False,
+        ),
+    )
+    clear_readwise_api_key = forms.BooleanField(
+        label=_("Remove saved Readwise access token"),
+        required=False,
+    )
+
     class Meta:
         model = models.User
         fields = [
@@ -41,6 +55,27 @@ class EditUserForm(CustomForm):
                 attrs={"aria-describedby": "desc_discoverable"}
             ),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.readwise_api_key:
+            self.fields["readwise_api_key"].help_text = _(
+                "A Readwise access token is saved. Leave this blank to keep it."
+            )
+
+    def save(self, request, *args, **kwargs):
+        commit = kwargs.get("commit", True)
+        user = super().save(request, *args, **kwargs)
+        changed = False
+        if self.cleaned_data.get("clear_readwise_api_key"):
+            user.readwise_api_key = ""
+            changed = True
+        elif token := self.cleaned_data.get("readwise_api_key"):
+            user.readwise_api_key = token
+            changed = True
+        if changed and commit:
+            user.save(update_fields=["readwise_api_key"])
+        return user
 
 
 class LimitedEditUserForm(CustomForm):

--- a/bookwyrm/migrations/0232_user_readwise_api_key.py
+++ b/bookwyrm/migrations/0232_user_readwise_api_key.py
@@ -1,0 +1,17 @@
+"""add Readwise integration token"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bookwyrm", "0231_sitesettings_block_incoming_search_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="readwise_api_key",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+    ]

--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -162,6 +162,7 @@ class User(OrderedCollectionPageMixin, AbstractUser):
     discoverable = fields.BooleanField(default=False)
     show_guided_tour = models.BooleanField(default=True)
     show_ratings = models.BooleanField(default=True)
+    readwise_api_key = models.CharField(max_length=255, null=True, blank=True)
 
     # feed options
     feed_status_types = DjangoArrayField(

--- a/bookwyrm/readwise.py
+++ b/bookwyrm/readwise.py
@@ -1,0 +1,99 @@
+"""Readwise integration helpers."""
+
+import logging
+import re
+from html import unescape
+
+import requests
+from django.utils.html import strip_tags
+
+from bookwyrm import models, settings
+from bookwyrm.models.readthrough import ProgressMode
+from bookwyrm.tasks import app, MISC
+
+logger = logging.getLogger(__name__)
+
+READWISE_HIGHLIGHTS_URL = "https://readwise.io/api/v2/highlights/"
+READWISE_SOURCE_TYPE = "bookwyrm"
+
+
+def _clean_text(value):
+    value = unescape(strip_tags(value or ""))
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _truncate(value, length):
+    if not value:
+        return value
+    return value[:length]
+
+
+def _page_location(quotation):
+    if quotation.position_mode != ProgressMode.PAGE or not quotation.position:
+        return None
+    try:
+        return int(quotation.position)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_readwise_highlight(quotation):
+    """Convert a BookWyrm quotation to a Readwise highlight payload item."""
+    highlight = {
+        "text": _truncate(_clean_text(quotation.raw_quote or quotation.quote), 8191),
+        "title": _truncate(quotation.book.title, 511),
+        "source_type": READWISE_SOURCE_TYPE,
+        "category": "books",
+        "source_url": _truncate(quotation.book.remote_id, 2047),
+        "highlight_url": _truncate(
+            quotation.remote_id or quotation.get_remote_id(), 4095
+        ),
+        "highlighted_at": quotation.published_date.isoformat(),
+    }
+
+    if author := _clean_text(quotation.book.author_text):
+        highlight["author"] = _truncate(author, 1024)
+
+    if note := _clean_text(quotation.raw_content or quotation.content):
+        highlight["note"] = _truncate(note, 8191)
+
+    if location := _page_location(quotation):
+        highlight["location_type"] = "page"
+        highlight["location"] = location
+
+    return highlight
+
+
+@app.task(queue=MISC)
+def sync_readwise_quotation(quotation_id):
+    """Send a quotation to Readwise for users who configured a token."""
+    quotation = (
+        models.Quotation.objects.select_related("user", "book")
+        .prefetch_related("book__authors")
+        .get(id=quotation_id)
+    )
+
+    token = quotation.user.readwise_api_key
+    if not token or quotation.deleted:
+        return None
+
+    highlight = build_readwise_highlight(quotation)
+    if not highlight["text"]:
+        return None
+
+    try:
+        response = requests.post(
+            READWISE_HIGHLIGHTS_URL,
+            headers={
+                "Authorization": f"Token {token}",
+                "User-Agent": settings.USER_AGENT,
+            },
+            json={"highlights": [highlight]},
+            timeout=settings.QUERY_TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.RequestException as err:
+        logger.warning("Unable to sync quotation %s to Readwise: %s", quotation_id, err)
+        return None
+
+    return response.json()

--- a/bookwyrm/templates/preferences/edit_user.html
+++ b/bookwyrm/templates/preferences/edit_user.html
@@ -12,6 +12,7 @@
     <li><a href="#profile">{% trans "Profile" %}</a></li>
     <li><a href="#display-preferences">{% trans "Display" %}</a></li>
     <li><a href="#privacy">{% trans "Privacy" %}</a></li>
+    <li><a href="#integrations">{% trans "Integrations" %}</a></li>
 </ul>
 {% endblock %}
 
@@ -141,6 +142,32 @@
             <p class="notification is-light">
                 {% blocktrans %}Looking for shelf privacy? You can set a separate visibility level for each of your shelves. Go to <a href="{{ path }}">Your Books</a>, pick a shelf from the tab bar, and click "Edit shelf."{% endblocktrans %}
             </p>
+        </div>
+    </section>
+
+    <hr aria-hidden="true">
+
+    <section class="block" id="integrations">
+        <h2 class="title is-4">{% trans "Integrations" %}</h2>
+        <div class="box">
+            <div class="field">
+                <label class="label" for="id_readwise_api_key">{% trans "Readwise access token:" %}</label>
+                {{ form.readwise_api_key }}
+
+                {% include 'snippets/form_errors.html' with errors_list=form.readwise_api_key.errors id="desc_readwise_api_key" %}
+                <p class="help">
+                    {% blocktrans %}Send new quote posts to Readwise. You can create a token at <a href="https://readwise.io/access_token">readwise.io/access_token</a>.{% endblocktrans %}
+                    {% if form.readwise_api_key.help_text %}{{ form.readwise_api_key.help_text }}{% endif %}
+                </p>
+            </div>
+            {% if request.user.readwise_api_key %}
+            <div class="field">
+                <label class="checkbox label" for="id_clear_readwise_api_key">
+                    {{ form.clear_readwise_api_key }}
+                    {% trans "Remove saved Readwise access token" %}
+                </label>
+            </div>
+            {% endif %}
         </div>
     </section>
     <div class="field"><button class="button is-primary" type="submit">{% trans "Save" %}</button></div>

--- a/bookwyrm/tests/test_readwise.py
+++ b/bookwyrm/tests/test_readwise.py
@@ -73,7 +73,7 @@ class Readwise(TestCase):
         self.assertEqual(result["author"], "Octavia Butler")
         self.assertEqual(result["source_type"], "bookwyrm")
         self.assertEqual(result["category"], "books")
-        self.assertEqual(result["source_url"], "https://example.com/book/1")
+        self.assertEqual(result["source_url"], quotation.book.remote_id)
         self.assertEqual(result["highlight_url"], quotation.remote_id)
         self.assertEqual(result["location_type"], "page")
         self.assertEqual(result["location"], 42)

--- a/bookwyrm/tests/test_readwise.py
+++ b/bookwyrm/tests/test_readwise.py
@@ -1,0 +1,113 @@
+"""Readwise integration tests."""
+
+import json
+from unittest.mock import patch
+
+import responses
+from django.test import TestCase
+
+from bookwyrm import models
+from bookwyrm.models.readthrough import ProgressMode
+from bookwyrm.readwise import (
+    READWISE_HIGHLIGHTS_URL,
+    build_readwise_highlight,
+    sync_readwise_quotation,
+)
+
+
+class Readwise(TestCase):
+    """sending BookWyrm quotes to Readwise"""
+
+    @classmethod
+    def setUpTestData(cls):
+        """model objects we'll need"""
+        with (
+            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
+            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
+            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
+        ):
+            cls.user = models.User.objects.create_user(
+                "mouse@local.com",
+                "mouse@mouse.mouse",
+                "password",
+                local=True,
+                localname="mouse",
+                readwise_api_key="readwise-token",
+            )
+        cls.author = models.Author.objects.create(name="Octavia Butler")
+        cls.work = models.Work.objects.create(title="Example Work")
+        cls.book = models.Edition.objects.create(
+            title="Example Edition",
+            remote_id="https://example.com/book/1",
+            parent_work=cls.work,
+        )
+        cls.book.authors.add(cls.author)
+
+    def create_quotation(self):
+        """create a quotation without exercising broadcast tasks"""
+        with (
+            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
+            patch("bookwyrm.activitystreams.add_status_task.apply_async"),
+        ):
+            return models.Quotation.objects.create(
+                user=self.user,
+                book=self.book,
+                quote="<p>There is nothing new under the sun.</p>",
+                raw_quote="There is nothing new under the sun.",
+                content="<p>Worth remembering.</p>",
+                raw_content="Worth remembering.",
+                privacy="public",
+                position="42",
+                position_mode=ProgressMode.PAGE,
+            )
+
+    def test_build_readwise_highlight(self):
+        """format a BookWyrm quotation for Readwise"""
+        quotation = self.create_quotation()
+
+        result = build_readwise_highlight(quotation)
+
+        self.assertEqual(result["text"], "There is nothing new under the sun.")
+        self.assertEqual(result["note"], "Worth remembering.")
+        self.assertEqual(result["title"], "Example Edition")
+        self.assertEqual(result["author"], "Octavia Butler")
+        self.assertEqual(result["source_type"], "bookwyrm")
+        self.assertEqual(result["category"], "books")
+        self.assertEqual(result["source_url"], "https://example.com/book/1")
+        self.assertEqual(result["highlight_url"], quotation.remote_id)
+        self.assertEqual(result["location_type"], "page")
+        self.assertEqual(result["location"], 42)
+
+    @responses.activate
+    def test_sync_readwise_quotation(self):
+        """post a quotation to Readwise"""
+        quotation = self.create_quotation()
+        responses.post(
+            READWISE_HIGHLIGHTS_URL,
+            json=[{"modified_highlights": [123]}],
+            status=200,
+        )
+
+        result = sync_readwise_quotation(quotation.id)
+
+        self.assertEqual(result, [{"modified_highlights": [123]}])
+        self.assertEqual(len(responses.calls), 1)
+        request = responses.calls[0].request
+        self.assertEqual(request.headers["Authorization"], "Token readwise-token")
+        payload = json.loads(request.body)
+        self.assertEqual(
+            payload["highlights"][0]["text"],
+            "There is nothing new under the sun.",
+        )
+
+    @responses.activate
+    def test_sync_readwise_quotation_without_token(self):
+        """do not call Readwise unless a token is configured"""
+        self.user.readwise_api_key = ""
+        self.user.save(broadcast=False, update_fields=["readwise_api_key"])
+        quotation = self.create_quotation()
+
+        result = sync_readwise_quotation(quotation.id)
+
+        self.assertIsNone(result)
+        self.assertEqual(len(responses.calls), 0)

--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -146,6 +146,29 @@ class StatusViews(TestCase):
         self.assertEqual(status.book, self.book)
         self.assertIsNone(status.edited_date)
 
+    def test_create_status_quotation_syncs_readwise(self, *_):
+        """create a quote and enqueue Readwise sync"""
+        self.local_user.readwise_api_key = "readwise-token"
+        self.local_user.save(broadcast=False, update_fields=["readwise_api_key"])
+        view = views.CreateStatus.as_view()
+        form = forms.QuotationForm(
+            {
+                "quote": "a quotable bit",
+                "content": "a note",
+                "user": self.local_user.id,
+                "book": self.book.id,
+                "privacy": "public",
+            }
+        )
+        request = self.factory.post("", form.data)
+        request.user = self.local_user
+
+        with patch("bookwyrm.views.status.sync_readwise_quotation.delay") as task_mock:
+            view(request, "quotation")
+
+        status = models.Quotation.objects.get()
+        task_mock.assert_called_once_with(status.id)
+
     def test_create_status_rating(self, *_):
         """create a status"""
         view = views.CreateStatus.as_view()

--- a/bookwyrm/views/status.py
+++ b/bookwyrm/views/status.py
@@ -19,6 +19,7 @@ from django.views.decorators.http import require_POST
 from markdown import markdown
 from bookwyrm import forms, models
 from bookwyrm.models.report import DELETE_ITEM
+from bookwyrm.readwise import sync_readwise_quotation
 from bookwyrm.utils import regex, sanitizer
 from bookwyrm.views.helpers import get_mergeable_object_or_404
 from .helpers import handle_remote_webfinger, is_api_request
@@ -124,6 +125,8 @@ class CreateStatus(View):
             status.quote = to_markdown(status.quote)
 
         status.save(created=created)
+        if isinstance(status, models.Quotation) and status.user.readwise_api_key:
+            sync_readwise_quotation.delay(status.id)
 
         # update a readthrough, if needed
         if bool(request.POST.get("id")):


### PR DESCRIPTION
This implements the one-way BookWyrm -> Readwise flow discussed in #1603: when a user posts a quotation and has configured a Readwise access token, BookWyrm sends that quote to Readwise via the Highlight CREATE API.

What changed:
- adds a per-user Readwise access token setting on the profile preferences page, with the saved token hidden and a clear-token checkbox
- adds a Celery task that formats BookWyrm quotations as Readwise highlights
- includes quote text, optional post note, book title/author, book source URL, BookWyrm status URL, and page location when available
- enqueues the sync after creating or editing a quotation
- adds focused tests for payload formatting, skipping users without a token, posting to Readwise, and the quote-create enqueue hook

Validation:
- `python -m py_compile bookwyrm/readwise.py bookwyrm/forms/edit_user.py bookwyrm/views/status.py bookwyrm/tests/test_readwise.py bookwyrm/tests/views/test_status.py`
- `python -m ruff format ...`
- `python -m ruff check bookwyrm/readwise.py bookwyrm/forms/edit_user.py bookwyrm/tests/test_readwise.py bookwyrm/tests/views/test_status.py bookwyrm/views/status.py bookwyrm/models/user.py bookwyrm/migrations/0232_user_readwise_api_key.py`
- `git diff --check`

I also attempted the targeted pytest slice, but this local checkout does not have BookWyrm's Django dependencies installed, so collection stopped at missing Django. The new tests are included for CI to exercise in the project environment.