### PR TITLE
container: mark released tag as latest instead of tag

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -12,6 +12,9 @@ on:
     branches: ["main"]
     tags:
       - v*
+  release:
+    types:
+      - released
   workflow_dispatch:
     inputs:
       tag:
@@ -52,7 +55,7 @@ jobs:
         type=semver,pattern=v{{version}}
         type=ref,event=branch
       meta-flavor: |
-        latest=${{ startsWith(github.ref, 'refs/tags/') }}
+        latest=${{ github.event_name == 'release' }}
       set-meta-labels: true
       set-meta-annotations: true
     secrets:


### PR DESCRIPTION
## Description

Allows to tag/pre-releases without `:latest` changing, when release is made, `:latest` is updated to that tag.

- Related Issue #
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [X] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
