### PR TITLE
Multilang preview images

### DIFF
--- a/bookwyrm/preview_images.py
+++ b/bookwyrm/preview_images.py
@@ -7,6 +7,8 @@ from io import BytesIO
 from uuid import uuid4
 import logging
 
+import arabic_reshaper
+from bidi.algorithm import get_display
 import colorsys
 from colorthief import ColorThief
 from PIL import Image, ImageDraw, ImageFont, ImageOps, ImageColor
@@ -80,6 +82,8 @@ def get_font(weight, size=28):
 def get_wrapped_text(text, font, content_width):
     """text wrap length depends on the max width of the content"""
 
+    text = process_arabic_script(text)
+
     low = 0
     high = len(text)
 
@@ -106,6 +110,13 @@ def get_wrapped_text(text, font, content_width):
         height = 26
 
     return wrapped_text, height
+
+
+def process_arabic_script(text):
+    """First we need to re-shape the text, then apply the bidirectional text algo"""
+    reshaped_text = arabic_reshaper.reshape(text)
+    bidi_text = get_display(reshaped_text)
+    return bidi_text
 
 
 def generate_texts_layer(texts, content_width):

--- a/bookwyrm/preview_images.py
+++ b/bookwyrm/preview_images.py
@@ -51,17 +51,28 @@ def get_imagefont(name, size):
 
 def get_font(weight, size=28):
     """Gets a custom font with the given weight and size"""
-    font = get_imagefont(DEFAULT_FONT, size)
 
-    try:
-        if weight == "light":
-            font.set_variation_by_name("Light")
-        if weight == "bold":
-            font.set_variation_by_name("Bold")
-        if weight == "regular":
-            font.set_variation_by_name("Regular")
-    except OSError:
-        pass
+    fonts = DEFAULT_FONT.split(",")
+    for file in fonts:
+        file = file.strip()
+        font = get_imagefont(file, size)
+        if weight in file.lower():
+            break
+
+        try:
+            variations = font.get_variation_names()
+            variations_lower = [
+                v.decode("UTF-8").lower() for v in font.get_variation_names()
+            ]
+            idx = (
+                variations_lower.index(weight.lower())
+                if weight.lower() in variations_lower
+                else 0
+            )
+            font.set_variation_by_name(variations[idx])
+
+        except:
+            pass
 
     return font
 

--- a/bookwyrm/preview_images.py
+++ b/bookwyrm/preview_images.py
@@ -6,6 +6,8 @@ import textwrap
 from io import BytesIO
 from uuid import uuid4
 import logging
+import unicodedata as ud
+from collections import Counter
 
 import arabic_reshaper
 from bidi.algorithm import get_display
@@ -119,6 +121,19 @@ def process_arabic_script(text):
     return bidi_text
 
 
+def get_text_direction(text):
+    """Get the dominant strong direction
+    We we will not be using direction="rtl" | "ltr" property in multiline_text()
+    because the bidirectionality has already been treated with process_arabic_script
+    instead, we use this property to set the align property
+    """
+    # from https://stackoverflow.com/a/75739782
+    count = Counter([ud.bidirectional(c) for c in list(text)])
+    rtl_count = count["R"] + count["AL"] + count["RLE"] + count["RLI"]
+    ltr_count = count["L"] + count["LRE"] + count["LRI"]
+    return "right" if rtl_count > ltr_count else "left"
+
+
 def generate_texts_layer(texts, content_width):
     """Adds text for images"""
     font_text_zero = get_font("bold", size=20)
@@ -129,7 +144,15 @@ def generate_texts_layer(texts, content_width):
     text_layer = Image.new("RGBA", (content_width, IMG_HEIGHT), color=TRANSPARENT_COLOR)
     text_layer_draw = ImageDraw.Draw(text_layer)
 
+    text_x = 0
+    text_anchor = None
     text_y = 0
+    main_title = texts["text_one"] if "text_one" in texts else ""
+    text_align = get_text_direction(main_title)
+
+    if text_align == "right":
+        text_x = content_width
+        text_anchor = "ra"
 
     if "text_zero" in texts and texts["text_zero"]:
         # Text zero (Site preview domain name)
@@ -138,7 +161,12 @@ def generate_texts_layer(texts, content_width):
         )
 
         text_layer_draw.multiline_text(
-            (0, text_y), text_zero, font=font_text_zero, fill=TEXT_COLOR
+            (text_x, text_y),
+            text_zero,
+            font=font_text_zero,
+            fill=TEXT_COLOR,
+            align=text_align,
+            anchor=text_anchor,
         )
 
         try:
