### PR TITLE
Don't include your own posts in the books stream

### DIFF
--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -314,22 +314,22 @@ class HomeStream(ActivityStream):
 
 
 class LocalStream(ActivityStream):
-    """users you follow"""
+    """Posts from local users"""
 
     key = "local"
 
-    def get_audience(self, status):
+    def get_audience(self, status, exclude_self=True):
         # this stream wants no part in non-public statuses
         if status.privacy != "public" or not status.user.local:
             return []
-        return super().get_audience(status)
+        return super().get_audience(status, exclude_self=exclude_self)
 
     def get_statuses_for_user(self, user):
         # all public statuses by a local user
         return models.Status.privacy_filter(
             user,
             privacy_levels=["public"],
-        ).filter(user__local=True)
+        ).filter(user__local=True).exclude(user=user.id)
 
 
 class BooksStream(ActivityStream):

--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -198,7 +198,7 @@ class ActivityStream(RedisStore):
         statuses = models.Status.privacy_filter(
             user,
             privacy_levels=["public"],
-        )
+        ).exclude(user=user.id)
 
         book_comments = statuses.filter(Q(comment__book__parent_work=work))
         book_quotations = statuses.filter(Q(quotation__book__parent_work=work))
@@ -331,14 +331,14 @@ class BooksStream(ActivityStream):
     key = "books"
 
     def _get_audience(self, status):
-        """anyone with the mentioned book on their shelves"""
+        """anyone with the mentioned book on their shelves except the poster"""
         work = (
             status.book.parent_work
             if hasattr(status, "book")
             else status.mention_books.first().parent_work
         )
 
-        audience = super()._get_audience(status)
+        audience = super()._get_audience(status).exclude(id=status.user.id)
         return audience.filter(shelfbook__book__parent_work=work)
 
     def get_audience(self, status):
@@ -367,6 +367,7 @@ class BooksStream(ActivityStream):
                 | Q(review__book__parent_work__id__in=books)
                 | Q(mention_books__parent_work__id__in=books)
             )
+            .exclude(user=user.id)  # ignore your own statuses
             .distinct()
         )
 

--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -107,7 +107,7 @@ class ActivityStream(RedisStore):
         self.populate_store(self.stream_id(user.id))
 
     @tracer.start_as_current_span("ActivityStream._get_audience")
-    def _get_audience(self, status):
+    def _get_audience(self, status, exclude_self=False):
         """given a status, what users should see it, excluding the author"""
         trace.get_current_span().set_attribute("status_type", status.status_type)
         trace.get_current_span().set_attribute("status_privacy", status.privacy)
@@ -126,6 +126,9 @@ class ActivityStream(RedisStore):
         ).exclude(
             Q(id__in=status.user.blocks.all()) | Q(blocks=status.user)  # not blocked
         )
+
+        if exclude_self:
+            audience = audience.exclude(id=status.user.id)
 
         if hasattr(status, "book") and status.book and status.book.parent_work:
             # exclude anyone who has blocked the book in a status
@@ -167,13 +170,17 @@ class ActivityStream(RedisStore):
         return audience.distinct("id")
 
     @tracer.start_as_current_span("ActivityStream.get_audience")
-    def get_audience(self, status):
+    def get_audience(self, status, exclude_self=False):
         """given a status, what users should see it"""
         trace.get_current_span().set_attribute("stream_id", self.key)
-        audience = self._get_audience(status).values_list("id", flat=True)
+        audience = self._get_audience(status, exclude_self=exclude_self).values_list(
+            "id", flat=True
+        )
         status_author = models.User.objects.filter(
             local=True, is_active=True, id=status.user.id
         ).values_list("id", flat=True)
+        if exclude_self:
+            return list(set(audience))
         return list(set(audience) | set(status_author))
 
     def get_stores_for_users(self, user_ids):
@@ -330,7 +337,7 @@ class BooksStream(ActivityStream):
 
     key = "books"
 
-    def _get_audience(self, status):
+    def _get_audience(self, status, exclude_self=True):
         """anyone with the mentioned book on their shelves except the poster"""
         work = (
             status.book.parent_work
@@ -338,10 +345,10 @@ class BooksStream(ActivityStream):
             else status.mention_books.first().parent_work
         )
 
-        audience = super()._get_audience(status).exclude(id=status.user.id)
+        audience = super()._get_audience(status, exclude_self=exclude_self)
         return audience.filter(shelfbook__book__parent_work=work)
 
-    def get_audience(self, status):
+    def get_audience(self, status, exclude_self=True):
         # only show public statuses on the books feed,
         # and only statuses that mention books
         if status.privacy != "public" or not (
@@ -349,7 +356,7 @@ class BooksStream(ActivityStream):
         ):
             return []
 
-        return super().get_audience(status)
+        return super().get_audience(status, exclude_self=exclude_self)
 
     def get_statuses_for_user(self, user):
         """any public status that mentions the user's books"""

--- a/bookwyrm/activitystreams.py
+++ b/bookwyrm/activitystreams.py
@@ -326,10 +326,14 @@ class LocalStream(ActivityStream):
 
     def get_statuses_for_user(self, user):
         # all public statuses by a local user
