### PR TITLE
Check reset token expiry before changing password 

### DIFF
--- a/bookwyrm/tests/views/landing/test_password.py
+++ b/bookwyrm/tests/views/landing/test_password.py
@@ -129,7 +129,10 @@ class PasswordViews(TestCase):
         )
         with patch("bookwyrm.views.landing.password.login"):
             resp = view(request, code.code)
+
         self.assertEqual(resp.status_code, 200)
+        self.assertIn("Invalid password reset link", resp.context_data["errors"])
+
         self.local_user.refresh_from_db()
         self.assertFalse(self.local_user.check_password("longwordsecure"))
         self.assertTrue(models.PasswordReset.objects.exists())

--- a/bookwyrm/tests/views/landing/test_password.py
+++ b/bookwyrm/tests/views/landing/test_password.py
@@ -119,6 +119,21 @@ class PasswordViews(TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertFalse(models.PasswordReset.objects.exists())
 
+    def test_password_reset_post_expired_code(self):
+        view = views.PasswordReset.as_view()
+        code = models.PasswordReset.objects.create(
+            user=self.local_user, expiry=timezone.now() - timedelta(days=2)
+        )
+        request = self.factory.post(
+            "", {"password": "longwordsecure", "confirm_password": "longwordsecure"}
+        )
+        with patch("bookwyrm.views.landing.password.login"):
+            resp = view(request, code.code)
+        self.assertEqual(resp.status_code, 200)
+        self.local_user.refresh_from_db()
+        self.assertFalse(self.local_user.check_password("longwordsecure"))
+        self.assertTrue(models.PasswordReset.objects.exists())
+
     def test_password_reset_wrong_code(self):
         """reset from code"""
         view = views.PasswordReset.as_view()

--- a/bookwyrm/views/landing/password.py
+++ b/bookwyrm/views/landing/password.py
@@ -64,9 +64,8 @@ class PasswordReset(View):
 
     def post(self, request, code):
         """allow a user to change their password through an emailed token"""
-        try:
-            reset_code = models.PasswordReset.objects.get(code=code)
-        except models.PasswordReset.DoesNotExist:
+        reset_code = models.PasswordReset.objects.filter(code=code).first()
+        if not reset_code or not reset_code.valid():
             data = {"errors": ["Invalid password reset link"]}
             return TemplateResponse(request, "landing/password_reset.html", data)
 


### PR DESCRIPTION
## Description

Currently, an expired password reset token can be used to change a user's password. This PR validates token expiry before allowing the reset.

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
