### PR TITLE
compose: add healthcheck to redis instances and wait for them

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,13 +114,21 @@ services:
       db:
         condition: service_healthy
       redis_activity:
-        condition: service_started
+        condition: service_healthy
     networks:
       - main
   redis_activity:
     image: redis:7.2.1
     command: redis-server --requirepass ${REDIS_ACTIVITY_PASSWORD} --appendonly yes --port ${REDIS_ACTIVITY_PORT}
     logging: *default-logging
+    environment:
+      REDISCLI_AUTH: ${REDIS_ACTIVITY_PASSWORD}
+    healthcheck:
+      test: redis-cli ping|grep PONG
+      interval: 3s
+      timeout: 1s
+      start_period: 1s
+      retries: 60
     volumes:
       - ./redis.conf:/etc/redis/redis.conf
       - redis_activity_data:/data
@@ -132,6 +140,14 @@ services:
     image: redis:7.2.1
     command: redis-server --requirepass ${REDIS_BROKER_PASSWORD} --appendonly yes --port ${REDIS_BROKER_PORT}
     logging: *default-logging
+    environment:
+      REDISCLI_AUTH: ${REDIS_BROKER_PASSWORD}
+    healthcheck:
+      test: redis-cli ping|grep PONG
+      interval: 3s
+      timeout: 1s
+      start_period: 1s
+      retries: 60
     volumes:
       - ./redis.conf:/etc/redis/redis.conf
       - redis_broker_data:/data
@@ -161,7 +177,7 @@ services:
       db:
         condition: service_healthy
       redis_broker:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
   celery_beat:
     env_file: .env
@@ -201,7 +217,7 @@ services:
       db:
         condition: service_healthy
       redis_broker:
-        condition: service_started
+        condition: service_healthy
       web:
         condition: service_healthy
     restart: unless-stopped


### PR DESCRIPTION

## Description
In case activity takes some time to load itself to be ready it returns 'LOADING' instead of PONG. By default we wait few minutes until defining things unhealthy. Not sure what is reasonable amount to wait in bigger instances.


- Related Issue #3929 
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [X] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
