### PR TITLE
Improves performance of shelf page

### DIFF
--- a/bookwyrm/views/shelf/shelf.py
+++ b/bookwyrm/views/shelf/shelf.py
@@ -59,6 +59,7 @@ class Shelf(PrivateProfileMixin, View):
             )
 
             shelf = FakeShelf("all", _("All books"), user, books, "public")
+        books = books.annotate(shelved_date=Max("shelfbook__shelved_date"))
 
         if is_api_request(request) and shelf_identifier:
             return ActivitypubResponse(shelf.to_activity(**request.GET))
@@ -80,18 +81,6 @@ class Shelf(PrivateProfileMixin, View):
             "start_date"
         )
 
-        books = books.annotate(shelved_date=Max("shelfbook__shelved_date"))
-        books = books.annotate(
-            rating=Subquery(reviews.values("rating")[:1]),
-            start_date=Subquery(reading.values("start_date")[:1]),
-            finish_date=Subquery(reading.values("finish_date")[:1]),
-            author=Subquery(
-                models.Book.objects.filter(id=OuterRef("id")).values("authors__name")[
-                    :1
-                ]
-            ),
-        ).prefetch_related("authors")
-
         books = sort_books(books, request.GET.get("sort"))
 
         if shelves_filter_query:
@@ -102,6 +91,16 @@ class Shelf(PrivateProfileMixin, View):
             PAGE_LENGTH,
         )
         page = paginated.get_page(request.GET.get("page"))
