### PR TITLE
anubis: check accept header contain instead of equal for json

### DIFF
--- a/anubis/botPolicy.yaml
+++ b/anubis/botPolicy.yaml
@@ -7,7 +7,7 @@ bots:
       all:
         - 'userAgent.startsWith("BookWyrm")'
         - '"Accept" in headers'
-        - 'headers["Accept"] == "application/activity+json"'
+        - 'headers["Accept"].contains("application/activity+json")'
   - name: Allow access to manifest.json directly
     action: ALLOW
     path_regex: "^/manifest.json$"


### PR DESCRIPTION
## Description

Check Accept-header containing activity/json instead of requiring it to be equal to it.

- Related Issue #4038  
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [X] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [X] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
