### PR TITLE
Show shelf implicit sort

### DIFF
--- a/bookwyrm/tests/views/shelf/test_shelf.py
+++ b/bookwyrm/tests/views/shelf/test_shelf.py
@@ -157,6 +157,25 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
+    def test_shelf_implicit_sort(self, *_):
+        """ensure the shelf view always has a sort in its response"""
+        view = views.Shelf.as_view()
+        shelf = self.local_user.shelf_set.first()
+        request = self.factory.get("")
+        request.user = self.local_user
+        with patch("bookwyrm.views.shelf.shelf.is_api_request") as is_api:
+            is_api.return_value = False
+            result = view(
+                request,
+                username=self.local_user.username,
+                shelf_identifier=shelf.identifier,
+            )
+        self.assertIsInstance(result, TemplateResponse)
+        validate_html(result.render())
+        self.assertIsNotNone(result.context_data["sort"])
+        self.assertNotEqual("", result.context_data["sort"])
+        self.assertEqual(result.status_code, 200)
+
     def test_shelf_page(self, *_):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Shelf.as_view()

--- a/bookwyrm/views/shelf/shelf.py
+++ b/bookwyrm/views/shelf/shelf.py
@@ -110,7 +110,7 @@ class Shelf(PrivateProfileMixin, View):
             "books": page,
             "edit_form": forms.ShelfForm(instance=shelf if shelf_identifier else None),
             "create_form": forms.ShelfForm(),
-            "sort": request.GET.get("sort"),
+            "sort": request.GET.get("sort") or "-shelved_date",
             "page_range": paginated.get_elided_page_range(
                 page.number, on_each_side=2, on_ends=1
             ),


### PR DESCRIPTION
## Description
The books in the shelf view are already being sorted such that `-shelved_date` is the default, so letting the template see the sort value in the request is just giving it the same default. null coalescing lets explicit sort in the URL still take precedence

- Related Issue #
- Closes # [3660](https://github.com/bookwyrm-social/bookwyrm/issues/3660)

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
