### PR TITLE
Cleans up connectors admin view

### DIFF
--- a/bookwyrm/connectors/abstract_connector.py
+++ b/bookwyrm/connectors/abstract_connector.py
@@ -585,7 +585,7 @@ def update_connector_status(
     try:
         connector = models.Connector.objects.get(pk=connector_id)
         if error_message:
-            connector.latest_error = error_message
+            connector.latest_error = error_message[:255]
             connector.most_recent_error = timezone.now()
             connector.save(update_fields=["latest_error", "most_recent_error"])
         else:

--- a/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
+++ b/bookwyrm/static/css/bookwyrm/overrides/_bulma_overrides.scss
@@ -142,3 +142,7 @@
         font-size: $size-6;
     }
 }
+
+.is-break-word {
+    overflow-wrap: anywhere;
+}

--- a/bookwyrm/templates/settings/connectors/connector.html
+++ b/bookwyrm/templates/settings/connectors/connector.html
@@ -45,7 +45,7 @@
                     </div>
                 </div>
             {% if connector.most_recent_error %}
-                <div class="card-footer-item">
+                <div class="card-footer-item is-break-word">
                     <div>
                         <h3 class="menu-label">{% trans 'Latest error' %}</h3>
                         <p>{{ connector.most_recent_error|naturaltime}}</p>
@@ -59,7 +59,7 @@
                 name="deactivate-{{ connector.id }}"
                 method="post"
                 action="{% url 'settings-deactivate-connector' connector.id %}"
-                class="card-footer-item m-2"
+                class="card-footer-item m-2 is-flex-grow-0"
             >
                 {% csrf_token %}
                 <input type="hidden" name="item" value="{{ connector.id }}">
@@ -70,7 +70,7 @@
                 name="activate-{{ connector.id }}"
                 method="post"
                 action="{% url 'settings-activate-connector' connector.id %}"
-                class="card-footer-item"
+                class="card-footer-item m-2 is-flex-grow-0"
             >
                 {% csrf_token %}
                 <input type="hidden" name="item" value="{{ connector.id }}">

--- a/bookwyrm/templates/settings/connectors/connectors.html
+++ b/bookwyrm/templates/settings/connectors/connectors.html
@@ -6,33 +6,31 @@
 {% block header %}{% trans "Connector Settings" %}{% endblock %}
 
 {% block panel %}
-<div class="columns mt-3">
-    <section class="column is-three-quarters">
-        <p class="mb-2">{% trans "Connectors are sources of data about books and authors." %}</p>
-        <p class="mb-2">{% trans "The priority determines the order in which search results appear. The highest priority is <code>1</code>. The default priority is <code>2</code>." %}</p>
-        <p class="mb-2">
-            {% trans "Connector settings only determine whether a connector will be used to deliver search results. To manage more interactions with other federated servers, including domain blocks, see" %} <a href="{% url 'settings-federation' %}"> {% trans "Federated Instances" %}</a>.
-        </p>
-        <h4 class="title is-4 my-6">External Connectors</h4>
-        <ul class="ordered-list">
-        {% for connector in update_connectors %}
-            {% include "settings/connectors/update.html" %}
+<section>
+    <p class="mb-2">{% trans "Connectors are sources of data about books and authors." %}</p>
+    <p class="mb-2">{% trans "The priority determines the order in which search results appear. The highest priority is <code>1</code>. The default priority is <code>2</code>." %}</p>
+    <p class="mb-2">
+        {% trans "Connector settings only determine whether a connector will be used to deliver search results. To manage more interactions with other federated servers, including domain blocks, see" %} <a href="{% url 'settings-federation' %}"> {% trans "Federated Instances" %}</a>.
+    </p>
+    <h4 class="title is-4 my-6">External Connectors</h4>
+    <ul class="ordered-list">
+    {% for connector in update_connectors %}
+        {% include "settings/connectors/update.html" %}
+    {% endfor %}
+    {% for connector in other_connectors %}
+        {% include "settings/connectors/connector.html" %}
+    {% endfor %}
+    {% if available_connectors %}
+        {% for connector in available_connectors %}
+            {% include "settings/connectors/available.html" %}
         {% endfor %}
