### PR TITLE
Fixes "show more" button showing up incorrectly

### DIFF
--- a/bookwyrm/templates/snippets/trimmed_text.html
+++ b/bookwyrm/templates/snippets/trimmed_text.html
@@ -4,52 +4,54 @@
 
 {% with 0|uuid as uuid %}
 {% firstof trim_length 150 as trim_length %}
-    {% if full %}
-        {% with full|to_markdown|safe as full %}
-            {% with full|to_markdown|safe|truncatewords_html:trim_length as trimmed %}
-                {% if not no_trim and trimmed != full %}
-                    <div id="hide_full_{{ uuid }}">
-                        <div class="content" id="trimmed_{{ uuid }}">
-                            <div dir="auto" class="preserve-whitespace">{{ trimmed }}</div>
+{% if full %}
 
-                            <div>
-                            {% if not hide_more %}
-                                {% trans "Show more" as button_text %}
-                                {% include 'snippets/toggle/open_button.html' with text=button_text controls_text="full" controls_uid=uuid class="is-small" %}
-                            {% endif %}
-                            </div>
-                        </div>
-                    </div>
+{% with full|to_markdown|safe as full_formatted %}
+    {% with full_formatted|truncatewords_html:trim_length as trimmed %}
+        {% if not no_trim and trimmed|length < full_formatted|length %}
+            <div id="hide_full_{{ uuid }}">
+                <div class="content" id="trimmed_{{ uuid }}">
+                    <div dir="auto" class="preserve-whitespace">{{ trimmed }}</div>
+
+                    <div>
                     {% if not hide_more %}
-                    <div id="full_{{ uuid }}" class="is-hidden">
-                        <div class="content">
-                            <div
-                                dir="auto"
-                                class="preserve-whitespace"
-                                {% if itemprop %}itemprop="{{ itemprop }}"{% endif %}
-                            >
-                                {{ full }}
-                            </div>
-
-                            <div>
-                                {% trans "Show less" as button_text %}
-                                {% include 'snippets/toggle/close_button.html' with text=button_text controls_text="full" controls_uid=uuid class="is-small" %}
-                            </div>
-                        </div>
-                    </div>
+                        {% trans "Show more" as button_text %}
+                        {% include 'snippets/toggle/open_button.html' with text=button_text controls_text="full" controls_uid=uuid class="is-small" %}
                     {% endif %}
-                {% else %}
-                    <div class="content">
-                        <div
-                            dir="auto"
-                            class="preserve-whitespace"
-                            {% if itemprop %}itemprop="{{ itemprop }}"{% endif %}
-                        >
-                            {{ full }}
-                        </div>
                     </div>
-                {% endif %}
-            {% endwith %}
-        {% endwith %}
-    {% endif %}
+                </div>
+            </div>
+            {% if not hide_more %}
+            <div id="full_{{ uuid }}" class="is-hidden">
+                <div class="content">
+                    <div
+                        dir="auto"
+                        class="preserve-whitespace"
+                        {% if itemprop %}itemprop="{{ itemprop }}"{% endif %}
+                    >
+                        {{ full_formatted }}
+                    </div>
+
+                    <div>
+                        {% trans "Show less" as button_text %}
+                        {% include 'snippets/toggle/close_button.html' with text=button_text controls_text="full" controls_uid=uuid class="is-small" %}
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+        {% else %}
+            <div class="content">
+                <div
+                    dir="auto"
+                    class="preserve-whitespace"
+                    {% if itemprop %}itemprop="{{ itemprop }}"{% endif %}
+                >
+                    {{ full_formatted }}
+                </div>
+            </div>
+        {% endif %}
+    {% endwith %}
+{% endwith %}
+
+{% endif %}
 {% endwith %}


### PR DESCRIPTION

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.

To check (tick) a list item, replace the space between square brackets with an x, like this:

- [x] I have checked the box

You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## Description
<!--
Describe what your pull request does here
-->
The button was appearing on statuses that were very short. This seems to fix it. I reduced the baseline white space and renamed an overloaded variable in the process of trying to figure this out

Before:
<img width="783" height="222" alt="Screenshot 2026-06-16 at 12 00 03 PM" src="https://github.com/user-attachments/assets/d538ee69-b84d-48aa-bbcb-95987d40d250" />

After:
<img width="795" height="196" alt="Screenshot 2026-06-16 at 11 59 35 AM" src="https://github.com/user-attachments/assets/e3abcb6d-7ee9-41ca-a212-ed7f740d81e4" />


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## What type of Pull Request is this?
<!-- Check all that apply -->

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?
<!-- Check all that apply -->

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Documentation for users, admins, and developers is an important way to keep the BookWyrm community welcoming and make Bookwyrm easy to use.
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

<!-- Check all that apply -->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests
<!-- Check one -->

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