@@ -153,7 +181,12 @@ def generate_texts_layer(texts, content_width):
         )
 
         text_layer_draw.multiline_text(
-            (0, text_y), text_one, font=font_text_one, fill=TEXT_COLOR
+            (text_x, text_y),
+            text_one,
+            font=font_text_one,
+            fill=TEXT_COLOR,
+            align=text_align,
+            anchor=text_anchor,
         )
 
         try:
@@ -168,7 +201,12 @@ def generate_texts_layer(texts, content_width):
         )
 
         text_layer_draw.multiline_text(
-            (0, text_y), text_two, font=font_text_two, fill=TEXT_COLOR
+            (text_x, text_y),
+            text_two,
+            font=font_text_two,
+            fill=TEXT_COLOR,
+            align=text_align,
+            anchor=text_anchor,
         )
 
         try:
@@ -183,11 +221,16 @@ def generate_texts_layer(texts, content_width):
         )
 
         text_layer_draw.multiline_text(
-            (0, text_y), text_three, font=font_text_three, fill=TEXT_COLOR
+            (text_x, text_y),
+            text_three,
+            font=font_text_three,
+            fill=TEXT_COLOR,
+            align=text_align,
+            anchor=text_anchor,
         )
 
     text_layer_box = text_layer.getbbox()
-    return text_layer.crop(text_layer_box)
+    return text_layer.crop(text_layer_box), text_align
 
 
 def generate_instance_layer(content_width):
@@ -230,10 +273,12 @@ def generate_instance_layer(content_width):
     )
     instance_layer.alpha_composite(line_layer, (0, 60))
 
+    instance_layer = instance_layer.crop((0, 0, line_width, instance_layer.height))
+
     return instance_layer
 
 
-def generate_rating_layer(rating, content_width):
+def generate_rating_layer(rating):
     """Places components for rating preview"""
     path_star_full = os.path.join(settings.STATIC_ROOT, "images/icons/star-full.png")
     path_star_empty = os.path.join(settings.STATIC_ROOT, "images/icons/star-empty.png")
@@ -242,12 +287,14 @@ def generate_rating_layer(rating, content_width):
     icon_size = 64
     icon_margin = 10
 
+    layer_width = (5 * icon_size) + (4 * icon_margin)
+
     rating_layer_base = Image.new(
-        "RGBA", (content_width, icon_size), color=TRANSPARENT_COLOR
+        "RGBA", (layer_width, icon_size), color=TRANSPARENT_COLOR
     )
-    rating_layer_color = Image.new("RGBA", (content_width, icon_size), color=TEXT_COLOR)
+    rating_layer_color = Image.new("RGBA", (layer_width, icon_size), color=TEXT_COLOR)
     rating_layer_mask = Image.new(
-        "RGBA", (content_width, icon_size), color=TRANSPARENT_COLOR
+        "RGBA", (layer_width, icon_size), color=TRANSPARENT_COLOR
     )
 
     position_x = 0
