### PR TITLE
Render status header via include tag instead of a nested render.

### DIFF
--- a/bookwyrm/templates/snippets/status/header_content.html
+++ b/bookwyrm/templates/snippets/status/header_content.html
@@ -1,4 +1,5 @@
 {% spaceless %}
 {% load status_display %}
-{% get_header_template status %}
+{% get_header_template status as header_template %}
+{% include header_template %}
 {% endspaceless %}

--- a/bookwyrm/templatetags/status_display.py
+++ b/bookwyrm/templatetags/status_display.py
@@ -67,8 +67,8 @@ def get_published_date(date):
     return naturaltime(date)
 
 
-@register.simple_tag(takes_context=True)
-def get_header_template(context, status):
+@register.simple_tag()
+def get_header_template(status):
     """get the path for the status template"""
     if isinstance(status, models.Boost):
         status = status.boosted_status
@@ -79,8 +79,7 @@ def get_header_template(context, status):
     except AttributeError:
         header_type = status.status_type.lower()
     filename = f"snippets/status/headers/{header_type}.html"
-    header_template = select_template([filename, "snippets/status/headers/note.html"])
-    return header_template.render({"status": status}, context.get("request"))
+    return select_template([filename, "snippets/status/headers/note.html"])
 
 
 @register.simple_tag(takes_context=False)

--- a/bookwyrm/tests/templatetags/test_status_display.py
+++ b/bookwyrm/tests/templatetags/test_status_display.py
@@ -3,6 +3,7 @@
 import datetime
 from unittest.mock import patch
 
+from django.template.loader import render_to_string
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils import timezone
@@ -135,9 +136,13 @@ class StatusDisplayTags(TestCase):
         request.user = self.user
 
         self.user.show_ratings = True
-        shown = status_display.get_header_template({"request": request}, rating)
+        shown = render_to_string(
+            "snippets/status/header_content.html", {"status": rating}, request=request
+        )
         self.assertNotIn("Show rating", shown)
 
         self.user.show_ratings = False
-        hidden = status_display.get_header_template({"request": request}, rating)
+        hidden = render_to_string(
+            "snippets/status/header_content.html", {"status": rating}, request=request
+        )
         self.assertIn("Show rating", hidden)


### PR DESCRIPTION
## Description
I made a mistake in https://github.com/bookwyrm-social/bookwyrm/pull/3979 as it causes the whole context-processor chain to run every time `get_header_template` is called, which happens dozens of times in the homepage.
This PR uses a more efficient approach that renders the header with {% include %} instead.

- Related Issue #3979


<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [x] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
