### PR TITLE
Only execute query once in redis function

### DIFF
--- a/bookwyrm/redis_store.py
+++ b/bookwyrm/redis_store.py
@@ -1,7 +1,10 @@
 """access the activity stores stored in redis"""
 
 from abc import ABC, abstractmethod
+from typing import Any
+
 import redis
+from django.db.models.query import QuerySet
 
 from bookwyrm import settings
 
@@ -45,27 +48,28 @@ class RedisStore(ABC):
             pipeline.zrem(store, -1, obj_id)
         pipeline.execute()
 
-    def bulk_add_objects_to_store(self, objs, store):
+    def bulk_add_objects_to_store(self, objs: QuerySet[Any], store: str) -> None:
         """add a list of objects to a given store"""
         pipeline = r.pipeline()
-        for obj in objs[: self.max_length]:
+        max_length_objs = objs[: self.max_length]
+        for obj in max_length_objs:
             pipeline.zadd(store, self.get_value(obj))
-        if objs and self.max_length:
+        if max_length_objs and self.max_length:
             pipeline.zremrangebyrank(store, 0, -1 * self.max_length)
         pipeline.execute()
 
-    def bulk_remove_objects_from_store(self, objs, store):
+    def bulk_remove_objects_from_store(self, objs: QuerySet[Any], store: str) -> None:
         """remove a list of objects from a given store"""
         pipeline = r.pipeline()
         for obj in objs[: self.max_length]:
             pipeline.zrem(store, -1, obj.id)
         pipeline.execute()
 
-    def get_store(self, store, **kwargs):
+    def get_store(self, store: str, **kwargs) -> list[int]:
         """load the values in a store"""
         return r.zrevrange(store, 0, -1, **kwargs)
 
-    def populate_store(self, store):
+    def populate_store(self, store: str) -> None:
         """go from zero to a store"""
         pipeline = r.pipeline()
         queryset = self.get_objects_for_store(store)


### PR DESCRIPTION
## Description
This changes how we bulk add to redis for activitystreams, so that the queryset is only evaluated once. I also added some typing that helped me remember how this code works.

- Related Issue #
- Closes #4028

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
