### PR TITLE
fix: build the shelf RSS alternate link from the path only

### DIFF
--- a/bookwyrm/templates/shelf/shelf.html
+++ b/bookwyrm/templates/shelf/shelf.html
@@ -14,7 +14,7 @@
 
 
 {% block head_links %}
-    <link rel="alternate" type="application/rss+xml" href="{{ request.get_full_path }}/rss" title="{{ user.display_name }} - {{ shelf.name }}" />
+    <link rel="alternate" type="application/rss+xml" href="{{ request.path }}/rss" title="{{ user.display_name }} - {{ shelf.name }}" />
 {% endblock %}
 
 {% block content %}

--- a/bookwyrm/tests/views/shelf/test_shelf.py
+++ b/bookwyrm/tests/views/shelf/test_shelf.py
@@ -146,6 +146,33 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
+    def test_shelf_page_rss_link_ignores_query_string(self):
+        """the RSS alternate link must use the path only: with the query
+        string included, /rss lands after ?sort=..., crawlers fetch it as a
+        sort value ending in /rss and the feed link grows /rss forever
+        (#4105)"""
+        view = views.Shelf.as_view()
+        shelf = self.local_user.shelf_set.first()
+        request = self.factory.get(
+            f"/user/{self.local_user.localname}/books/{shelf.identifier}",
+            {"sort": "sort_title"},
+        )
+        request.user = self.local_user
+        with patch("bookwyrm.views.shelf.shelf.is_api_request") as is_api:
+            is_api.return_value = False
+            result = view(
+                request,
+                username=self.local_user.username,
+                shelf_identifier=shelf.identifier,
+            )
+        self.assertIsInstance(result, TemplateResponse)
+        html = result.render().content.decode()
+        self.assertIn(
+            f'href="/user/{self.local_user.localname}/books/{shelf.identifier}/rss"',
+            html,
+        )
+        self.assertNotIn("?sort=", html.split('rel="alternate"')[1].split("/>")[0])
+
     def test_shelf_page_sorted_rating(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Shelf.as_view()


### PR DESCRIPTION
Fixes #4105.

## Summary

The shelf template built the RSS `<link rel="alternate">` href with `request.get_full_path`, which **includes the query string**, so `/rss` was appended after it:

```
/user/USERNAME/books/read?sort=sort_title/rss
```

Fetching that URL gives the view a `sort` parameter that ends in `/rss`; the template then appends `/rss` again — an unbounded family of unique URLs. The report's nginx log shows requests carrying up to **380** `/rss` segments as a crawler walked the chain.

The fix uses `request.path` (the shelf feed URL itself is query-free — the feed does not consume `sort`), so the alternate link is simply:

```
/user/USERNAME/books/read/rss
```

## Testing

Added `test_shelf_page_rss_link_ignores_query_string` to `bookwyrm/tests/views/shelf/test_shelf.py`: renders a sorted shelf page (`?sort=sort_title`) and asserts the alternate link href is the plain `/user/<name>/books/<shelf>/rss` with no query string.

Note: I could not execute the Django suite locally (the project's settings require a PostgreSQL server, none available in this environment); the test follows the existing patterns in the same file (`test_shelf_page_sorted_shelved` next door) and runs under the project's CI.
