### PR TITLE
Fixes checking for existing reports on a user

### DIFF
--- a/bookwyrm/models/antispam.py
+++ b/bookwyrm/models/antispam.py
@@ -102,7 +102,7 @@ def automod_users(reporter):
         reduce(operator.or_, (Q(**f) for f in filters)),
         is_active=True,
         local=True,
-        report__isnull=True,  # don't flag users that already have reports
+        reported_user__isnull=True,  # don't flag users that already have reports
     ).distinct()
 
     report_model = apps.get_model("bookwyrm", "Report", require_ready=True)

--- a/bookwyrm/templates/settings/users/user_info.html
+++ b/bookwyrm/templates/settings/users/user_info.html
@@ -56,7 +56,7 @@
                 <dd>{{ user.email }}</dd>
                 {% endif %}
 
-                {% with report_count=user.report_set.count %}
+                {% with report_count=user.reported_user.count %}
                 <dt class="is-pulled-left mr-5">{% trans "Reports:" %}</dt>
                 <dd>
                     {{ report_count|intcomma }}

--- a/bookwyrm/tests/models/test_automod.py
+++ b/bookwyrm/tests/models/test_automod.py
@@ -1,7 +1,4 @@
 """test for app action functionality"""
-
-from unittest.mock import patch
-
 from django.test import TestCase
 from django.test.client import RequestFactory
 
@@ -9,40 +6,39 @@ from bookwyrm import models
 from bookwyrm.models.antispam import automod_task
 
 
-@patch("bookwyrm.models.Status.broadcast")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class AutomodModel(TestCase):
     """every response to a get request, html or json"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-                is_superuser=True,
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+            is_superuser=True,
+        )
+        cls.another_user = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@mouse.mouse",
+            "password",
+            local=True,
+            localname="rat",
+        )
 
     def setUp(self):
         self.factory = RequestFactory()
 
-    def test_automod_task_no_rules(self, *_):
+    def test_automod_task_no_rules(self):
         """nothing to see here"""
         self.assertFalse(models.Report.objects.exists())
         automod_task()
         self.assertFalse(models.Report.objects.exists())
         self.assertFalse(models.Notification.objects.exists())
 
-    def test_automod_task_user(self, *_):
+    def test_automod_task_user(self):
         """scan activity"""
         self.assertFalse(models.Report.objects.exists())
         models.AutoMod.objects.create(
@@ -62,7 +58,30 @@ class AutomodModel(TestCase):
         self.assertEqual(reports.first().user, self.local_user)
         self.assertEqual(models.Notification.objects.count(), 1)
 
-    def test_automod_status(self, *_):
+    def test_automod_task_user_existing_reports(self):
+        """scan activity"""
+        self.assertFalse(models.Report.objects.exists())
+        models.AutoMod.objects.create(
+            string_match="hi",
+            flag_users=True,
+            flag_statuses=True,
+            created_by=self.local_user,
+        )
+        models.Report.objects.create(
+            user=self.local_user,
+            reported_user=self.another_user,
+            allow_broadcast=False,
+        )
+
+        self.another_user.name = "okay hi"
+        self.another_user.save(broadcast=False, update_fields=["name"])
+
+        automod_task()
+
+        reports = models.Report.objects.all()
+        self.assertEqual(reports.count(), 1)
+
+    def test_automod_status(self):
         """scan activity"""
         self.assertFalse(models.Report.objects.exists())
         models.AutoMod.objects.create(

--- a/bookwyrm/tests/models/test_automod.py
+++ b/bookwyrm/tests/models/test_automod.py
@@ -1,4 +1,5 @@
 """test for app action functionality"""
+
 from django.test import TestCase
 from django.test.client import RequestFactory
 

--- a/bookwyrm/views/admin/reports.py
+++ b/bookwyrm/views/admin/reports.py
@@ -39,10 +39,10 @@ class ReportsAdmin(View):
 
         server = request.GET.get("server")
         if server:
-            filters["user__federated_server__server_name"] = server
+            filters["reported_user__federated_server__server_name"] = server
         username = request.GET.get("username")
         if username:
-            filters["user__username__icontains"] = username
+            filters["reported_user__username__icontains"] = username
         if resolved != "all":
             filters["resolved"] = resolved
 


### PR DESCRIPTION
## Description
I overlooked changes needed to the auto-mod tool in #3188 and it's causing the task to re-create reports on users that have already been resolved as false positives.

- Related Issue #
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
