### PR TITLE
Show feed `Filters are applied` badge whenever filters are in effect

### DIFF
--- a/bookwyrm/models/user.py
+++ b/bookwyrm/models/user.py
@@ -256,6 +256,10 @@ class User(OrderedCollectionPageMixin, AbstractUser):
             notification_type__in=["REPLY", "MENTION", "TAG", "REPORT"],
         ).exists()
 
+    @property
+    def filters_applied(self):
+        return set(self.feed_status_types) != set(get_feed_filter_choices())
+
     activity_serializer = activitypub.Person
 
     @classmethod

--- a/bookwyrm/templates/snippets/filters_panel/filters_panel.html
+++ b/bookwyrm/templates/snippets/filters_panel/filters_panel.html
@@ -1,25 +1,26 @@
 {% load i18n %}
-<details class="details-panel box is-size-{{ size|default:'normal' }}" {% if filters_applied %}open{% endif %}>
+<details class="details-panel box is-size-{{ size|default:'normal' }}">
     <summary class="is-flex is-align-items-center is-flex-wrap-wrap is-gap-2">
         <span class="mb-0 title {% if size == 'small' %}is-6{% else %}is-5{% endif %} is-flex-shrink-0">
             {% trans "Filters" %}
         </span>
 
-        {% if filters_applied %}
-        <span class="tag is-success is-light ml-2 mb-0 is-{{ size|default:'normal' }}">
-            {% trans "Filters are applied" %}
-        </span>
-        {% endif %}
-
-        {% if method != "post" and request.GET %}
-        <span class="mb-0 tags has-addons">
-            <span class="mb-0 tag is-success is-light is-{{ size|default:'normal' }}">
-                {% trans "Filters are applied" %}
+        {% if feed_filters_applied is not None %}
+            {# Feed filters persist on the user record, not in the query string. #}
+            {% if feed_filters_applied %}
+                <span class="tag is-success is-light ml-2 mb-0 is-{{ size|default:'normal' }}">
+                    {% trans "Filters are applied" %}
+                </span>
+            {% endif %}
+        {% elif method != "post" and request.GET %}
+            <span class="mb-0 tags has-addons">
+                <span class="mb-0 tag is-success is-light is-{{ size|default:'normal' }}">
+                    {% trans "Filters are applied" %}
+                </span>
+                <a class="mb-0 tag is-success is-{{ size|default:'normal' }}" href="{{ request.path }}">
+                    {% trans "Clear filters" %}
+                </a>
             </span>
-            <a class="mb-0 tag is-success is-{{ size|default:'normal' }}" href="{{ request.path }}">
-                {% trans "Clear filters" %}
-            </a>
-        </span>
         {% endif %}
 
         <span class="details-close icon icon-x is-{{ size|default:'normal' }}" aria-hidden="true"></span>

--- a/bookwyrm/tests/models/test_user_model.py
+++ b/bookwyrm/tests/models/test_user_model.py
@@ -51,6 +51,13 @@ class User(TestCase):
         self.assertIsNotNone(self.user.key_pair.private_key)
         self.assertIsNotNone(self.user.key_pair.public_key)
 
+    def test_filters_applied_all_types_selected(self):
+        self.assertFalse(self.user.filters_applied)
+
+    def test_filters_applied_with_excluded_type(self):
+        self.user.feed_status_types = ["review"]
+        self.assertTrue(self.user.filters_applied)
+
     def test_remote_user(self):
         with patch("bookwyrm.models.user.set_remote_server.delay"):
             user = models.User.objects.create_user(

--- a/bookwyrm/tests/views/test_feed.py
+++ b/bookwyrm/tests/views/test_feed.py
@@ -80,7 +80,8 @@ class FeedViews(TestCase):
 
         result = view(request, "home")
 
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(result.url, "/home")
         self.local_user.refresh_from_db()
         self.assertEqual(self.local_user.feed_status_types, ["review"])
 

--- a/bookwyrm/tests/views/test_feed.py
+++ b/bookwyrm/tests/views/test_feed.py
@@ -84,6 +84,17 @@ class FeedViews(TestCase):
         self.local_user.refresh_from_db()
         self.assertEqual(self.local_user.feed_status_types, ["review"])
 
+    @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
+    def test_feed_shows_filters_applied_badge(self, *_):
+        self.local_user.feed_status_types = ["review"]
+        view = views.Feed.as_view()
+        request = self.factory.get("")
+        request.user = self.local_user
+
+        result = view(request, "home")
+
+        self.assertContains(result, "Filters are applied")
+
     def test_status_page(self, *_):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Status.as_view()

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -515,7 +515,7 @@ urlpatterns = [
         name="get-started-users",
     ),
     # feeds
-    re_path(rf"^(?P<tab>{STREAMS})/?$", views.Feed.as_view()),
+    re_path(rf"^(?P<tab>{STREAMS})/?$", views.Feed.as_view(), name="feed"),
     re_path(
         r"^direct-messages/?$", views.DirectMessage.as_view(), name="direct-messages"
     ),

--- a/bookwyrm/views/feed.py
+++ b/bookwyrm/views/feed.py
@@ -34,7 +34,7 @@ class Feed(View):
             user = form.save(request, commit=False)
             user.save(broadcast=False, update_fields=["feed_status_types"])
 
-        return redirect(request.path)
+        return redirect("feed", tab=tab)
 
     def get(self, request, tab):
         """user's homepage with activity feed"""

--- a/bookwyrm/views/feed.py
+++ b/bookwyrm/views/feed.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.db.models import Prefetch, Q, prefetch_related_objects
 from django.http import HttpResponseNotFound, Http404
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -28,17 +28,15 @@ class Feed(View):
 
     def post(self, request, tab):
         """save feed settings form, with a silent validation fail"""
-        filters_applied = False
         form = forms.FeedStatusTypesForm(request.POST, instance=request.user)
         if form.is_valid():
             # workaround to avoid broadcasting this change
             user = form.save(request, commit=False)
             user.save(broadcast=False, update_fields=["feed_status_types"])
-            filters_applied = True
 
-        return self.get(request, tab, filters_applied)
+        return redirect(request.path)
 
-    def get(self, request, tab, filters_applied=False):
+    def get(self, request, tab):
         """user's homepage with activity feed"""
         tab = [s for s in STREAMS if s["key"] == tab]
         tab = tab[0] if tab else STREAMS[0]
@@ -84,7 +82,7 @@ class Feed(View):
                 "streams": STREAMS,
                 "goal_form": forms.GoalForm(),
                 "feed_status_types_options": FeedFilterChoices,
-                "filters_applied": filters_applied,
+                "feed_filters_applied": request.user.filters_applied,
                 "path": f"/{tab['key']}",
                 "annual_summary_year": get_annual_summary_year(),
                 "has_tour": True,


### PR DESCRIPTION
## Description

- Closes https://github.com/bookwyrm-social/bookwyrm/issues/3687.

The badge only showed right after submitting the filter form. On a normal GET, `filters_applied` is always `False`, so just loading the feed never showed it.
This PR reads the badge from the saved `user.feed_status_types`, so it shows on every load while filters are on. Also redirect after saving so a reload doesn't re-post the form.
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
