### PR TITLE
backup-job: fix database user and database name variables

### DIFF
--- a/postgres-docker/backup.sh
+++ b/postgres-docker/backup.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 info() { echo >&2 "[$(date --iso-8601=seconds)] $*"; }
 
-if [ -z "$POSTGRES_DB" ]; then
+if [ -z "$PGDATABASE" ]; then
     info "backup: Database not specified, defaulting to bookwyrm"
 fi
-if [ -z "$POSTGRES_USER" ]; then
+if [ -z "$PGUSER" ]; then
     info "backup: Database user not specified, defaulting to bookwyrm"
 fi
-BACKUP_DB=${POSTGRES_DB:-bookwyrm}
-BACKUP_USER=${POSTGRES_USER:-bookwyrm}
+BACKUP_DB=${PGDATABASE:-bookwyrm}
+BACKUP_USER=${PGUSER:-bookwyrm}
 filename=backup_${BACKUP_DB}_$(date +%F)
 pg_dump -U "${BACKUP_USER}" "${BACKUP_DB}" --file "/backups/$filename.sql"
 info "backup: completed backup of $BACKUP_DB to /backups/$filename.sql"


### PR DESCRIPTION
## Description

We don't define all .env file to backup-job, only specific ones. So use those specific env-variables in backup-job.


- Related Issue #
- Closes #3990

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [X] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