@@ -349,10 +396,16 @@ def generate_preview_image(
     img = Image.new("RGBA", (IMG_WIDTH, IMG_HEIGHT), color=image_bg_color)
 
     # Contents
-    inner_img_x = margin + inner_img_width - inner_img_layer.width
     inner_img_y = math.floor((IMG_HEIGHT - inner_img_layer.height) / 2)
-    content_x = margin + inner_img_width + gutter
-    content_width = IMG_WIDTH - content_x - margin
+    content_width = IMG_WIDTH - margin - gutter - inner_img_width - margin
+
+    texts_layer, text_align = generate_texts_layer(texts, content_width)
+    if text_align == "left":
+        inner_img_x = margin + inner_img_width - inner_img_layer.width
+        content_x = margin + inner_img_width + gutter
+    elif text_align == "right":
+        inner_img_x = IMG_WIDTH - margin - inner_img_width
+        content_x = margin
 
     contents_layer = Image.new(
         "RGBA", (content_width, IMG_HEIGHT), color=TRANSPARENT_COLOR
@@ -361,20 +414,29 @@ def generate_preview_image(
 
     if show_instance_layer:
         instance_layer = generate_instance_layer(content_width)
-        contents_layer.alpha_composite(instance_layer, (0, contents_composite_y))
+        instance_layer_x = (
+            0 if text_align == "left" else content_width - instance_layer.width
+        )
+        contents_layer.alpha_composite(
+            instance_layer, (instance_layer_x, contents_composite_y)
+        )
         contents_composite_y = contents_composite_y + instance_layer.height + gutter
 
-    texts_layer = generate_texts_layer(texts, content_width)
-    contents_layer.alpha_composite(texts_layer, (0, contents_composite_y))
+    texts_layer_x = 0 if text_align == "left" else content_width - texts_layer.width
+    contents_layer.alpha_composite(texts_layer, (texts_layer_x, contents_composite_y))
     contents_composite_y = contents_composite_y + texts_layer.height + gutter
 
     if rating:
         # Add some more margin
         contents_composite_y = contents_composite_y + gutter
-        rating_layer = generate_rating_layer(rating, content_width)
-
+        rating_layer = generate_rating_layer(rating)
         if rating_layer:
-            contents_layer.alpha_composite(rating_layer, (0, contents_composite_y))
+            rating_layer_x = (
+                0 if text_align == "left" else content_width - rating_layer.width
+            )
+            contents_layer.alpha_composite(
+                rating_layer, (rating_layer_x, contents_composite_y)
+            )
             contents_composite_y = contents_composite_y + rating_layer.height + gutter
 
     contents_layer_box = contents_layer.getbbox()

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -61,15 +61,31 @@ PREVIEW_TEXT_COLOR = env.str("PREVIEW_TEXT_COLOR", "#363636")
 PREVIEW_IMG_WIDTH = env.int("PREVIEW_IMG_WIDTH", 1200)
 PREVIEW_IMG_HEIGHT = env.int("PREVIEW_IMG_HEIGHT", 630)
 PREVIEW_DEFAULT_COVER_COLOR = env.str("PREVIEW_DEFAULT_COVER_COLOR", "#002549")
-PREVIEW_DEFAULT_FONT = env.str("PREVIEW_DEFAULT_FONT", "Source Han Sans")
+PREVIEW_DEFAULT_FONT = env.str(
+    "PREVIEW_DEFAULT_FONT",
+    "NotoSansMultilanguage-Bold, NotoSansMultilanguage-Regular, NotoSansMultilanguage-Light",
+)
 
-FONTS = {
-    "Source Han Sans": {
-        "directory": "source_han_sans",
-        "filename": "SourceHanSans-VF.ttf.ttc",
-        "url": "https://github.com/adobe-fonts/source-han-sans/raw/release/Variable/OTC/SourceHanSans-VF.ttf.ttc",
-    }
-}
+FONTS = env.json(
+    "FONTS",
+    {
+        "NotoSansMultilanguage-Bold": {
+            "directory": "NotoMultilanguageFonts",
+            "filename": "NotoSansMultilanguage-Bold.ttf",
+            "url": "https://github.com/sefadogann/noto-multilanguage/raw/refs/heads/main/NotoMultilanguageFonts/NotoSansMultilanguage-Bold.ttf",
+        },
+        "NotoSansMultilanguage-Regular": {
+            "directory": "NotoMultilanguageFonts",
+            "filename": "NotoSansMultilanguage-Regular.ttf",
+            "url": "https://github.com/sefadogann/noto-multilanguage/raw/refs/heads/main/NotoMultilanguageFonts/NotoSansMultilanguage-Regular.ttf",
+        },
+        "NotoSansMultilanguage-Light": {
+            "directory": "NotoMultilanguageFonts",
+            "filename": "NotoSansMultilanguage-Light.ttf",
+            "url": "https://github.com/sefadogann/noto-multilanguage/raw/refs/heads/main/NotoMultilanguageFonts/NotoSansMultilanguage-Light.ttf",
+        },
+    },
+)
 FONT_DIR = os.path.join(STATIC_ROOT, "fonts")
 
 # Quick-start development settings - unsuitable for production

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [dependency-groups]
 main = [
     "aiohttp==3.14.1",
+    "arabic-reshaper==3.0.1",
     "bleach==6.4.0",
     "boto3==1.34.74",
     "bw-file-resubmit==0.6.0rc2",
@@ -33,6 +34,7 @@ main = [
     "psycopg[binary]==3.2.9",
     "pycryptodome==3.20.0",
     "pyotp==2.9.0",
+    "python-bidi==0.6.10",
     "python-dateutil==2.9.0.post0",
     "qrcode==7.4.2",
     "redis==5.0.3",


### PR DESCRIPTION
## Description

This PR aims to resolve multilanguage preview images generation. The recent project https://github.com/sefadogann/noto-multilanguage allows us to embark many scripts in one font (among others: Latin, Arabic, Chinese, Japanese, Korean…).

<details>
<summary>samples</summary>

<img width="1200" height="630" alt="19899-20b2dbe6-1d14-4a47-b44d-dcb585f29a92" src="https://github.com/user-attachments/assets/d3f448e1-58b7-46a8-903f-3436c5797a73" />
<img width="1200" height="630" alt="19490-9c33ccd1-d45e-4553-b014-be011b860867" src="https://github.com/user-attachments/assets/374177c9-57c0-4274-85ef-ca6f06562d54" />
<img width="1200" height="630" alt="20301-730ef847-b4aa-48a0-9275-65524562c146" src="https://github.com/user-attachments/assets/1883e99d-317b-489f-8e5c-b148b214d023" />
<img width="1200" height="630" alt="20300-63067f35-7afd-485a-aed8-ddec62a6c6ee" src="https://github.com/user-attachments/assets/2db26291-c175-48f8-a754-3f50d90a204a" />

<img width="1200" height="630" alt="19481-6e76ee63-2dc2-4520-a5cd-5ef7b8778d35" src="https://github.com/user-attachments/assets/c5788ba8-ce3e-4dc6-8763-578f4d7fbc37" />

<img width="1200" height="630" alt="19911-1415d9a6-0ab4-470a-84eb-92385ef68174" src="https://github.com/user-attachments/assets/3c0ec12d-5073-411a-adbf-1da14073a9da" />
<img width="1200" height="630" alt="19908-ae3f63aa-3d8f-48e7-9a8b-111948e9a9c4" src="https://github.com/user-attachments/assets/f0f6a4c3-1405-41b0-926e-1928f16bc467" />
<img width="1200" height="630" alt="19902-1652bd04-6328-438f-a358-8fb95d6c5afa" src="https://github.com/user-attachments/assets/88d77cf4-eb14-4afb-a107-7c82bbfb01ce" />

</details>

In order to load 3 files (for 3 weights) I had to modify the font loading system.

Now you can specify variable and non-variable preview fonts in your `.env`

```
FONTS = {"Source Han Sans": {"directory": "source_han_sans","filename": "SourceHanSans-VF.ttf.ttc","url": "https://github.com/adobe-fonts/source-han-sans/raw/release/Variable/OTC/SourceHanSans-VF.ttf.ttc"}
PREVIEW_DEFAULT_FONT = "Source Han Sans"
```

```
FONTS = {"NotoSansMultilanguage-Bold": { "directory": "NotoMultilanguageFonts", "filename": "NotoSansMultilanguage-Bold.ttf", "url": "https://github.com/sefadogann/noto-multilanguage/raw/refs/heads/main/NotoMultilanguageFonts/NotoSansMultilanguage-Bold.ttf"},"NotoSansMultilanguage-Regular": { "directory": "NotoMultilanguageFonts", "filename": "NotoSansMultilanguage-Regular.ttf", "url": "https://github.com/sefadogann/noto-multilanguage/raw/refs/heads/main/NotoMultilanguageFonts/NotoSansMultilanguage-Regular.ttf"},"NotoSansMultilanguage-Light": { "directory": "NotoMultilanguageFonts", "filename": "NotoSansMultilanguage-Light.ttf", "url": "https://github.com/sefadogann/noto-multilanguage/raw/refs/heads/main/NotoMultilanguageFonts/NotoSansMultilanguage-Light.ttf"}}
PREVIEW_DEFAULT_FONT = "NotoSansMultilanguage-Bold,NotoSansMultilanguage-Regular,NotoSansMultilanguage-Light"
```

In order to specify one font or a list of fonts, `FONTS` accepts a (one-line) JSON object with font items, each containing a dir, filename and url ; while `PREVIEW_DEFAULT_FONT` accepts a string containing a list of names separated by commas (the string will be split in a list if it contains commas).


- Closes #3596
- Closes #1828
- Closes #3403
- Closes #2661

## Notable issues

- ~~Arabic scripts support is not pretty. I do not know how PIL handles ligatures, but I’m not convinced by the result. It might take Arabic/Urdu/Farsi speakers to confirm if it is usable for the languages.~~ Arabic letter shapes are now handled, and a basic RTL mode is enabled for languages that need it.
- I haven’t been able to pinpoint the problem, but when a distant book is imported to the instance, the image that is generated lacks the author line

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [x] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
