### PR TITLE
Hoverable half star ratings

### DIFF
--- a/bookwyrm/static/css/bookwyrm/components/_stars.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_stars.scss
@@ -76,6 +76,7 @@
     position:relative;
 
 }
+
 .form-rate-stars input.full {
     width: 0.75rem !important;
     position:relative;

--- a/bookwyrm/static/css/bookwyrm/components/_stars.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_stars.scss
@@ -22,8 +22,13 @@
     width: max-content;
 }
 
-/* All stars are visually filled by default. */
+/* All stars are visually empty by default. */
 .form-rate-stars .icon::before {
+    content: "\e9d7"; /* icon-star-empty */
+}
+
+// if a star container is checked, fill all stars
+.form-rate-stars:has(input:checked) .icon::before {
     content: "\e9d9"; /* icon-star-full */
 }
 
@@ -74,8 +79,6 @@
 .form-rate-stars input.full {
     width: 0.75rem !important;
     position:relative;
-    opacity: 0;
-    pointer-events: none;
 }
 
 .form-rate-stars .star-container {

--- a/bookwyrm/static/css/bookwyrm/components/_stars.scss
+++ b/bookwyrm/static/css/bookwyrm/components/_stars.scss
@@ -13,8 +13,9 @@
  *
  * Specificity makes hovering taking over checked inputs.
  *
- * \e9d9: filled star
  * \e9d7: empty star;
+ * \e9d8: half-filled star;
+ * \e9d9: filled star
  * -------------------------------------------------------------------------- */
 
 .form-rate-stars {
@@ -26,31 +27,62 @@
     content: "\e9d9"; /* icon-star-full */
 }
 
-/* Icons directly following half star inputs are marked as half */
-.form-rate-stars input.half:checked ~ .icon::before {
+// if a star container has a half-input checked, its icon is a half-star
+.form-rate-stars .star-container:has(input.half:checked) .icon::before {
     content: "\e9d8"; /* icon-star-half */
 }
 
-/* stylelint-disable no-descending-specificity */
-.form-rate-stars input.half:checked + input + .icon:hover::before {
-    content: "\e9d8" !important; /* icon-star-half */
+// if a star container has a full-input checked, its icon is a full-star
+.form-rate-stars .star-container:has(input.full:checked) .icon::before {
+    content: "\e9d9"; /* icon-star-full */
 }
 
-/* Icons directly following half check inputs that follow the checked input are emptied. */
-.form-rate-stars input.half:checked + input + .icon ~ .icon::before {
+// stars following stars with checked inputs have icons that are empty
+.form-rate-stars .star-container:has(input:checked) ~ .star-container .icon::before {
     content: "\e9d7"; /* icon-star-empty */
 }
 
-/* Icons directly following inputs that follow the checked input are emptied. */
-.form-rate-stars input:checked ~ input + .icon::before {
-    content: "\e9d7"; /* icon-star-empty */
-}
-
-/* When a label is hovered, repeat the fill-all-then-empty-following pattern. */
-.form-rate-stars:hover .icon.icon::before {
+// When a star is hovered, pre-fill all icons as full
+.form-rate-stars:hover .icon::before
+{
     content: "\e9d9" !important; /* icon-star-full */
 }
 
-.form-rate-stars .icon:hover ~ .icon::before {
+// when an star is hovered, following icons are emptied
+.form-rate-stars .star-container:hover ~ .star-container .icon::before
+{
     content: "\e9d7" !important; /* icon-star-empty */
+}
+
+// if you hover over a star's half-input make its icon a half-star
+.inputs-container:has(input.half:hover) + .icon::before
+{
+    content: "\e9d8" !important; /* icon-star-half */
+}
+
+// if you hover over a star's full-input make its icon a full-star
+.inputs-container:has(input.full:hover) + .icon::before
+{
+    content: "\e9d9" !important; /* icon-star-full */
+}
+
+.form-rate-stars input.half {
+    width: 0.75rem !important;
+    position:relative;
+
+}
+.form-rate-stars input.full {
+    width: 0.75rem !important;
+    position:relative;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.form-rate-stars .star-container {
+    position: relative;
+}
+
+.inputs-container {
+    position: absolute;
+    opacity: 0;
 }

--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -7,20 +7,13 @@
     stars form-rate-stars
     {% if classes %}{{classes}}{% endif%}
 ">
-
-    {% if not default_rating %}
-        <label class="is-sr-only" for="{{ type|slugify }}_{{ book.id }}_no_rating">
-            {% trans "No rating" %}
-        </label>
-    {% endif %}
-
     {% for i in '12345'|make_list %}
     <div class="star-container">
         <div class="inputs-container">
             <label for="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half">
                 <span class="is-sr-only">
                     {% blocktranslate trimmed count rating=forloop.counter0 %}
-                        {{ rating }} star
+                        {{ rating }}.5 stars
                     {% plural %}
                         {{ rating }}.5 stars
                     {% endblocktranslate %}

--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -20,7 +20,7 @@
             <input
                 id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half"
                 class="half"
-                type="checkbox"
+                type="radio"
                 name="rating"
                 value="{{ forloop.counter0 }}.5"
                 {% if default_rating > 0 and default_rating > forloop.counter0 %}checked{% endif %}
@@ -28,7 +28,7 @@
             <input
                 id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}_full"
                 class="full"
-                type="checkbox"
+                type="radio"
                 name="rating"
                 value="{{ forloop.counter }}"
                 {% if default_rating >= forloop.counter %}checked{% endif %}

--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -21,32 +21,25 @@
     </label>
 
     {% for i in '12345'|make_list %}
-        <label
-            class="is-sr-only"
-            for="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half"
-        >
-                {% blocktranslate trimmed count rating=forloop.counter0 with half_rating=forloop.counter0|half_star %}
-                    {{ half_rating }} star
-                {% plural %}
-                    {{ half_rating }} stars
-                {% endblocktranslate %}
-        </label>
-        <input
-            id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half"
-            class="is-sr-only half"
-            type="radio"
-            name="rating"
-            value="{{ forloop.counter0 }}.5"
-            {% if default_rating > 0 and default_rating > forloop.counter0 %}checked{% endif %}
-        />
-        <input
-            id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}"
-            class="is-sr-only"
-            type="radio"
-            name="rating"
-            value="{{ forloop.counter }}"
-            {% if default_rating >= forloop.counter %}checked{% endif %}
-        />
+    <div class="star-container">
+        <div class="inputs-container">
+            <input
+                id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half"
+                class="half"
+                type="radio"
+                name="rating"
+                value="{{ forloop.counter0 }}.5"
+                {% if default_rating > 0 and default_rating > forloop.counter0 %}checked{% endif %}
+            />
+            <input
+                id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}_full"
+                class="full"
+                type="radio"
+                name="rating"
+                value="{{ forloop.counter }}"
+                {% if default_rating >= forloop.counter %}checked{% endif %}
+            />
+        </div>
 
         <label
             class="
@@ -68,6 +61,7 @@
                 {% endblocktranslate %}
             </span>
         </label>
+    </div>
     {% endfor %}
 </div>
 {% endspaceless %}

--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -7,26 +7,13 @@
     stars form-rate-stars
     {% if classes %}{{classes}}{% endif%}
 ">
-    <input
-        id="{{ type|slugify }}_{{ book.id }}_no_rating"
-        class="is-sr-only"
-        type="radio"
-        name="rating"
-        value=""
-        {% if default_rating == 0 or not default_rating %}checked{% endif %}
-    >
-
-    <label class="is-sr-only" for="{{ type|slugify }}_{{ book.id }}_no_rating">
-        {% trans "No rating" %}
-    </label>
-
     {% for i in '12345'|make_list %}
     <div class="star-container">
         <div class="inputs-container">
             <input
                 id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half"
                 class="half"
-                type="radio"
+                type="checkbox"
                 name="rating"
                 value="{{ forloop.counter0 }}.5"
                 {% if default_rating > 0 and default_rating > forloop.counter0 %}checked{% endif %}
@@ -34,7 +21,7 @@
             <input
                 id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}_full"
                 class="full"
-                type="radio"
+                type="checkbox"
                 name="rating"
                 value="{{ forloop.counter }}"
                 {% if default_rating >= forloop.counter %}checked{% endif %}

--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -17,6 +17,15 @@
     {% for i in '12345'|make_list %}
     <div class="star-container">
         <div class="inputs-container">
+            <label for="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half">
+                <span class="is-sr-only">
+                    {% blocktranslate trimmed count rating=forloop.counter0 %}
+                        {{ rating }} star
+                    {% plural %}
+                        {{ rating }}.5 stars
+                    {% endblocktranslate %}
+                </span>
+            </label>
             <input
                 id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half"
                 class="half"
@@ -25,8 +34,17 @@
                 value="{{ forloop.counter0 }}.5"
                 {% if default_rating > 0 and default_rating > forloop.counter0 %}checked{% endif %}
             />
+            <label for="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}">
+                <span class="is-sr-only">
+                    {% blocktranslate trimmed count rating=forloop.counter %}
+                        {{ rating }} star
+                    {% plural %}
+                        {{ rating }} stars
+                    {% endblocktranslate %}
+                </span>
+            </label>
             <input
-                id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}_full"
+                id="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}"
                 class="full"
                 type="radio"
                 name="rating"
@@ -35,7 +53,7 @@
             />
         </div>
 
-        <label
+        <div
             class="
                 icon
                 {% if forloop.counter <= default_rating %}
@@ -44,16 +62,9 @@
                 icon-star-empty
                 {% endif %}
             "
-            for="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}"
         >
-            <span class="is-sr-only">
-                {% blocktranslate trimmed count rating=forloop.counter %}
-                    {{ rating }} star
-                {% plural %}
-                    {{ rating }} stars
-                {% endblocktranslate %}
-            </span>
-        </label>
+
+        </div>
     </div>
     {% endfor %}
 </div>

--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -7,6 +7,13 @@
     stars form-rate-stars
     {% if classes %}{{classes}}{% endif%}
 ">
+
+    {% if not default_rating %}
+        <label class="is-sr-only" for="{{ type|slugify }}_{{ book.id }}_no_rating">
+            {% trans "No rating" %}
+        </label>
+    {% endif %}
+
     {% for i in '12345'|make_list %}
     <div class="star-container">
         <div class="inputs-container">
@@ -38,7 +45,6 @@
                 {% endif %}
             "
             for="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}"
-            data-for-half="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter0 }}_half"
         >
             <span class="is-sr-only">
                 {% blocktranslate trimmed count rating=forloop.counter %}

--- a/bookwyrm/templates/snippets/generated_status/rating.html
+++ b/bookwyrm/templates/snippets/generated_status/rating.html
@@ -1,6 +1,6 @@
 {% load i18n %}{% load humanize %}{% load utilities %}
 
-{% blocktrans trimmed with title=book|book_title path=book.remote_id display_rating=rating|floatformat:"-1" count counter=rating|add:0 %}
+{% blocktrans trimmed with title=book|book_title path=book.remote_id display_rating=rating|floatformat:"-1" count counter=rating|default_if_none:0|add:0 %}
 rated <em><a href="{{ path }}">{{ title }}</a></em>: {{ display_rating }} star
 {% plural %}
 rated <em><a href="{{ path }}">{{ title }}</a></em>: {{ display_rating }} stars


### PR DESCRIPTION
## Description

Changes the HTML and CSS of the `form_rate_stars` template so hovering over star ratings lets you hover over half or full stars and choose just half or full.

- Related Issue #
- Closes #4018 

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [x] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
