### PR TITLE
Add a mutex lock on to_model function

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -1,9 +1,13 @@
 """basics for an activitypub serializer"""
 
 from __future__ import annotations
+from contextlib import contextmanager
 from dataclasses import dataclass, fields, MISSING
+from hashlib import md5
 from json import JSONEncoder
 import logging
+import random
+import time
 from typing import Optional, Union, TypeVar, overload, Any
 
 import requests
@@ -15,6 +19,7 @@ from django.utils.http import http_date
 from bookwyrm import models
 from bookwyrm.connectors import ConnectorException, get_data
 from bookwyrm.models import base_model
+from bookwyrm.redis_store import r
 from bookwyrm.signatures import make_signature
 from bookwyrm.settings import (
     DOMAIN,
@@ -39,6 +44,45 @@ class ActivityEncoder(JSONEncoder):
 
     def default(self, o):
         return o.__dict__
+
+
+@contextmanager
+def item_lock(object_id):
+    """Set a mutex lock on an incoming item to prevent race conditions causing duplicates"""
+
+    # hash the remote id so the key is a reasonable length
+    try:
+        id_hash = md5(object_id.encode("utf-8")).hexdigest()
+    except AttributeError:
+        raise ActivitySerializerError("Incoming object has no identifier")
+    lock_id = f"lock:{id_hash}"
+    # expire after 10 minutes in case something goes wrong
+    expire_seconds = time.monotonic() + 600
+    # try to get the lock until you have it or it has (nearly) expired
+    while time.monotonic() < expire_seconds - 5:
+        # 1: arbitrary value for the key
+        # nx: only set if the key doesn't already exist
+        # ex: expire after this many seconds
+        if lock := r.set(lock_id, "1", nx=True, ex=600):
+            break
+
+        # if we don't have the lock, try again in 5 to 10 seconds
+        sleep_time = random.randint(5, 10)
+        time.sleep(sleep_time)
+
+    if not lock:
+        raise ActivitySerializerError(
+            f"Lock expired on {object_id} before being acquired"
+        )
+
+    try:
+        yield lock
+    finally:
+        # after we have used it, clear the lock
+        # only release lock if you have it and it isn't expired
+        # otherwise we might clear a lock owned by another process
+        if time.monotonic() < expire_seconds and lock:
+            r.delete(lock_id)
 
 
 @dataclass
@@ -160,87 +204,94 @@ class ActivityObject:
             return None
         instance = instance or model()
 
-        # keep track of what we've changed
-        update_fields = []
-        # sets field on the model using the activity value
-        for field in instance.simple_fields:
-            try:
+        identifier = (
+            self.id
+            or instance.id
+            or getattr(self, "href", None)
+            or getattr(self, "url", None)
+        )
+        with item_lock(identifier):  # lock processing this item to prevent duplicates
+            # keep track of what we've changed
+            update_fields = []
+            # sets field on the model using the activity value
+            for field in instance.simple_fields:
+                try:
+                    changed = field.set_field_from_activity(
+                        instance,
+                        self,
+                        overwrite=overwrite,
+                        allow_external_connections=allow_external_connections,
+                    )
+                    if changed:
+                        update_fields.append(field.name)
+                except AttributeError as e:
+                    raise ActivitySerializerError(e)
+
+            # image fields have to be set after other fields because they can save
+            # too early and jank up users
+            for field in instance.image_fields:
                 changed = field.set_field_from_activity(
                     instance,
                     self,
+                    save=save,
                     overwrite=overwrite,
                     allow_external_connections=allow_external_connections,
                 )
                 if changed:
                     update_fields.append(field.name)
-            except AttributeError as e:
-                raise ActivitySerializerError(e)
 
-        # image fields have to be set after other fields because they can save
-        # too early and jank up users
-        for field in instance.image_fields:
-            changed = field.set_field_from_activity(
-                instance,
-                self,
-                save=save,
-                overwrite=overwrite,
-                allow_external_connections=allow_external_connections,
-            )
-            if changed:
-                update_fields.append(field.name)
+            if not save:
+                return instance
 
-        if not save:
-            return instance
-
-        with transaction.atomic():
-            # can't force an update on fields unless the object already exists in the db
-            if not instance.id:
-                update_fields = None
-            # we can't set many to many and reverse fields on an unsaved object
-            try:
+            with transaction.atomic():
+                # can't force an update on fields unless the object already exists in the db
+                if not instance.id:
+                    update_fields = None
+                # we can't set many to many and reverse fields on an unsaved object
                 try:
-                    instance.save(broadcast=False, update_fields=update_fields)
-                except TypeError:
-                    instance.save(update_fields=update_fields)
-            except IntegrityError as e:
-                raise ActivitySerializerError(e)
+                    try:
+                        instance.save(broadcast=False, update_fields=update_fields)
+                    except TypeError:
+                        instance.save(update_fields=update_fields)
+                except IntegrityError as e:
+                    raise ActivitySerializerError(e)
 
-            # add many to many fields, which have to be set post-save
-            for field in instance.many_to_many_fields:
-                # mention books/users/hashtags, for example
-                field.set_field_from_activity(
-                    instance,
-                    self,
-                    allow_external_connections=allow_external_connections,
-                )
+                # add many to many fields, which have to be set post-save
+                for field in instance.many_to_many_fields:
+                    # mention books/users/hashtags, for example
+                    field.set_field_from_activity(
+                        instance,
+                        self,
+                        allow_external_connections=allow_external_connections,
+                    )
 
-        # reversed relationships in the models
-        for (
-            model_field_name,
-            activity_field_name,
-        ) in instance.deserialize_reverse_fields:
-            # attachments on Status, for example
-            values = getattr(self, activity_field_name)
-            if values is None or values is MISSING:
-                continue
-
-            model_field = getattr(model, model_field_name)
-            # creating a Work, model_field is 'editions'
-            # creating a User, model field is 'key_pair'
-            related_model = model_field.field.model
-            related_field_name = model_field.field.name
-
-            for item in values:
-                if trigger and item == trigger.remote_id:
+            # reversed relationships in the models
+            for (
+                model_field_name,
+                activity_field_name,
+            ) in instance.deserialize_reverse_fields:
+                # attachments on Status, for example
+                values = getattr(self, activity_field_name)
+                if values is None or values is MISSING:
                     continue
-                set_related_field.delay(
-                    related_model.__name__,
-                    instance.__class__.__name__,
-                    related_field_name,
-                    instance.remote_id,
-                    item,
-                )
-        return instance
+
+                model_field = getattr(model, model_field_name)
+                # creating a Work, model_field is 'editions'
+                # creating a User, model field is 'key_pair'
+                related_model = model_field.field.model
+                related_field_name = model_field.field.name
+
+                for item in values:
+                    if trigger and item == trigger.remote_id:
+                        continue
+                    set_related_field.delay(
+                        related_model.__name__,
+                        instance.__class__.__name__,
+                        related_field_name,
+                        instance.remote_id,
+                        item,
+                    )
+            return instance
 
     def serialize(self, **kwargs):
         """convert to dictionary with context attr"""

--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -25,6 +25,7 @@ from bookwyrm.settings import (
     DOMAIN,
     INSTANCE_ACTOR_USERNAME,
     USER_AGENT,
+    QUERY_TIMEOUT,
     SEARCH_TIMEOUT,
 )
 from bookwyrm.tasks import app, MISC
@@ -56,18 +57,18 @@ def item_lock(object_id):
     except AttributeError:
         raise ActivitySerializerError("Incoming object has no identifier")
     lock_id = f"lock:{id_hash}"
-    # expire after 10 minutes in case something goes wrong
-    expire_seconds = time.monotonic() + 600
+    # expire after enough time to make up to ~59 queries
+    expire_seconds = time.monotonic() + (QUERY_TIMEOUT * 60)
     # try to get the lock until you have it or it has (nearly) expired
     while time.monotonic() < expire_seconds - 5:
         # 1: arbitrary value for the key
         # nx: only set if the key doesn't already exist
         # ex: expire after this many seconds
-        if lock := r.set(lock_id, "1", nx=True, ex=600):
+        if lock := r.set(lock_id, "1", nx=True, ex=QUERY_TIMEOUT * 60):
             break
 
-        # if we don't have the lock, try again in 5 to 10 seconds
-        sleep_time = random.randint(5, 10)
+        # if we don't have the lock, try again in a few seconds
+        sleep_time = random.randint(1, QUERY_TIMEOUT)
         time.sleep(sleep_time)
 
     if not lock:

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -140,20 +140,7 @@ class ActivitypubMixin:
         if len(recipients) == 0:
             return
 
-        # if we're posting about ShelfBooks, set a delay to give the base activity
-        # time to add the book on remote servers first to avoid race conditions
-        countdown = (
-            10
-            if (
-                isinstance(activity, dict)
-                and not isinstance(activity["object"], str)
-                and not isinstance(activity["object"], list)
-                and activity["object"].get("type", None) in ["GeneratedNote", "Comment"]
-            )
-            else 0
-        )
         broadcast_task.apply_async(
-            countdown=countdown,
             args=(
                 sender.id,
                 json.dumps(activity, cls=activitypub.ActivityEncoder),

--- a/bookwyrm/tests/activitypub/test_base_activity.py
+++ b/bookwyrm/tests/activitypub/test_base_activity.py
@@ -1,5 +1,6 @@
 """tests the base functionality for activitypub dataclasses"""
 
+from hashlib import md5
 import json
 import pathlib
 from unittest.mock import patch
@@ -17,6 +18,7 @@ from bookwyrm.activitypub.base_activity import (
     set_related_field,
     get_representative,
     get_activitypub_data,
+    item_lock
 )
 from bookwyrm.activitypub import ActivitySerializerError
 from bookwyrm import models
@@ -352,3 +354,67 @@ class BaseActivity(TestCase):
         # should log nothing if we only want to log errors
         with self.assertNoLogs(logger=None, level="ERROR") as logger:
             resolved = resolve_remote_id("https://example.com/user/mouse")
+
+
+    @patch("bookwyrm.activitypub.base_activity.r.set")
+    @patch("bookwyrm.activitypub.base_activity.time.sleep")
+    def test_mutex_lock(self, mock_sleep, mock_set, *_):
+        """test the mutex lock is called"""
+
+        with item_lock("https://example.com") as locked:
+            self.assertTrue(locked)
+            self.assertTrue(mock_set.called)
+            self.assertEqual(mock_set.call_count, 1)
+            self.assertEqual(mock_set.call_args.args, ("lock:c984d06aafbecf6bc55569f964148ea3", "1"))
+            self.assertEqual(mock_set.call_args.kwargs, {"nx": True, "ex": 300})
+
+
+
+    @patch("bookwyrm.activitypub.base_activity.r.set")
+    @patch("bookwyrm.activitypub.base_activity.r.delete")
+    @patch("bookwyrm.activitypub.base_activity.time.sleep")
+    def test_mutex_lock_is_locked_and_released(self, mock_sleep, mock_delete, mock_set, *_):
+        """test mutex lock causes a pause and then releases when free"""
+
+        mock_set.side_effect = [None,"OK"]
+
+        with item_lock("testtest") as locked:
+            self.assertTrue(locked)
+
+        self.assertTrue(mock_set.called)
+        self.assertTrue(mock_sleep.called)
+        self.assertTrue(mock_sleep.call_count, 1)
+        self.assertEqual(mock_set.call_count, 2)
+        self.assertTrue(mock_delete.called)
+
+
+    @patch("bookwyrm.activitypub.base_activity.r.set")
+    @patch("bookwyrm.activitypub.base_activity.r.delete")
+    @patch("bookwyrm.activitypub.base_activity.time.sleep")
+    @patch("bookwyrm.activitypub.base_activity.time.monotonic")
+    def test_mutex_lock_expires(self, mock_time, mock_sleep, mock_delete, mock_set, *_):
+        """test mutex lock is released if it takes too long"""
+
+        mock_time.side_effect = [1000.0, 1000.0, 1000.0, 1000.0, 2000]
+        mock_set.return_value = None
+
+        with self.assertRaises(ActivitySerializerError) as raises:
+            with item_lock("blhblahl") as lock:
+                pass
+
+        self.assertTrue(mock_set.called)
+        self.assertTrue(mock_sleep.call_count, 3)
+        self.assertEqual(mock_set.call_count, 3)
+        self.assertFalse(mock_delete.called)
+
+        self.assertEqual(raises.exception.args, ("Lock expired on blhblahl before being acquired",))
+
+    @patch("bookwyrm.activitypub.base_activity.time.sleep")
+    def test_mutex_lock_null_id(self, *_):
+        """test the mutex lock raises error when id is null"""
+
+        with self.assertRaises(ActivitySerializerError) as raises:
+            with item_lock(None) as lock:
+                pass
+
+        self.assertEqual(raises.exception.args, ("Incoming object has no identifier",))

--- a/bookwyrm/tests/activitypub/test_base_activity.py
+++ b/bookwyrm/tests/activitypub/test_base_activity.py
@@ -1,6 +1,5 @@
 """tests the base functionality for activitypub dataclasses"""
 
-from hashlib import md5
 import json
 import pathlib
 from unittest.mock import patch
@@ -18,7 +17,7 @@ from bookwyrm.activitypub.base_activity import (
     set_related_field,
     get_representative,
     get_activitypub_data,
-    item_lock
+    item_lock,
 )
 from bookwyrm.activitypub import ActivitySerializerError
 from bookwyrm import models
@@ -355,7 +354,6 @@ class BaseActivity(TestCase):
         with self.assertNoLogs(logger=None, level="ERROR") as logger:
             resolved = resolve_remote_id("https://example.com/user/mouse")
 
-
     @patch("bookwyrm.activitypub.base_activity.r.set")
     @patch("bookwyrm.activitypub.base_activity.time.sleep")
     def test_mutex_lock(self, mock_sleep, mock_set, *_):
@@ -365,18 +363,20 @@ class BaseActivity(TestCase):
             self.assertTrue(locked)
             self.assertTrue(mock_set.called)
             self.assertEqual(mock_set.call_count, 1)
-            self.assertEqual(mock_set.call_args.args, ("lock:c984d06aafbecf6bc55569f964148ea3", "1"))
+            self.assertEqual(
+                mock_set.call_args.args, ("lock:c984d06aafbecf6bc55569f964148ea3", "1")
+            )
             self.assertEqual(mock_set.call_args.kwargs, {"nx": True, "ex": 300})
-
-
 
     @patch("bookwyrm.activitypub.base_activity.r.set")
     @patch("bookwyrm.activitypub.base_activity.r.delete")
     @patch("bookwyrm.activitypub.base_activity.time.sleep")
-    def test_mutex_lock_is_locked_and_released(self, mock_sleep, mock_delete, mock_set, *_):
+    def test_mutex_lock_is_locked_and_released(
+        self, mock_sleep, mock_delete, mock_set, *_
+    ):
         """test mutex lock causes a pause and then releases when free"""
 
-        mock_set.side_effect = [None,"OK"]
+        mock_set.side_effect = [None, "OK"]
 
         with item_lock("testtest") as locked:
             self.assertTrue(locked)
@@ -386,7 +386,6 @@ class BaseActivity(TestCase):
         self.assertTrue(mock_sleep.call_count, 1)
         self.assertEqual(mock_set.call_count, 2)
         self.assertTrue(mock_delete.called)
-
 
     @patch("bookwyrm.activitypub.base_activity.r.set")
     @patch("bookwyrm.activitypub.base_activity.r.delete")
@@ -399,7 +398,7 @@ class BaseActivity(TestCase):
         mock_set.return_value = None
 
         with self.assertRaises(ActivitySerializerError) as raises:
-            with item_lock("blhblahl") as lock:
+            with item_lock("blhblahl"):
                 pass
 
         self.assertTrue(mock_set.called)
@@ -407,14 +406,16 @@ class BaseActivity(TestCase):
         self.assertEqual(mock_set.call_count, 3)
         self.assertFalse(mock_delete.called)
 
-        self.assertEqual(raises.exception.args, ("Lock expired on blhblahl before being acquired",))
+        self.assertEqual(
+            raises.exception.args, ("Lock expired on blhblahl before being acquired",)
+        )
 
     @patch("bookwyrm.activitypub.base_activity.time.sleep")
     def test_mutex_lock_null_id(self, *_):
         """test the mutex lock raises error when id is null"""
 
         with self.assertRaises(ActivitySerializerError) as raises:
-            with item_lock(None) as lock:
+            with item_lock(None):
                 pass
 
         self.assertEqual(raises.exception.args, ("Incoming object has no identifier",))

--- a/bookwyrm/tests/conftest.py
+++ b/bookwyrm/tests/conftest.py
@@ -1,0 +1,14 @@
+"""test override fixtures"""
+
+import fakeredis
+import pytest
+from unittest import mock
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fake_redis():
+    """use fake redis server to avoid problems testing anything use to_model()"""
+    with mock.patch(
+        "bookwyrm.activitypub.base_activity.r", fakeredis.FakeRedis()
+    ) as _fakeredis:
+        yield _fakeredis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ main = [
 dev = [
     "celery-types==0.22.0",
     "django-stubs[compatible-mypy]==4.2.7",
+    "fakeredis==2.37.0",
     "mypy==1.7.1",
     "ruff==0.14.7",
     "pytest==9.0.3",


### PR DESCRIPTION
## Description
Adds a [mutex lock](https://en.wikipedia.org/wiki/Lock_(computer_science)) on every object processed by to_model. This should have a negligible impact on most items but will block processing on any activity object where an incoming object with the same remote ID is currently being processed until the first one releases the lock.

This is intended to fix the problem described in #4062 and partially addressed in #3471 where reading activities with statuses cause two near-simultaneous broadcasts referring to the same external edition. This seems to be at the core of our problem with duplicate identical editions, works, and possible series and authors, as well as many childless works.

### caveats

1. I've never done anything with mutex locks before so there might be a better way to do this. This proposal is based on [the Celery docs](https://docs.celeryq.dev/en/stable/tutorials/task-cookbook.html) plus some web searching to understand that example and for different approaches. Maybe it doesn't work the way I think. Maybe it doesn't work at all! ~I'm not sure how to run tests against it~ - suggestions very welcome.
2. ~There is a failing test and I have no idea why it is failing, or whether the failure is directly related to this code, but it might be.~
3. If an incoming object doesn't have a discernable URI it will throw an error
4. If the first item takes longer than ~10~ ~5 minutes to process the lock will release. Note that this is ~10 minutes~ from the point it first starts running `to_model`, not ~10 minutes~ from when it is received and added to a processing queue.

- Related Issue #
- Closes #4062

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [x] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
