### PR TITLE
Simplifies PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,14 @@
-<!--
-Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
-
-To check (tick) a list item, replace the space between square brackets with an x, like this:
-
-- [x] I have checked the box
-
-You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
--->
 ## Description
-<!--
-Describe what your pull request does here
--->
 
-
-<!--
-For pull requests that relate or close an issue, please include them
-below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-
-For example having the text: "closes #1234" would connect the current pull
-request to issue 1234.  And when we merge the pull request, Github will
-automatically close the issue.
--->
 
 - Related Issue #
 - Closes #
 
+<!--
+Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
+You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
+-->
 ## What type of Pull Request is this?
-<!-- Check all that apply -->
 
 - [ ] Bug Fix
 - [ ] Enhancement
@@ -34,7 +16,6 @@ automatically close the issue.
 - [ ] Refactor
 
 ## Does this PR change settings or dependencies, or break something?
-<!-- Check all that apply -->
 
 - [ ] This PR changes or adds default settings, configuration, or .env values
 - [ ] This PR changes or adds dependencies
@@ -45,11 +26,8 @@ automatically close the issue.
 
 ## Documentation
 <!--
-Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
 Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
 -->
-
-<!-- Check all that apply -->
 
 - [ ] New or amended documentation will be required if this PR is merged
 - [ ] I have created a matching pull request in the Documentation repository
@@ -60,7 +38,6 @@ You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters
 -->
 
 ### Tests
-<!-- Check one -->
 
 - [ ] My changes do not need new tests
 - [ ] All tests I have added are passing


### PR DESCRIPTION
## Description
I think we've erred on the side of being too wordy and detailed in the template. When I open a PR, the comments take up enough space at the top that the place where I would enter my description is not shown, which makes it hard to find. I've removed some lines that I think are self-explanatory (like the comment about what the description section is for), moved the welcome-type message down lower so that it's still present but not the first thing you hit every time you open a PR, and shortened some of the other messaging.

Here's how it looks on my screen currently:
<img width="884" height="474" alt="Screenshot 2026-06-16 at 10 02 18 AM" src="https://github.com/user-attachments/assets/59bc4c10-39d9-4f37-93d0-35d2357902ee" />

Versus a
<img width="875" height="488" alt="Screenshot 2026-06-16 at 10 08 49 AM" src="https://github.com/user-attachments/assets/a17fa0bc-2965-4bc8-b74a-458e5f70b592" />
fter this change:


- Related Issue #
- Closes #

## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
