### PR TITLE
Handle own-profile visibility in is_profile_visible_to

### DIFF
--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -532,6 +532,8 @@ class User(OrderedCollectionPageMixin, AbstractUser):
             return True
         if viewer_id is None:
             return False
+        if self.id == viewer_id:
+            return True
         return self.followers.filter(id=viewer_id).exists()
 
 

--- a/bookwyrm/tests/models/test_user_model.py
+++ b/bookwyrm/tests/models/test_user_model.py
@@ -70,6 +70,10 @@ class User(TestCase):
         self.assertTrue(self.user.is_profile_visible_to(None))
         self.assertTrue(self.user.is_profile_visible_to(self.another_user.id))
 
+    def test_is_visible_to_yourself(self):
+        self.user.is_profile_private = True
+        self.assertTrue(self.user.is_profile_visible_to(self.user.id))
+
     def test_is_visible_to_private(self):
         self.user.is_profile_private = True
         self.assertFalse(self.user.is_profile_visible_to(None))

--- a/bookwyrm/views/mixins.py
+++ b/bookwyrm/views/mixins.py
@@ -17,8 +17,7 @@ class PrivateProfileMixin:
             # The API reveals no private activities.
             return super().dispatch(request, *args, **kwargs)
 
-        is_self = request.user.is_authenticated and profile_user.id == request.user.id
-        if is_self or profile_user.is_profile_visible_to(request.user.id):
+        if profile_user.is_profile_visible_to(request.user.id):
             return super().dispatch(request, *args, **kwargs)
 
         return TemplateResponse(


### PR DESCRIPTION
## Description

Small follow-up refactor for #3965.
Moves the own-profile visibility check into `User.is_profile_visible_to`, so private profile visibility logic is centralized in the model.

## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [x] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
