### PR TITLE
Keep shelf links on the local instance for remote users

### DIFF
--- a/bookwyrm/models/shelf.py
+++ b/bookwyrm/models/shelf.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.utils import timezone
 
 from bookwyrm import activitypub
-from bookwyrm.settings import BASE_URL
 from bookwyrm.tasks import BROADCAST
 from bookwyrm.utils.db import add_update_fields
 from .activitypub_mixin import CollectionItemMixin, OrderedCollectionMixin
@@ -75,7 +74,8 @@ class Shelf(OrderedCollectionMixin, BookWyrmModel):
     @property
     def local_path(self):
         """No slugs"""
-        return self.get_remote_id().replace(BASE_URL, "")
+        identifier = self.identifier or self.get_identifier()
+        return f"{self.user.local_path}/books/{identifier}"
 
     def raise_not_deletable(self, viewer):
         """don't let anyone delete a default shelf"""

--- a/bookwyrm/tests/models/test_shelf_model.py
+++ b/bookwyrm/tests/models/test_shelf_model.py
@@ -37,6 +37,27 @@ class Shelf(TestCase):
         expected_id = f"{settings.BASE_URL}/user/mouse/books/test-shelf"
         self.assertEqual(shelf.get_remote_id(), expected_id)
 
+    def test_local_path_for_local_user_shelf(self, *_):
+        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
+            shelf = models.Shelf.objects.create(
+                name="Test Shelf", identifier="test-shelf", user=self.local_user
+            )
+        self.assertEqual(shelf.local_path, "/user/mouse/books/test-shelf")
+
+    def test_local_path_for_remote_user_shelf_stays_local(self, *_):
+        remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.rat",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/user/rat",
+            bookwyrm_user=False,
+        )
+        shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=remote_user
+        )
+        self.assertEqual(shelf.local_path, "/user/rat@example.com/books/test-shelf")
+
     def test_to_activity(self, *_):
         """jsonify it"""
         with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):


### PR DESCRIPTION
## Description

`Shelf.local_path` was not actually local for remote owners, it returned the origin instance URL, resulting in the shelf tabs redirecting to the remote url.

- Closes https://github.com/bookwyrm-social/bookwyrm/issues/3685

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