-        return models.Status.privacy_filter(
-            user,
-            privacy_levels=["public"],
-        ).filter(user__local=True).exclude(user=user.id)
+        return (
+            models.Status.privacy_filter(
+                user,
+                privacy_levels=["public"],
+            )
+            .filter(user__local=True)
+            .exclude(user=user.id)
+        )
 
 
 class BooksStream(ActivityStream):

--- a/bookwyrm/tests/activitystreams/test_localstream.py
+++ b/bookwyrm/tests/activitystreams/test_localstream.py
@@ -1,50 +1,38 @@
 """testing activitystreams"""
 
-from unittest.mock import patch
 from django.test import TestCase
 from bookwyrm import activitystreams, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="test work")
         cls.book = models.Edition.objects.create(title="test book", parent_work=work)
 
-    def test_localstream_get_audience_remote_status(self, *_):
+    def test_localstream_get_audience_remote_status(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.remote_user, content="hi", privacy="public"
@@ -52,7 +40,7 @@ class Activitystreams(TestCase):
         users = activitystreams.LocalStream().get_audience(status)
         self.assertEqual(users, [])
 
-    def test_localstream_get_audience_local_status(self, *_):
+    def test_localstream_get_audience_local_status(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="public"
@@ -61,7 +49,7 @@ class Activitystreams(TestCase):
         self.assertTrue(self.local_user.id in users)
         self.assertTrue(self.another_user.id in users)
 
-    def test_localstream_get_audience_unlisted(self, *_):
+    def test_localstream_get_audience_unlisted(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="unlisted"
@@ -69,16 +57,21 @@ class Activitystreams(TestCase):
         users = activitystreams.LocalStream().get_audience(status)
         self.assertEqual(users, [])
 
-    def test_localstream_get_audience_books_no_book(self, *_):
+    def test_bookstream_get_audience_books_no_book(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="public"
+        )
+        models.ShelfBook.objects.create(
+            user=self.local_user,
+            shelf=self.local_user.shelf_set.first(),
+            book=self.book,
         )
         audience = activitystreams.BooksStream().get_audience(status)
         # no books, no audience
         self.assertEqual(audience, [])
 
-    def test_localstream_get_audience_books_mention_books(self, *_):
+    def test_bookstream_get_audience_books_mention_books(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="public"
@@ -86,29 +79,29 @@ class Activitystreams(TestCase):
         status.mention_books.add(self.book)
         status.save(broadcast=False)
         models.ShelfBook.objects.create(
-            user=self.local_user,
-            shelf=self.local_user.shelf_set.first(),
+            user=self.another_user,
+            shelf=self.another_user.shelf_set.first(),
             book=self.book,
         )
         # yes book, yes audience
         audience = activitystreams.BooksStream().get_audience(status)
-        self.assertTrue(self.local_user.id in audience)
+        self.assertTrue(self.another_user.id in audience)
 
-    def test_localstream_get_audience_books_book_field(self, *_):
+    def test_bookstream_get_audience_books_book_field(self):
         """get a list of users that should see a status"""
         status = models.Comment.objects.create(
             user=self.local_user, content="hi", privacy="public", book=self.book
         )
         models.ShelfBook.objects.create(
-            user=self.local_user,
-            shelf=self.local_user.shelf_set.first(),
+            user=self.another_user,
+            shelf=self.another_user.shelf_set.first(),
             book=self.book,
         )
-        # yes book, yes audience
+        # yes book, no audience
         audience = activitystreams.BooksStream().get_audience(status)
-        self.assertTrue(self.local_user.id in audience)
+        self.assertTrue(self.another_user.id in audience)
 
-    def test_localstream_get_audience_books_alternate_edition(self, *_):
+    def test_bookstream_get_audience_books_alternate_edition(self):
         """get a list of users that should see a status"""
         alt_book = models.Edition.objects.create(
             title="hi", parent_work=self.book.parent_work
@@ -117,15 +110,15 @@ class Activitystreams(TestCase):
             user=self.remote_user, content="hi", privacy="public", book=alt_book
         )
         models.ShelfBook.objects.create(
-            user=self.local_user,
-            shelf=self.local_user.shelf_set.first(),
+            user=self.another_user,
+            shelf=self.another_user.shelf_set.first(),
             book=self.book,
         )
         # yes book, yes audience
         audience = activitystreams.BooksStream().get_audience(status)
-        self.assertTrue(self.local_user.id in audience)
+        self.assertTrue(self.another_user.id in audience)
 
-    def test_localstream_get_audience_books_non_public(self, *_):
+    def test_bookstream_get_audience_books_non_public(self):
         """get a list of users that should see a status"""
         alt_book = models.Edition.objects.create(
             title="hi", parent_work=self.book.parent_work

--- a/bookwyrm/tests/activitystreams/test_localstream.py
+++ b/bookwyrm/tests/activitystreams/test_localstream.py
@@ -46,7 +46,7 @@ class Activitystreams(TestCase):
             user=self.local_user, content="hi", privacy="public"
         )
         users = activitystreams.LocalStream().get_audience(status)
-        self.assertTrue(self.local_user.id in users)
+        self.assertFalse(self.local_user.id in users)
         self.assertTrue(self.another_user.id in users)
 
     def test_localstream_get_audience_unlisted(self):


### PR DESCRIPTION
## Description
This PR makes it so that your own posts don't appear in the books stream. I think it makes the stream less useful for discovery.

- Related Issue #
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
