### PR TITLE
Prevent followed users from appearing in follow suggestions

### DIFF
--- a/bookwyrm/suggested_users.py
+++ b/bookwyrm/suggested_users.py
@@ -100,6 +100,9 @@ class SuggestedUsers(RedisStore):
             When(pk=int(pk), then=self.get_counts_from_rank(score)["mutuals"])
             for (pk, score) in values
         ]
+        invalid_suggestion = (
+            Q(id=user.id) | Q(followers=user) | Q(follower_requests=user)
+        )
         # annotate users with mutuals and shared book counts
         users = (
             models.User.objects.filter(
@@ -109,6 +112,7 @@ class SuggestedUsers(RedisStore):
                 mutuals=Case(*annotations, output_field=IntegerField(), default=0)
             )
             .exclude(localname=INSTANCE_ACTOR_USERNAME)
+            .exclude(invalid_suggestion)
         )
         if local:
             users = users.filter(local=True)

--- a/bookwyrm/tests/test_suggested_users.py
+++ b/bookwyrm/tests/test_suggested_users.py
@@ -143,11 +143,67 @@ class SuggestedUsers(TestCase):
 
     def test_get_suggestions(self, *_):
         """load from store"""
+        suggestion_candidate = models.User.objects.create_user(
+            "rat", "rat@local.rat", "password", local=True, localname="rat"
+        )
         with patch("bookwyrm.suggested_users.SuggestedUsers.get_store") as mock:
-            mock.return_value = [(self.local_user.id, 7.9)]
+            mock.return_value = [(suggestion_candidate.id, 7.9)]
             results = suggested_users.get_suggestions(self.local_user)
-        self.assertEqual(results[0], self.local_user)
+        self.assertEqual(results[0], suggestion_candidate)
         self.assertEqual(results[0].mutuals, 7)
+
+    def test_get_suggestions_excludes_self(self, *_):
+        suggestion_candidate = models.User.objects.create_user(
+            "rat", "rat@local.rat", "password", local=True, localname="rat"
+        )
+        with patch("bookwyrm.suggested_users.SuggestedUsers.get_store") as mock:
+            mock.return_value = [
+                (self.local_user.id, 1.0),
+                (suggestion_candidate.id, 1.0),
+            ]
+            results = suggested_users.get_suggestions(self.local_user)
+        self.assertEqual(list(results), [suggestion_candidate])
+
+    def test_get_suggestions_excludes_followed_users(self, *_):
+        followed_user = models.User.objects.create_user(
+            "rat", "rat@local.rat", "password", local=True, localname="rat"
+        )
+        suggestion_candidate = models.User.objects.create_user(
+            "fish", "fish@fish.fish", "password", local=True, localname="fish"
+        )
+        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
+            self.local_user.following.add(followed_user)
+        with patch("bookwyrm.suggested_users.SuggestedUsers.get_store") as mock:
+            mock.return_value = [
+                (followed_user.id, 1.0),
+                (suggestion_candidate.id, 1.0),
+            ]
+            results = suggested_users.get_suggestions(self.local_user)
+        self.assertEqual(list(results), [suggestion_candidate])
+
+    def test_get_suggestions_excludes_follow_requests(self, *_):
+        requested_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+            manually_approves_followers=True,
+        )
+        suggestion_candidate = models.User.objects.create_user(
+            "fish", "fish@fish.fish", "password", local=True, localname="fish"
+        )
+        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
+            models.UserFollowRequest.objects.create(
+                user_subject=self.local_user, user_object=requested_user
+            )
+        with patch("bookwyrm.suggested_users.SuggestedUsers.get_store") as mock:
+            mock.return_value = [
+                (requested_user.id, 1.0),
+                (suggestion_candidate.id, 1.0),
+            ]
+            results = suggested_users.get_suggestions(self.local_user)
+        self.assertEqual(list(results), [suggestion_candidate])
 
     def test_get_annotated_users(self, *_):
         """list of people you might know"""


### PR DESCRIPTION
## Description

- Closes https://github.com/bookwyrm-social/bookwyrm/issues/3198

This PR prevents the `Who to follow` panel from showing users the viewer already follows.

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
