### PR TITLE
User docker builder workflow and also build postgres-backup container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,6 +3,11 @@ name: Container building for release
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - ".github/workflows/container.yml"
+      - "Dockerfile"
+      - "entrypoint.sh"
+      - "postgres-docker/*"
   push:
     branches: ["main"]
     tags:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -52,3 +52,19 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+  cleanup:
+    needs: build
+    if: ${{ github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [bookwyrm, postgres-backup]
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.image }}
+          package-type: "container"
+          delete-only-untagged-versions: "true"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -17,6 +17,14 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        image: [bookwyrm, postgres-backup]
+        include:
+          - image: bookwyrm
+            context: .
+          - image: postgres-backup
+            context: postgres-docker
     uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
       contents: read # for checkout
@@ -25,13 +33,14 @@ jobs:
     with:
       output: image
       push: ${{ github.event_name != 'pull_request' }}
-      context: .
+      context: ${{ matrix.context }}
       platforms: linux/amd64,linux/arm64
       cache: true
       cache-mode: max
       fail-fast: true
       sbom: true
-      meta-images: ghcr.io/${{ github.repository_owner }}/bookwyrm
+      cache-scope: ${{ matrix.image }}
+      meta-images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
       meta-tags: |
         type=raw,value=${{ inputs.tag }},event=workflow_dispatch
         type=semver,pattern=v{{version}}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -39,6 +39,7 @@ jobs:
       cache-mode: max
       fail-fast: true
       sbom: true
+      sign: false
       cache-scope: ${{ matrix.image }}
       meta-images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
       meta-tags: |

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -51,6 +51,8 @@ jobs:
         type=raw,value=${{ inputs.tag }},event=workflow_dispatch
         type=semver,pattern=v{{version}}
         type=ref,event=branch
+      meta-flavor: |
+        latest=${{ startsWith(github.ref, 'refs/tags/') }}
       set-meta-labels: true
       set-meta-annotations: true
     secrets:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -17,48 +17,29 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
       contents: read # for checkout
       packages: write # to upload build to GHCR
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Work out Docker tags
-        id: docker_meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{ inputs.tag }},event=workflow_dispatch
-            type=semver,pattern=v{{version}}
-            type=ref,event=branch
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
+      id-token: write # signing attestations with github oidc token
+    with:
+      output: image
+      push: ${{ github.event_name != 'pull_request' }}
+      context: .
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-mode: max
+      fail-fast: true
+      sbom: true
+      meta-images: ghcr.io/${{ github.repository_owner }}/bookwyrm
+      meta-tags: |
+        type=raw,value=${{ inputs.tag }},event=workflow_dispatch
+        type=semver,pattern=v{{version}}
+        type=ref,event=branch
+      set-meta-labels: true
+      set-meta-annotations: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        id: docker-build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            APP_VERSION=${{ steps.docker_meta.outputs.version }}
-            GIT_SHA=${{ github.sha }}
-            DOCKER_TAG=${{ steps.docker_meta.outputs.tags }}

--- a/postgres-docker/Dockerfile
+++ b/postgres-docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:17
 
 # crontab
-RUN apt-get update && apt-get -y install cron
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && apt-get -y install cron
 
 RUN mkdir /backups
 COPY ./backup.sh /usr/local/bin/bookwyrm-backup.sh


### PR DESCRIPTION
## Description

User docker builder workflow into use, doesn't bring huge benefit regarding build times other than arm64 containers are build in native node instead of qemu emulator. Not huge speed benefits currently, as prepare/finalize stages take the improved build time.

Build also postgres-backup container as separate package, so allowing users to just pull release-version/main containers instead of checking out whole repo/building containers themselves.

Cleanup untagged layers from ghcr.io registry on main branch build. As main tag moves, there are some leftover layers that are not anymore in any tagged containers, so save space and clean those out.

Build containers from PR only if there are changes in build-related files. This is mainly as it takes somewhat constant amount of time to build, but might not be usefull in most of the PR builds to check container builds to work.

- Related Issue #
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [X] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
