### PR TITLE
fix reports admin page when no `reported_user`

### DIFF
--- a/bookwyrm/models/report.py
+++ b/bookwyrm/models/report.py
@@ -60,7 +60,9 @@ class Report(ActivityMixin, BookWyrmModel):
 
     def object(self):
         """Generate a list of reported objects in a format Mastodon will like"""
-        items = [self.reported_user.remote_id]
+        items = []
+        if self.reported_user and hasattr(self.reported_user, "remote_id"):
+            items.append(self.reported_user.remote_id)
         if self.statuses:
             items += self.statuses.values_list("remote_id", flat=True)
 

--- a/bookwyrm/templates/settings/reports/report_header.html
+++ b/bookwyrm/templates/settings/reports/report_header.html
@@ -3,9 +3,15 @@
 
 {% if report.statuses.exists %}
 
+{% if report.reported_user %}
 {% blocktrans trimmed with report_id=report.id username=report.reported_user|username %}
 Report #{{ report_id }}: Status posted by @{{ username }}
 {% endblocktrans %}
+{% else %}
+{% blocktrans trimmed with report_id=report.id %}
+Report #{{ report_id }}
+{% endblocktrans %}
+{% endif %}
 
 {% elif report.links.exists %}
 


### PR DESCRIPTION
## Description

Fixes the reports admin page not loading if a report is missing a `reported_user`. This is unlikely to happen except for legacy reports.

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
