### PR TITLE
Fix race condition in the export cleanup task counter

### DIFF
--- a/bookwyrm/models/housekeeping.py
+++ b/bookwyrm/models/housekeeping.py
@@ -7,6 +7,7 @@ from itertools import chain
 from django.db.models import (
     CharField,
     DateTimeField,
+    F,
     IntegerField,
     ManyToManyField,
     TextChoices,
@@ -71,9 +72,8 @@ class CleanUpExportsTask(ParentTask):
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """Handler called after the task returns"""
 
+        CleanUpUserExportFilesJob.objects.filter(id=kwargs["job_id"]).update(completed_tasks=F("completed_tasks") + 1)
         job = CleanUpUserExportFilesJob.objects.get(id=kwargs["job_id"])
-        job.completed_tasks += 1
-        job.save(update_fields=["completed_tasks"])
 
         if job.completed_tasks == job.tasks:
             job.complete_job()

--- a/bookwyrm/models/housekeeping.py
+++ b/bookwyrm/models/housekeeping.py
@@ -72,7 +72,9 @@ class CleanUpExportsTask(ParentTask):
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """Handler called after the task returns"""
 
-        CleanUpUserExportFilesJob.objects.filter(id=kwargs["job_id"]).update(completed_tasks=F("completed_tasks") + 1)
+        CleanUpUserExportFilesJob.objects.filter(id=kwargs["job_id"]).update(
+            completed_tasks=F("completed_tasks") + 1
+        )
         job = CleanUpUserExportFilesJob.objects.get(id=kwargs["job_id"])
 
         if job.completed_tasks == job.tasks:

--- a/bookwyrm/models/housekeeping.py
+++ b/bookwyrm/models/housekeeping.py
@@ -4,10 +4,10 @@ import math
 from datetime import datetime, timedelta, timezone
 from itertools import chain
 
+from django.db import transaction
 from django.db.models import (
     CharField,
     DateTimeField,
-    F,
     IntegerField,
     ManyToManyField,
     TextChoices,
@@ -72,12 +72,15 @@ class CleanUpExportsTask(ParentTask):
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """Handler called after the task returns"""
 
-        CleanUpUserExportFilesJob.objects.filter(id=kwargs["job_id"]).update(
-            completed_tasks=F("completed_tasks") + 1
-        )
-        job = CleanUpUserExportFilesJob.objects.get(id=kwargs["job_id"])
+        with transaction.atomic():
+            job = CleanUpUserExportFilesJob.objects.select_for_update().get(
+                id=kwargs["job_id"]
+            )
+            job.completed_tasks += 1
+            job.save(update_fields=["completed_tasks"])
+            is_finished = job.completed_tasks == job.tasks
 
-        if job.completed_tasks == job.tasks:
+        if is_finished:
             job.complete_job()
 
 

--- a/bookwyrm/tests/models/test_housekeeping.py
+++ b/bookwyrm/tests/models/test_housekeeping.py
@@ -1,5 +1,6 @@
 """test file management"""
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from os import listdir
 import pathlib
@@ -9,7 +10,7 @@ from PIL import Image
 import responses
 
 from django.core.files.base import ContentFile
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 from bookwyrm.book_search import SearchResult
 from bookwyrm.models import (
@@ -25,6 +26,7 @@ from bookwyrm.models import (
     Work,
 )
 from bookwyrm.models.housekeeping import (
+    CleanUpExportsTask,
     FindMissingCoversJob,
     get_cover_from_identifiers,
     get_covers_with_incorrect_filepaths,
@@ -127,6 +129,45 @@ class TestCleanUpExportFiles(TestCase):
         for filename in listdir("exports"):
             if "zzz_testfile.tar" in filename:
                 pathlib.Path(f"exports/{filename}").unlink(missing_ok=True)
+
+
+class TestCleanUpExportsTask(TransactionTestCase):
+    """the task reports its completion back to the job"""
+
+    def setUp(self):
+        with (
+            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
+            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
+            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
+        ):
+            self.user = User.objects.create_user(
+                f"mouse@{DOMAIN}",
+                "mouse@mouse.mouse",
+                "mouseword",
+                local=True,
+                localname="mouse",
+            )
+            SiteSettings.objects.create()
+
+        self.job = CleanUpUserExportFilesJob.objects.create(
+            user=self.user,
+            expiry_date=datetime.now(timezone.utc) - timedelta(hours=2),
+            tasks=10,
+        )
+
+    def test_concurrent_task_returns_complete_the_job_once(self):
+        def report_completion(_):
+            CleanUpExportsTask().after_return(
+                None, None, None, None, {"job_id": self.job.id}, None
+            )
+
+        with patch.object(CleanUpUserExportFilesJob, "complete_job") as complete_job:
+            with ThreadPoolExecutor(max_workers=10) as pool:
+                list(pool.map(report_completion, range(10)))
+
+        self.job.refresh_from_db()
+        self.assertEqual(self.job.completed_tasks, 10)
+        complete_job.assert_called_once()
 
 
 class Covers(TestCase):


### PR DESCRIPTION
## Description


- Closes https://github.com/bookwyrm-social/bookwyrm/issues/4006

When multiple deletion tasks finished concurrently, updates to `completed_tasks` could overwrite each other. This meant the cleanup job could show incomplete progress indefinitely even though every file deletion had succeeded.

This changes the progress update to use a database-side atomic increment, ensuring every completed deletion task is counted.

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