-        {% for connector in other_connectors %}
+    {% endif%}
+    </ul>
+    <h4 class="title is-4 my-6">BookWyrm Connectors</h4>
+    <ul class="ordered-list">
+        {% for connector in bookwyrm_connectors %}
             {% include "settings/connectors/connector.html" %}
         {% endfor %}
-        {% if available_connectors %}
-            {% for connector in available_connectors %}
-                {% include "settings/connectors/available.html" %}
-            {% endfor %}
-        {% endif%}
-        </ul>
-        <h4 class="title is-4 my-6">BookWyrm Connectors</h4>
-        <ul class="ordered-list">
-            {% for connector in bookwyrm_connectors %}
-                {% include "settings/connectors/connector.html" %}
-            {% endfor %}
-        </ul>
-    </section>
-</div>
+    </ul>
+</section>
 {% endblock %}

--- a/bookwyrm/tests/connectors/test_abstract_connector.py
+++ b/bookwyrm/tests/connectors/test_abstract_connector.py
@@ -10,6 +10,7 @@ from bookwyrm.connectors.abstract_connector import (
     Mapping,
     get_data,
     activitydata_to_seriesbook,
+    update_connector_status,
 )
 from bookwyrm.settings import BASE_URL, INSTANCE_ACTOR_USERNAME
 
@@ -325,3 +326,25 @@ class AbstractConnector(TestCase):
 
         self.assertEqual(models.Series.objects.count(), 1)
         self.assertEqual(models.SeriesBook.objects.count(), 1)
+
+    def test_update_connector_status(self):
+        """make sure we save errors correctly"""
+        self.assertIsNone(self.connector.connector.most_recent_error)
+
+        message = "normal length message"
+        update_connector_status(self.connector.connector.id, message)
+
+        self.connector.connector.refresh_from_db()
+        self.assertIsNotNone(self.connector.connector.most_recent_error)
+        self.assertEqual(self.connector.connector.latest_error, "normal length message")
+
+    def test_update_connector_status_long(self):
+        """make sure we save errors correctly"""
+        self.assertIsNone(self.connector.connector.most_recent_error)
+
+        message = "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz"
+        update_connector_status(self.connector.connector.id, message)
+
+        self.connector.connector.refresh_from_db()
+        self.assertIsNotNone(self.connector.connector.most_recent_error)
+        self.assertEqual(self.connector.connector.latest_error, message[:255])

--- a/bookwyrm/views/admin/connectors.py
+++ b/bookwyrm/views/admin/connectors.py
@@ -45,7 +45,7 @@ class ConnectorSettings(View):
         # other BookWyrm instances
         bookwrym_connectors = Connector.objects.filter(
             connector_file="bookwyrm_connector"
-        ).order_by("identifier")
+        ).order_by("-active", "latest_error", "identifier")
 
         # Optional and new connectors e.g. Finna
         # These are not yet Connector objects so we have to describe them in the


### PR DESCRIPTION
## Description
I noticed that connector error messages are failing to save when the error is too long, so this fixes that and throws in some formatting fixes as well. The big win was noticing that there was an unnecessary 3/4 width column constraining the page width.

Before:
<img width="1211" height="755" alt="Screenshot 2026-07-09 at 11 45 33 AM" src="https://github.com/user-attachments/assets/57348350-c735-4a29-850e-0c9bf709e995" />

After:
<img width="1185" height="756" alt="Screenshot 2026-07-09 at 11 45 17 AM" src="https://github.com/user-attachments/assets/f251c80b-8d09-4c45-b4f4-aa6b1eb3d5b0" />


- Related Issue #
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
