### PR TITLE
Prefetch feed book authors to fix N+1 queries in the Home page

### DIFF
--- a/bookwyrm/views/feed.py
+++ b/bookwyrm/views/feed.py
@@ -3,7 +3,7 @@
 from datetime import date
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import Prefetch, Q, prefetch_related_objects
 from django.http import HttpResponseNotFound, Http404
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
@@ -67,11 +67,18 @@ class Feed(View):
             else []
         )
 
+        page = paginated.get_page(request.GET.get("page"))
+        # prefetch on the objects, not the queryset, so the cache lands directly on status.book.
+        prefetch_related_objects(
+            [status.book for status in page if getattr(status, "book", None)],
+            Prefetch("authors", queryset=models.Author.objects.order_by("id")),
+        )
+
         data = {
             **feed_page_data(request.user),
             **{
                 "user": request.user,
-                "activities": paginated.get_page(request.GET.get("page")),
+                "activities": page,
                 "suggested_users": suggestions,
                 "tab": tab,
                 "streams": STREAMS,


### PR DESCRIPTION
## Description
Home page has an N+1 issue causing 129 queries. The fix reduces it to 46 queries.

<img width="222" height="629" alt="ảnh" src="https://github.com/user-attachments/assets/f4627add-ccd6-47e2-b85a-b5784939f12b" />
<img width="217" height="632" alt="ảnh" src="https://github.com/user-attachments/assets/a9a9e387-25ff-4d50-a801-c35774701315" />

## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
