### PR TITLE
Fix garbled avatar object

### DIFF
--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -229,7 +229,7 @@ class User(OrderedCollectionPageMixin, AbstractUser):
     @property
     def alt_text(self):
         """alt text with username"""
-        return _(f"avatar for {self.localname or self.username}")
+        return _("avatar for {name}").format(name=(self.localname or self.username))
 
     @property
     def display_name(self):

--- a/bookwyrm/tests/models/test_user_model.py
+++ b/bookwyrm/tests/models/test_user_model.py
@@ -1,4 +1,5 @@
 """testing models"""
+
 import pathlib
 
 from unittest.mock import patch
@@ -126,18 +127,17 @@ class User(TestCase):
         with open(avatar_path, "rb") as avatar_file:
             self.user.avatar.save("mouse-avatar.jpg", avatar_file)
         activity = self.user.to_activity()
-        self.assertEqual(activity["icon"],
-           {
+        self.assertEqual(
+            activity["icon"],
+            {
                 "type": "Image",
                 "url": f"{BASE_URL}{self.user.avatar.url}",
                 "name": "avatar for mouse",
                 "@context": [
                     "https://www.w3.org/ns/activitystreams",
-                    {
-                    "Hashtag": "as:Hashtag"
-                    }
-                ]
-            }
+                    {"Hashtag": "as:Hashtag"},
+                ],
+            },
         )
 
     def test_activitypub_outbox(self):

--- a/bookwyrm/tests/views/test_user.py
+++ b/bookwyrm/tests/views/test_user.py
@@ -118,18 +118,17 @@ class UserViews(TestCase):
             is_api.return_value = True
             result = view(request, username="mouse")
         activity = json.loads(result.content)
-        self.assertEqual(activity["icon"],
-           {
+        self.assertEqual(
+            activity["icon"],
+            {
                 "type": "Image",
                 "url": f"{BASE_URL}{self.local_user.avatar.url}",
                 "name": "avatar for mouse",
                 "@context": [
                     "https://www.w3.org/ns/activitystreams",
-                    {
-                    "Hashtag": "as:Hashtag"
-                    }
-                ]
-            }
+                    {"Hashtag": "as:Hashtag"},
+                ],
+            },
         )
 
     def test_user_page_domain(self):


### PR DESCRIPTION
## Description

Well this was an adventure.

Per [Django docs](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#formatting-strings-format-lazy):

> Python f-strings cannot be used directly with gettext functions because f-string expressions are evaluated before they reach gettext.

Using `or` statements inside gettext also seems to be the likely cause of the weird return value, though I can't pin down a definitive explanation.

Should resolve #3986

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
