### PR TITLE
Stop importers from mutating the shared row mappings list

### DIFF
--- a/bookwyrm/importers/openlibrary_import.py
+++ b/bookwyrm/importers/openlibrary_import.py
@@ -1,7 +1,5 @@
 """handle reading a csv from openlibrary"""
 
-from typing import Any
-
 from . import Importer
 
 
@@ -10,7 +8,7 @@ class OpenLibraryImporter(Importer):
 
     service = "OpenLibrary"
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        self.row_mappings_guesses.append(("openlibrary_key", ["edition id"]))
-        self.row_mappings_guesses.append(("openlibrary_work_key", ["work id"]))
-        super().__init__(*args, **kwargs)
+    row_mappings_guesses = Importer.row_mappings_guesses + [
+        ("openlibrary_key", ["edition id"]),
+        ("openlibrary_work_key", ["work id"]),
+    ]

--- a/bookwyrm/importers/openreads_import.py
+++ b/bookwyrm/importers/openreads_import.py
@@ -1,6 +1,6 @@
 """handle reading a csv from openreads"""
 
-from typing import Any, Optional
+from typing import Optional
 from datetime import datetime
 from bookwyrm.models import Shelf
 
@@ -19,13 +19,13 @@ class OpenReadsImporter(Importer):
 
     service = "OpenReads"
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        self.row_mappings_guesses.append(("openlibrary_key", ["olid"]))
-        self.row_mappings_guesses.append(("pages", ["pages"]))
-        self.row_mappings_guesses.append(("description", ["description"]))
-        self.row_mappings_guesses.append(("physical_format", ["book_format"]))
-        self.row_mappings_guesses.append(("published_date", ["publication_year"]))
-        super().__init__(*args, **kwargs)
+    row_mappings_guesses = Importer.row_mappings_guesses + [
+        ("openlibrary_key", ["olid"]),
+        ("pages", ["pages"]),
+        ("description", ["description"]),
+        ("physical_format", ["book_format"]),
+        ("published_date", ["publication_year"]),
+    ]
 
     def normalize_row(
         self, entry: dict[str, str], mappings: dict[str, Optional[str]]

--- a/bookwyrm/tests/importers/test_openlibrary_import.py
+++ b/bookwyrm/tests/importers/test_openlibrary_import.py
@@ -77,6 +77,12 @@ class OpenLibraryImport(TestCase):
         self.assertEqual(import_items[2].normalized_data["shelf"], "to-read")
         self.assertEqual(import_items[3].normalized_data["shelf"], "read")
 
+    def test_repeat_instantiation_does_not_duplicate_row_mappings(self, *_):
+        OpenLibraryImporter()
+        OpenLibraryImporter()
+        keys = [key for key, _ in OpenLibraryImporter.row_mappings_guesses]
+        self.assertEqual(len(keys), len(set(keys)))
+
     def test_handle_imported_book(self, *_):
         """openlibrary import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(

--- a/bookwyrm/tests/importers/test_openreads_import.py
+++ b/bookwyrm/tests/importers/test_openreads_import.py
@@ -193,6 +193,12 @@ class OpenReadsImport(TestCase):
         self.assertEqual(review.published_date, make_date(2023, 11, 15))
         self.assertEqual(review.privacy, "unlisted")
 
+    def test_repeat_instantiation_does_not_duplicate_row_mappings(self, *_):
+        OpenReadsImporter()
+        OpenReadsImporter()
+        keys = [key for key, _ in OpenReadsImporter.row_mappings_guesses]
+        self.assertEqual(len(keys), len(set(keys)))
+
     def test_get_shelf_prefers_reading_dates(self, *_):
         """a recorded finish/start date wins over the shelf column"""
         self.assertEqual(


### PR DESCRIPTION
## Description

Each import request creates a new importer, and their `self.row_mappings_guesses.append` calls append to `Importer.row_mappings_guesses`, a class attribute so the shared list keeps growing with duplicated entries for the life of the worker process.

## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [x] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
