### PR TITLE
Quality: Raw SQL in migration without proper parameterization

### DIFF
--- a/bookwyrm/migrations/0046_reviewrating.py
+++ b/bookwyrm/migrations/0046_reviewrating.py
@@ -17,13 +17,13 @@ def convert_review_rating(app_registry, schema_editor):
     )
 
     with connection.cursor() as cursor:
-        values = [(r.id,) for r in reviews]
-        cursor.executemany(
-            """
+        for review in reviews:
+            cursor.execute(
+                """
 INSERT INTO bookwyrm_reviewrating(review_ptr_id)
-VALUES %s""",
-            values,
-        )
+VALUES (%s)""",
+                (review.id,),
+            )
 
 
 def unconvert_review_rating(app_registry, schema_editor):


### PR DESCRIPTION
## Summary

Quality: Raw SQL in migration without proper parameterization

## Problem

**Severity**: `Medium` | **File**: `bookwyrm/migrations/0046_reviewrating.py:L25`

Migration 0046_reviewrating uses raw SQL with `cursor.executemany` but the SQL contains a string formatting placeholder `%s` that is passed as values. While executemany is used, the SQL string construction could be problematic. More critically, the migration directly manipulates database tables outside Django's ORM for a model inheritance scenario.

## Solution

Use Django's ORM operations or properly parameterized migrations. Consider using RunPython with model operations rather than raw SQL for better maintainability and database compatibility.

## Changes

- `bookwyrm/migrations/0046_reviewrating.py` (modified)