### PR TITLE
docker-compose: reference by default to builded containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,6 +8,7 @@ on:
       - "Dockerfile"
       - "entrypoint.sh"
       - "postgres-docker/*"
+      - "dev-tools/*"
   push:
     branches: ["main"]
     tags:

--- a/.github/workflows/dev-tool-container.yml
+++ b/.github/workflows/dev-tool-container.yml
@@ -1,0 +1,49 @@
+name: Dev-tool Container building
+
+on:
+  workflow_run:
+    branches: ["main"]
+    workflows: [Container building for release]
+    types: [completed]
+
+jobs:
+  build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read # for checkout
+      packages: write # to upload build to GHCR
+      id-token: write # signing attestations with github oidc token
+    with:
+      output: image
+      push: true
+      context: dev-tools
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-mode: max
+      fail-fast: true
+      sbom: true
+      sign: false
+      cache-scope: bookwyrm-dev-tools
+      meta-images: ghcr.io/${{ github.repository_owner }}/bookwyrm-dev-tools
+      meta-tags: |
+        type=ref,event=branch
+      set-meta-labels: true
+      set-meta-annotations: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  cleanup:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: bookwyrm-dev-tools
+          delete-untagged: true
+          older-than: 1 hour

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM dev-wyrm-web
+FROM ghcr.io/bookwyrm-social/bookwyrm:main
 WORKDIR /app/dev-tools
 
 ENV PATH="/app/dev-tools/node_modules/.bin:$PATH"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - .:/app
   dev-tools:
+    image: ghcr.io/bookwyrm-social/bookwyrm-dev-tools:main
     build: dev-tools
     env_file:
       - .env

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,18 +4,23 @@ services:
     env_file: .env.dev
   web:
     env_file: .env.dev
+    image: ghcr.io/bookwyrm-social/bookwyrm:main
+    build: .
     volumes:
       - .:/app
   db-backup-job: !reset null
   celery_worker:
     env_file: .env.dev
+    image: ghcr.io/bookwyrm-social/bookwyrm:main
     volumes:
       - .:/app
   celery_beat:
+    image: ghcr.io/bookwyrm-social/bookwyrm:main
     env_file: .env.dev
     volumes:
       - .:/app
   flower:
+    image: ghcr.io/bookwyrm-social/bookwyrm:main
     env_file: .env.dev
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,8 @@ services:
       - ./certbot/logs:/var/log/letsencrypt
       - ./certbot/data:/var/www/certbot
   db-backup-job:
-    image: ghcr.io/bookwyrm-social/postgres-docker:latest
+    image: ghcr.io/bookwyrm-social/postgres-backup:latest
+    build: postgres-docker
     environment:
       - DEBUG=${DEBUG}
       - PGPASSWORD=${POSTGRES_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
   web:
     restart: unless-stopped
     image: ghcr.io/bookwyrm-social/bookwyrm:latest
+    build: .
     env_file: .env
     command: gunicorn bookwyrm.wsgi:application
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-x-logging:
-  &default-logging
+x-logging: &default-logging
   driver: "json-file"
   options:
     max-size: "150m"
@@ -66,7 +65,7 @@ services:
       - ./certbot/logs:/var/log/letsencrypt
       - ./certbot/data:/var/www/certbot
   db-backup-job:
-    build: postgres-docker
+    image: ghcr.io/bookwyrm-social/postgres-docker:latest
     environment:
       - DEBUG=${DEBUG}
       - PGPASSWORD=${POSTGRES_PASSWORD}
@@ -96,8 +95,8 @@ services:
     networks:
       - main
   web:
-    build: .
     restart: unless-stopped
+    image: ghcr.io/bookwyrm-social/bookwyrm:latest
     env_file: .env
     command: gunicorn bookwyrm.wsgi:application
     volumes:
@@ -140,8 +139,8 @@ services:
       - main
     restart: unless-stopped
   celery_worker:
+    image: ghcr.io/bookwyrm-social/bookwyrm:latest
     env_file: .env
-    build: .
     networks:
       - main
     command: celery -A celerywyrm worker --pool=threads --concurrency=20 -l info -Q high_priority,medium_priority,low_priority,streams,images,suggested_users,email,connectors,lists,inbox,imports,import_triggered,broadcast,misc
@@ -164,8 +163,8 @@ services:
         condition: service_started
     restart: unless-stopped
   celery_beat:
+    image: ghcr.io/bookwyrm-social/bookwyrm:latest
     env_file: .env
-    build: .
     networks:
       - main
     command: celery -A celerywyrm beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
@@ -184,7 +183,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
   flower:
-    build: .
+    image: ghcr.io/bookwyrm-social/bookwyrm:latest
     command: celery -A celerywyrm flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD} --url_prefix=flower
     healthcheck:
       test: celery -A celerywyrm status


### PR DESCRIPTION
## Description

This change allows to develop/run bookwyrm without needing to build all the containers. Building of container is needed only for dev-tools and if you have changes dependencies.

Build is needed only if dependencies are changed when developing, otherwise bookwyrm:main is  good base as it is latest build of main branch.

By default reference to `:latest` containers, which are latest tagged builds, meaning latest releases. This should be sensible default and update to newest version just requires pulling the image.

If people have automatic pull enabled, they might want to pin to specific version instead of latests, to prevent unannounced updates on restart of container.

This might have some rough edges that I didn't anticipate, so please test and comment how it feels and works.

- Related Issue #
- Closes #2095

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [X] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [X] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

Container images points to bookwyrm container builds instead requiring local builds. Building of release containers is not supported out of the box locally anymore.

## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [X] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
