### PR TITLE
Explain how to select half-star ratings

### DIFF
--- a/bookwyrm/templates/snippets/form_rate_stars.html
+++ b/bookwyrm/templates/snippets/form_rate_stars.html
@@ -25,6 +25,7 @@
                 type="radio"
                 name="rating"
                 value="{{ forloop.counter0 }}.5"
+                aria-describedby="half_star_help_{{ type|default:'rating'|slugify }}_book{{ book.id }}"
                 {% if default_rating > 0 and default_rating > forloop.counter0 %}checked{% endif %}
             />
             <label for="{{ type|slugify }}_book{{ book.id }}_star_{{ forloop.counter }}">
@@ -42,6 +43,7 @@
                 type="radio"
                 name="rating"
                 value="{{ forloop.counter }}"
+                aria-describedby="half_star_help_{{ type|default:'rating'|slugify }}_book{{ book.id }}"
                 {% if default_rating >= forloop.counter %}checked{% endif %}
             />
         </div>
@@ -61,4 +63,7 @@
     </div>
     {% endfor %}
 </div>
+<p class="help" id="half_star_help_{{ type|default:'rating'|slugify }}_book{{ book.id }}">
+    {% trans "Select the left half of a star for a half-star rating." %}
+</p>
 {% endspaceless %}

--- a/bookwyrm/tests/templatetags/test_rating_tags.py
+++ b/bookwyrm/tests/templatetags/test_rating_tags.py
@@ -1,11 +1,29 @@
 """Gettings book ratings"""
 
+from unittest import TestCase as UnitTestCase
 from unittest.mock import patch
 
+from django.template.loader import render_to_string
 from django.test import TestCase
 
 from bookwyrm import models
 from bookwyrm.templatetags import rating_tags
+
+
+class RatingTemplateTests(UnitTestCase):
+    """tests for rating form templates"""
+
+    def test_rating_form_explains_half_stars(self):
+        """the rating control explains how to select half stars"""
+        result = render_to_string(
+            "snippets/form_rate_stars.html",
+            {"book": {"id": 42}, "type": "review"},
+        )
+
+        help_id = "half_star_help_review_book42"
+        self.assertIn("Select the left half of a star for a half-star rating.", result)
+        self.assertEqual(result.count(f'aria-describedby="{help_id}"'), 10)
+        self.assertIn(f'id="{help_id}"', result)
 
 
 @patch("bookwyrm.activitystreams.add_status_task.delay")


### PR DESCRIPTION
## Description

Adds a visible hint explaining that selecting the left half of a star creates a half-star rating. Each rating input references the hint with `aria-describedby`, making the guidance available to assistive technology as well.

- Related Issue #3581
- Closes #3581

Fixes bookwyrm-social/bookwyrm#3581

## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

N/A

## Documentation

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged
- [x] No documentation changes are required

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them

Validation:

- `pytest -q bookwyrm/tests/templatetags/test_rating_tags.py::RatingTemplateTests::test_rating_form_explains_half_stars --no-cov`
- `ruff format --check bookwyrm/tests/templatetags/test_rating_tags.py`
- `ruff check bookwyrm/tests/templatetags/test_rating_tags.py`
- `git diff --check`
