### PR TITLE
Don't ignore boosts from external services

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -16,7 +16,7 @@ from bookwyrm import models
 from bookwyrm.connectors import ConnectorException, get_data
 from bookwyrm.models import base_model
 from bookwyrm.signatures import make_signature
-from bookwyrm.settings import DOMAIN, INSTANCE_ACTOR_USERNAME
+from bookwyrm.settings import DOMAIN, INSTANCE_ACTOR_USERNAME, USER_AGENT
 from bookwyrm.tasks import app, MISC
 
 logger = logging.getLogger(__name__)
@@ -432,6 +432,7 @@ def get_activitypub_data(url):
                 "Accept": 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
                 "Date": now,
                 "Signature": make_signature("get", sender, url, now),
+                "User-Agent": USER_AGENT,
             },
             timeout=15,
         )

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -133,6 +133,7 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
                 activity.object,
                 get_activity=True,
                 allow_external_connections=allow_external_connections,
+                model=cls,
             )
             if not boosted:
                 # if we can't load the status, definitely ignore it

--- a/bookwyrm/models/status.py
+++ b/bookwyrm/models/status.py
@@ -133,7 +133,7 @@ class Status(OrderedCollectionPageMixin, BookWyrmModel):
                 activity.object,
                 get_activity=True,
                 allow_external_connections=allow_external_connections,
-                model=cls,
+                model=apps.get_model("bookwyrm.Status", require_ready=True),
             )
             if not boosted:
                 # if we can't load the status, definitely ignore it

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -589,23 +589,24 @@ class Status(TestCase):
             to="",
         )
         status = {
-            "id": "http://fish.com/nothing",
-            "type": "Article",
+            "id": "https://fish.com/user/mouse/review/11934130",
+            "type": "Review",
             "published": "2026-07-06T16:05:15.746622+00:00",
-            "attributedTo": "http://fish.com/user/mouse",
-            "content": "<p>review content</p>",
+            "attributedTo": "https://fish.com/user/mouse",
+            "content": "<p>content</p>",
             "to": ["https://www.w3.org/ns/activitystreams#Public"],
-            "cc": ["http://fish.com/user/mouse/followers"],
+            "cc": ["https://fish.com/user/mouse/followers"],
             "replies": {},
+            "tag": [],
+            "attachment": [],
             "sensitive": False,
-            "inReplyToBook": "http://fish.com/book/2265331",
-            "name": 'Review of "Radiant Star": Leckie\'s Study of Provincial Life',
+            "inReplyToBook": "https://fish.com/book/2265331",
+            "name": "Leckie's Study of Provincial Life",
             "@context": [
                 "https://www.w3.org/ns/activitystreams",
                 {"Hashtag": "as:Hashtag"},
             ],
         }
-
         responses.add(responses.GET, "http://fish.com/nothing", json=status, status=200)
 
         self.assertFalse(models.Status.ignore_activity(activity))

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -556,6 +556,27 @@ class Status(TestCase):
 
         self.assertEqual(status.recipients, [self.remote_user])
 
+    def test_ignore_activity_boost_include(self, *_):
+        """do bother with some boost statuses"""
+        activity = activitypub.Announce(
+            id="http://www.faraway.com/boost/12",
+            actor=self.remote_user.remote_id,
+            object="http://fish.com/nothing",
+            published="2021-03-24T18:59:41.841208+00:00",
+            cc="",
+            to="",
+        )
+        status = models.Quotation.objects.create(
+            quote="<p>my quote</p>",
+            content="",
+            user=self.local_user,
+            book=self.book,
+        )
+        status.remote_id = "http://fish.com/nothing"
+        status.save(broadcast=False)
+
+        self.assertFalse(models.Status.ignore_activity(activity))
+
     @responses.activate
     def test_ignore_activity_boost(self, *_):
         """don't bother with most remote statuses"""

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -578,6 +578,39 @@ class Status(TestCase):
         self.assertFalse(models.Status.ignore_activity(activity))
 
     @responses.activate
+    def test_ignore_activity_boost_include_review(self, *_):
+        """don't ignore remote reviews"""
+        activity = activitypub.Announce(
+            id="http://www.faraway.com/boost/12",
+            actor=self.remote_user.remote_id,
+            object="http://fish.com/nothing",
+            published="2021-03-24T18:59:41.841208+00:00",
+            cc="",
+            to="",
+        )
+        status = {
+            "id": "http://fish.com/nothing",
+            "type": "Article",
+            "published": "2026-07-06T16:05:15.746622+00:00",
+            "attributedTo": "http://fish.com/user/mouse",
+            "content": "<p>review content</p>",
+            "to": ["https://www.w3.org/ns/activitystreams#Public"],
+            "cc": ["http://fish.com/user/mouse/followers"],
+            "replies": {},
+            "sensitive": False,
+            "inReplyToBook": "http://fish.com/book/2265331",
+            "name": 'Review of "Radiant Star": Leckie\'s Study of Provincial Life',
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                {"Hashtag": "as:Hashtag"},
+            ],
+        }
+
+        responses.add(responses.GET, "http://fish.com/nothing", json=status, status=200)
+
+        self.assertFalse(models.Status.ignore_activity(activity))
+
+    @responses.activate
     def test_ignore_activity_boost(self, *_):
         """don't bother with most remote statuses"""
         responses.add(responses.GET, "http://fish.com/nothing")


### PR DESCRIPTION
## Description
Per @qbi's suggestion, this adds the model to the lookup for whether to ignore a boost, which allows it to complete the lookup without making an HTTP request. It also sets the user agent so that Reviews are detected as type `Review`, not type `Article`

- Related Issue #
- Closes #4011 

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
