### PR TITLE
connectors: rate-limit connector status updates

### DIFF
--- a/bookwyrm/connectors/abstract_connector.py
+++ b/bookwyrm/connectors/abstract_connector.py
@@ -100,7 +100,7 @@ class AbstractMinimalConnector(ABC):
         try:
             async with (
                 session.get(url, headers=headers, params=params) as response,
-                redis.from_url(REDIS_ACTIVITY_URL) as r,
+                redis.from_url(REDIS_ACTIVITY_URL) as r,  # type: ignore[no-untyped-call]
             ):
                 if not response.ok:
                     if await r.set(
@@ -137,7 +137,9 @@ class AbstractMinimalConnector(ABC):
                     ),
                 )
         except asyncio.TimeoutError:
-            async with redis.from_url(REDIS_ACTIVITY_URL) as r:
+            async with redis.from_url(  # type: ignore[no-untyped-call]
+                REDIS_ACTIVITY_URL
+            ) as r:
                 if await r.set(
                     error_ratelimit_key, "1", nx=True, ex=CONNECTOR_STATUS_RATE
                 ):
@@ -146,7 +148,9 @@ class AbstractMinimalConnector(ABC):
                     )
             logger.info("Connection timed out for url: %s", url)
         except aiohttp.ClientError as err:
-            async with redis.from_url(REDIS_ACTIVITY_URL) as r:
+            async with redis.from_url(  # type: ignore[no-untyped-call]
+                REDIS_ACTIVITY_URL
+            ) as r:
                 if await r.set(
                     error_ratelimit_key, "1", nx=True, ex=CONNECTOR_STATUS_RATE
                 ):

--- a/bookwyrm/connectors/abstract_connector.py
+++ b/bookwyrm/connectors/abstract_connector.py
@@ -10,6 +10,7 @@ import re
 import asyncio
 from PIL import Image, UnidentifiedImageError
 import requests
+import redis.asyncio as redis
 from requests.exceptions import RequestException
 import aiohttp
 
@@ -20,7 +21,7 @@ from django.db import transaction
 from django.db.models import Subquery
 
 from bookwyrm import activitypub, models, settings
-from bookwyrm.settings import USER_AGENT, INSTANCE_ACTOR_USERNAME
+from bookwyrm.settings import USER_AGENT, INSTANCE_ACTOR_USERNAME, REDIS_ACTIVITY_URL
 from bookwyrm.tasks import app, CONNECTORS
 from .connector_manager import load_more_data, ConnectorException, raise_not_valid_url
 from .format_mappings import format_mappings
@@ -28,7 +29,10 @@ from ..book_search import SearchResult
 
 logger = logging.getLogger(__name__)
 
+
 JsonDict = dict[str, Any]
+
+CONNECTOR_STATUS_RATE = 60  # once per 60s error or ok
 
 
 class ConnectorResults(TypedDict):
@@ -91,27 +95,41 @@ class AbstractMinimalConnector(ABC):
             "User-Agent": USER_AGENT,
         }
         params = {"min_confidence": str(min_confidence)}
+        error_ratelimit_key = f"connector:error:{self.connector.pk}"
+        success_ratelimit_key = f"connector:success:{self.connector.pk}"
         try:
-            async with session.get(url, headers=headers, params=params) as response:
+            async with (
+                session.get(url, headers=headers, params=params) as response,
+                redis.from_url(REDIS_ACTIVITY_URL) as r,
+            ):
                 if not response.ok:
-                    update_connector_status.delay(
-                        self.connector.pk,
-                        f"Unable to connect to {url}: {response.reason}",
-                    )
+                    if await r.set(
+                        error_ratelimit_key, "1", nx=True, ex=CONNECTOR_STATUS_RATE
+                    ):
+                        update_connector_status.delay(
+                            self.connector.pk,
+                            f"Unable to connect to {url}: {response.reason}",
+                        )
                     logger.info("Unable to connect to %s: %s", url, response.reason)
                     return None
 
                 try:
                     raw_data = await response.json()
                 except aiohttp.client_exceptions.ContentTypeError as err:
-                    update_connector_status.delay(
-                        self.connector.pk, f"ContentType Error: {str(err)}"
-                    )
+                    if await r.set(
+                        error_ratelimit_key, "1", nx=True, ex=CONNECTOR_STATUS_RATE
+                    ):
+                        update_connector_status.delay(
+                            self.connector.pk, f"ContentType Error: {str(err)}"
+                        )
                     logger.exception(err)
 
                     return None
 
-                update_connector_status.delay(self.connector.id)
+                if await r.set(
+                    success_ratelimit_key, "1", nx=True, ex=CONNECTOR_STATUS_RATE
+                ):
+                    update_connector_status.delay(self.connector.id)
                 return ConnectorResults(
                     connector=self,
                     results=self.process_search_response(
@@ -119,14 +137,22 @@ class AbstractMinimalConnector(ABC):
                     ),
                 )
         except asyncio.TimeoutError:
-            update_connector_status.delay(
-                self.connector.pk, f"Timed out for url: {url}"
-            )
+            async with redis.from_url(REDIS_ACTIVITY_URL) as r:
+                if await r.set(
+                    error_ratelimit_key, "1", nx=True, ex=CONNECTOR_STATUS_RATE
+                ):
+                    update_connector_status.delay(
+                        self.connector.pk, f"Timed out for url: {url}"
+                    )
             logger.info("Connection timed out for url: %s", url)
         except aiohttp.ClientError as err:
-            update_connector_status.delay(
-                self.connector.pk, f"Client Error: {str(err)}"
-            )
+            async with redis.from_url(REDIS_ACTIVITY_URL) as r:
+                if await r.set(
+                    error_ratelimit_key, "1", nx=True, ex=CONNECTOR_STATUS_RATE
+                ):
+                    update_connector_status.delay(
+                        self.connector.pk, f"Client Error: {str(err)}"
+                    )
             logger.info(err)
         return None
 

--- a/bookwyrm/tests/connectors/test_connector_manager.py
+++ b/bookwyrm/tests/connectors/test_connector_manager.py
@@ -1,13 +1,33 @@
 """interface between the app and various connectors"""
 
 from django.test import TestCase
+import fakeredis
+import pytest
 import responses
+from unittest import mock
 
 from bookwyrm import models
 from bookwyrm.connectors import connector_manager
 from bookwyrm.connectors.bookwyrm_connector import Connector as BookWyrmConnector
 
 
+@pytest.fixture(autouse=True)
+def fake_aredis(settings):
+    """use fake redis server to avoid problems testing anything use to_model()"""
+    with (
+        mock.patch(
+            "bookwyrm.connectors.abstract_connector.redis",
+            fakeredis.FakeAsyncRedis,
+        ) as _fakeredis,
+        mock.patch(
+            "bookwyrm.connectors.abstract_connector.REDIS_ACTIVITY_URL",
+            "redis://activity:6379/0",
+        ) as _fakeredis,
+    ):
+        yield _fakeredis
+
+
+@pytest.mark.usefixtures("fake_aredis")
 class ConnectorManager(TestCase):
     """interface between the app and various connectors"""
 


### PR DESCRIPTION
## Description

Add simple redis-based rate-limiting for connector status update celery-tasks, send one per 60 seconds, as high resolution updates are not useful in admin point of view or celery worker workload point of view.

Not sure if it is good idea to take new connection in exceptions, but I didn't want to wrap the whole function in another async with block.

- Related Issue #
- Closes #4096 

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [X] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