+        page.object_list = page.object_list.annotate(
+            rating=Subquery(reviews.values("rating")[:1]),
+            start_date=Subquery(reading.values("start_date")[:1]),
+            finish_date=Subquery(reading.values("finish_date")[:1]),
+            author=Subquery(
+                models.Book.objects.filter(id=OuterRef("id")).values("authors__name")[
+                    :1
+                ]
+            ),
+        ).prefetch_related("authors")
         data = {
             "user": user,
             "is_self": is_self,


### PR DESCRIPTION
## Description
The paginator was taking the count of the queryset including all the annotations -- this changes the workflow so that the annotations are only run on the current page.

The performance report from EXPLAIN ANALYZE before:
```sql
SELECT COUNT(*) FROM ( SELECT DISTINCT "bookwyrm_book"."id" AS "col1", "bookwyrm_book"."created_date" AS "col2", "bookwyrm_book"."updated_date" AS "col3", "bookwyrm_book"."remote_id" AS "col4", "bookwyrm_book"."origin_id" AS "col5", "bookwyrm_book"."openlibrary_key" AS "col6", "bookwyrm_book"."finna_key" AS "col7", "bookwyrm_book"."libris_key" AS "col8", "bookwyrm_book"."inventaire_id" AS "col9", "bookwyrm_book"."librarything_key" AS "col10", "bookwyrm_book"."goodreads_key" AS "col11", "bookwyrm_book"."bnf_id" AS "col12", "bookwyrm_book"."viaf" AS "col13", "bookwyrm_book"."wikidata" AS "col14", "bookwyrm_book"."asin" AS "col15", "bookwyrm_book"."aasin" AS "col16", "bookwyrm_book"."isfdb" AS "col17", "bookwyrm_book"."search_vector" AS "col18", "bookwyrm_book"."last_edited_by_id" AS "col19", "bookwyrm_book"."connector_id" AS "col20", "bookwyrm_book"."title" AS "col21", "bookwyrm_book"."sort_title" AS "col22", "bookwyrm_book"."subtitle" AS "col23", "bookwyrm_book"."description" AS "col24", "bookwyrm_book"."languages" AS "col25", "bookwyrm_book"."series" AS "col26", "bookwyrm_book"."series_number" AS "col27", "bookwyrm_book"."subjects" AS "col28", "bookwyrm_book"."subject_places" AS "col29", "bookwyrm_book"."cover" AS "col30", "bookwyrm_book"."preview_image" AS "col31", "bookwyrm_book"."first_published_date" AS "col32", "bookwyrm_book"."published_date" AS "col33", "bookwyrm_book"."first_published_date_precision" AS "col34", "bookwyrm_book"."published_date_precision" AS "col35", "bookwyrm_edition"."book_ptr_id" AS "col36", "bookwyrm_edition"."isbn_10" AS "col37", "bookwyrm_edition"."isbn_13" AS "col38", "bookwyrm_edition"."oclc_number" AS "col39", "bookwyrm_edition"."pages" AS "col40", "bookwyrm_edition"."physical_format" AS "col41", "bookwyrm_edition"."physical_format_detail" AS "col42", "bookwyrm_edition"."publishers" AS "col43", "bookwyrm_edition"."parent_work_id" AS "col44", "bookwyrm_edition"."edition_rank" AS "col45", MAX("bookwyrm_shelfbook"."shelved_date") AS "shelved_date", ( SELECT U0."rating" AS "rating" FROM "bookwyrm_review" U0 INNER JOIN "bookwyrm_status" U3 ON (U0."status_ptr_id" = U3."id") WHERE (U0."book_id" = ("bookwyrm_edition"."book_ptr_id") AND NOT U3."deleted" AND U0."rating" IS NOT NULL AND U3."user_id" = 1) ORDER BY U3."published_date" DESC LIMIT 1 ) AS "rating", ( SELECT U0."start_date" AS "start_date" FROM "bookwyrm_readthrough" U0 WHERE (U0."book_id" = ("bookwyrm_edition"."book_ptr_id") AND U0."user_id" = 1) ORDER BY 1 ASC LIMIT 1 ) AS "start_date", ( SELECT U0."finish_date" AS "finish_date" FROM "bookwyrm_readthrough" U0 WHERE (U0."book_id" = ("bookwyrm_edition"."book_ptr_id") AND U0."user_id" = 1) ORDER BY U0."start_date" ASC LIMIT 1 ) AS "finish_date", ( SELECT U2."name" AS "authors__name" FROM "bookwyrm_book" U0 LEFT OUTER JOIN "bookwyrm_book_authors" U1 ON (U0."id" = U1."book_id") LEFT OUTER JOIN "bookwyrm_author" U2 ON (U1."author_id" = U2."id") WHERE U0."id" = ("bookwyrm_edition"."book_ptr_id") LIMIT 1 ) AS "author" FROM "bookwyrm_edition" INNER JOIN "bookwyrm_shelfbook" ON ("bookwyrm_edition"."book_ptr_id" = "bookwyrm_shelfbook"."book_id") INNER JOIN "bookwyrm_book" ON ("bookwyrm_edition"."book_ptr_id" = "bookwyrm_book"."id") WHERE (NOT ("bookwyrm_edition"."parent_work_id" IN (SELECT U0."book_ptr_id" AS "id" FROM "bookwyrm_work" U0 INNER JOIN "bookwyrm_user_blocked_books" U1 ON (U0."book_ptr_id" = U1."work_id") WHERE U1."user_id" = 1) AND "bookwyrm_edition"."parent_work_id" IS NOT NULL) AND "bookwyrm_shelfbook"."shelf_id" IN (SELECT U0."id" FROM "bookwyrm_shelf" U0 WHERE U0."user_id" = 1)) GROUP BY 1, 36 ) subquery;

Aggregate  (cost=10696.44..10696.45 rows=1 width=8) (actual time=4984.081..4984.093 rows=1 loops=1)
   ->  Unique  (cost=5597.21..10696.20 rows=19 width=3317) (actual time=579.085..4983.993 rows=898 loops=1)
 Planning Time: 1.440 ms
 Execution Time: 4984.222 ms
```

And after:
```sql
SELECT COUNT(*) FROM ( SELECT DISTINCT "bookwyrm_book"."id" AS "col1", "bookwyrm_book"."created_date" AS "col2", "bookwyrm_book"."updated_date" AS "col3", "bookwyrm_book"."remote_id" AS "col4", "bookwyrm_book"."origin_id" AS "col5", "bookwyrm_book"."openlibrary_key" AS "col6", "bookwyrm_book"."finna_key" AS "col7", "bookwyrm_book"."libris_key" AS "col8", "bookwyrm_book"."inventaire_id" AS "col9", "bookwyrm_book"."librarything_key" AS "col10", "bookwyrm_book"."goodreads_key" AS "col11", "bookwyrm_book"."bnf_id" AS "col12", "bookwyrm_book"."viaf" AS "col13", "bookwyrm_book"."wikidata" AS "col14", "bookwyrm_book"."asin" AS "col15", "bookwyrm_book"."aasin" AS "col16", "bookwyrm_book"."isfdb" AS "col17", "bookwyrm_book"."search_vector" AS "col18", "bookwyrm_book"."last_edited_by_id" AS "col19", "bookwyrm_book"."connector_id" AS "col20", "bookwyrm_book"."title" AS "col21", "bookwyrm_book"."sort_title" AS "col22", "bookwyrm_book"."subtitle" AS "col23", "bookwyrm_book"."description" AS "col24", "bookwyrm_book"."languages" AS "col25", "bookwyrm_book"."series" AS "col26", "bookwyrm_book"."series_number" AS "col27", "bookwyrm_book"."subjects" AS "col28", "bookwyrm_book"."subject_places" AS "col29", "bookwyrm_book"."cover" AS "col30", "bookwyrm_book"."preview_image" AS "col31", "bookwyrm_book"."first_published_date" AS "col32", "bookwyrm_book"."published_date" AS "col33", "bookwyrm_book"."first_published_date_precision" AS "col34", "bookwyrm_book"."published_date_precision" AS "col35", "bookwyrm_edition"."book_ptr_id" AS "col36", "bookwyrm_edition"."isbn_10" AS "col37", "bookwyrm_edition"."isbn_13" AS "col38", "bookwyrm_edition"."oclc_number" AS "col39", "bookwyrm_edition"."pages" AS "col40", "bookwyrm_edition"."physical_format" AS "col41", "bookwyrm_edition"."physical_format_detail" AS "col42", "bookwyrm_edition"."publishers" AS "col43", "bookwyrm_edition"."parent_work_id" AS "col44", "bookwyrm_edition"."edition_rank" AS "col45", MAX("bookwyrm_shelfbook"."shelved_date") AS "shelved_date" FROM "bookwyrm_edition" INNER JOIN "bookwyrm_shelfbook" ON ("bookwyrm_edition"."book_ptr_id" = "bookwyrm_shelfbook"."book_id") INNER JOIN "bookwyrm_book" ON ("bookwyrm_edition"."book_ptr_id" = "bookwyrm_book"."id") WHERE (NOT ("bookwyrm_edition"."parent_work_id" IN (SELECT U0."book_ptr_id" AS "id" FROM "bookwyrm_work" U0 INNER JOIN "bookwyrm_user_blocked_books" U1 ON (U0."book_ptr_id" = U1."work_id") WHERE U1."user_id" = 1) AND "bookwyrm_edition"."parent_work_id" IS NOT NULL) AND "bookwyrm_shelfbook"."shelf_id" IN (SELECT U0."id" FROM "bookwyrm_shelf" U0 WHERE U0."user_id" = 1)) GROUP BY 1, 36 ) subquery;

 Aggregate  (cost=5317.66..5317.67 rows=1 width=8) (actual time=19.118..19.122 rows=1 loops=1)
   ->  Unique  (cost=5314.13..5317.43 rows=19 width=2773) (actual time=16.792..19.078 rows=898 loops=1)

 Planning Time: 1.165 ms
 Execution Time: 19.229 ms
```

- Related Issue #3805 
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
