### PR TITLE
Prevent editing another user's shelf via the user field

### DIFF
--- a/bookwyrm/tests/views/shelf/test_shelf.py
+++ b/bookwyrm/tests/views/shelf/test_shelf.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
 from django.template.response import TemplateResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -259,6 +260,38 @@ class ShelfViews(TestCase):
 
         self.assertEqual(shelf.name, "cool name")
         self.assertEqual(shelf.identifier, f"testshelf-{shelf.id}")
+
+    def test_edit_shelf_by_non_owner_blocked(self, *_):
+        view = views.Shelf.as_view()
+        shelf = models.Shelf.objects.create(name="Test Shelf", user=self.local_user)
+        with (
+            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
+            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
+            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
+        ):
+            attacker = models.User.objects.create_user(
+                "rat@local.com",
+                "rat@rat.com",
+                "ratword",
+                local=True,
+                localname="rat",
+                remote_id="https://example.com/users/rat",
+            )
+
+        request = self.factory.post(
+            "", {"privacy": "public", "user": attacker.pk, "name": "Hijacked"}
+        )
+        request.user = attacker
+        with self.assertRaises(Http404):
+            view(
+                request,
+                username=self.local_user.username,
+                shelf_identifier=shelf.identifier,
+            )
+        shelf.refresh_from_db()
+
+        self.assertEqual(shelf.name, "Test Shelf")
+        self.assertEqual(shelf.user, self.local_user)
 
     def test_edit_shelf_name_not_editable(self, *_):
         """can't change the name of an non-editable shelf"""

--- a/bookwyrm/views/shelf/shelf.py
+++ b/bookwyrm/views/shelf/shelf.py
@@ -123,8 +123,7 @@ class Shelf(PrivateProfileMixin, View):
     @method_decorator(login_required, name="dispatch")
     def post(self, request, username, shelf_identifier):
         """edit a shelf"""
-        user = get_user_from_username(request.user, username)
-        shelf = get_object_or_404(user.shelf_set, identifier=shelf_identifier)
+        shelf = get_object_or_404(request.user.shelf_set, identifier=shelf_identifier)
 
         # you can't change the name of the default shelves
         if not shelf.editable and request.POST.get("name") != shelf.name:

--- a/bookwyrm/views/shelf/shelf.py
+++ b/bookwyrm/views/shelf/shelf.py
@@ -16,7 +16,7 @@ from django.views.decorators.vary import vary_on_headers
 from bookwyrm import forms, models
 from bookwyrm.activitypub import ActivitypubResponse
 from bookwyrm.settings import PAGE_LENGTH
-from bookwyrm.views.helpers import is_api_request, get_user_from_username
+from bookwyrm.views.helpers import is_api_request
 from bookwyrm.book_search import search
 from bookwyrm.views.mixins import PrivateProfileMixin
 


### PR DESCRIPTION
## Description
Any logged-in user could edit someone else's shelf by setting `user` in the request body to their own id, bypassing the ownership check in
https://github.com/bookwyrm-social/bookwyrm/blob/3dc92597a50759b9cb1695a20a1733fa56744d34/bookwyrm/models/base_model.py#L117-L127
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
