### PR TITLE
Allow users to delete completed imports from their import history

### DIFF
--- a/bookwyrm/templates/import/delete_import_modal.html
+++ b/bookwyrm/templates/import/delete_import_modal.html
@@ -1,0 +1,26 @@
+{% extends 'components/modal.html' %}
+{% load i18n %}
+
+{% block modal-title %}{% trans "Delete this import?" %}{% endblock %}
+
+{% block modal-body %}
+{% trans "This import will be removed from your import history. The books, reviews, and reading activity created by this import will not be deleted. This action cannot be un-done" %}
+{% endblock %}
+
+{% block modal-footer %}
+<form
+    name="delete-import-{{ job.id }}"
+    action="{% url 'import-delete' job.id %}"
+    method="POST"
+    class="is-flex-grow-1"
+>
+    {% csrf_token %}
+
+    <div class="buttons is-right">
+        <button type="button" class="button" data-modal-close>{% trans "Cancel" %}</button>
+        <button class="button is-danger" type="submit">
+            {% trans "Delete" %}
+        </button>
+    </div>
+</form>
+{% endblock %}

--- a/bookwyrm/templates/import/import_status.html
+++ b/bookwyrm/templates/import/import_status.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load humanize %}
 {% load static %}
+{% load utilities %}
 
 {% block title %}{% trans "Import Status" %}{% endblock %}
 
@@ -71,6 +72,14 @@
         {% csrf_token %}
         <button class="button is-danger" type="submit">{% trans "Stop import" %}</button>
     </form>
+    {% else %}
+    <div class="block">
+        <button class="button is-danger is-light" type="button" data-modal-open="delete_import_{{ job.id }}">
+            {% trans "Delete import" %}
+        </button>
+    </div>
+    {% join "delete_import" job.id as delete_import_modal_id %}
+    {% include 'import/delete_import_modal.html' with id=delete_import_modal_id job=job %}
     {% endif %}
 
     {% if manual_review_count and not legacy %}

--- a/bookwyrm/tests/views/imports/test_import.py
+++ b/bookwyrm/tests/views/imports/test_import.py
@@ -4,7 +4,9 @@ import datetime
 import pathlib
 from unittest.mock import patch
 
+from django.core.exceptions import PermissionDenied
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import Http404
 from django.template.response import TemplateResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -113,6 +115,89 @@ class ImportViews(TestCase):
         with patch("bookwyrm.models.import_job.import_item_task.delay") as mock:
             views.retry_item(request, job.id, item.id)
         self.assertEqual(mock.call_count, 1)
+
+    def test_import_status_complete(self):
+        """the status page of a completed import offers deletion"""
+        view = views.ImportStatus.as_view()
+        import_job = models.ImportJob.objects.create(
+            user=self.local_user,
+            status="complete",
+            complete=True,
+            mappings={},
+        )
+        request = self.factory.get("")
+        request.user = self.local_user
+
+        result = view(request, import_job.id)
+
+        self.assertIsInstance(result, TemplateResponse)
+        html = result.render().content.decode()
+        validate_html(result.render())
+        self.assertIn("Delete import", html)
+
+    def test_delete_import(self):
+        """remove a completed import from the import history"""
+        job = models.ImportJob.objects.create(
+            user=self.local_user,
+            status="complete",
+            complete=True,
+            mappings={},
+        )
+        models.ImportItem.objects.create(
+            index=0,
+            job=job,
+            data={},
+            normalized_data={},
+        )
+        request = self.factory.post("")
+        request.user = self.local_user
+
+        result = views.delete_import(request, job.id)
+
+        self.assertEqual(result.status_code, 302)
+        self.assertFalse(models.ImportJob.objects.filter(id=job.id).exists())
+        self.assertFalse(models.ImportItem.objects.filter(job__id=job.id).exists())
+
+    def test_delete_import_in_progress(self):
+        """incomplete imports can't be deleted, they have to be stopped first"""
+        job = models.ImportJob.objects.create(
+            user=self.local_user,
+            status="active",
+            mappings={},
+        )
+        request = self.factory.post("")
+        request.user = self.local_user
+
+        with self.assertRaises(PermissionDenied):
+            views.delete_import(request, job.id)
+        self.assertTrue(models.ImportJob.objects.filter(id=job.id).exists())
+
+    def test_delete_import_wrong_user(self):
+        """you can only delete your own imports"""
+        with (
+            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
+            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
+            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
+        ):
+            other_user = models.User.objects.create_user(
+                "rat@local.com",
+                "rat@rat.rat",
+                "password",
+                local=True,
+                localname="rat",
+            )
+        job = models.ImportJob.objects.create(
+            user=self.local_user,
+            status="complete",
+            complete=True,
+            mappings={},
+        )
+        request = self.factory.post("")
+        request.user = other_user
+
+        with self.assertRaises(Http404):
+            views.delete_import(request, job.id)
+        self.assertTrue(models.ImportJob.objects.filter(id=job.id).exists())
 
     def test_get_average_import_time_no_imports(self):
         """Give people a sense of the timing"""

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -546,6 +546,11 @@ urlpatterns = [
         name="import-stop",
     ),
     re_path(
+        r"^import/(?P<job_id>\d+)/delete/?$",
+        views.delete_import,
+        name="import-delete",
+    ),
+    re_path(
         r"^user-import/(?P<job_id>\d+)/stop/?$",
         views.stop_user_import,
         name="user-import-stop",

--- a/bookwyrm/views/__init__.py
+++ b/bookwyrm/views/__init__.py
@@ -118,6 +118,7 @@ from .imports.import_data import Import, UserImport, user_import_available
 from .imports.import_status import (
     ImportStatus,
     UserImportStatus,
+    delete_import,
     retry_item,
     stop_import,
     stop_user_import,

--- a/bookwyrm/views/imports/import_status.py
+++ b/bookwyrm/views/imports/import_status.py
@@ -86,6 +86,17 @@ def stop_import(request, job_id):
     return redirect("import-status", job_id)
 
 
+@login_required
+@require_POST
+def delete_import(request, job_id):
+    """remove an import job and its items from the import history"""
+    job = get_object_or_404(models.ImportJob, id=job_id, user=request.user)
+    if not job.complete:
+        raise PermissionDenied()
+    job.delete()
+    return redirect("import")
+
+
 @method_decorator(login_required, name="dispatch")
 class UserImportStatus(View):
     """status of an existing import"""


### PR DESCRIPTION
## Description

Implements the ability to delete a completed import from the "Recent Imports" history, as requested in #2097 ("the right to be forgotten" for import history, not just hiding it).

- New **"Delete import"** button (danger style, with a confirmation modal following the pattern of `delete_readthrough_modal.html`) on the import status page for completed imports.
- New `delete_import` view + `import-delete` URL: POST-only, login-required, owner-only (404 otherwise), and only for completed jobs (`PermissionDenied` for in-progress imports — those must be stopped first).
- Deleting removes the `ImportJob` and its `ImportItem` rows from the server. The books, reviews, and reading activity created by the import are **preserved** — `ImportItem.linked_review` is `SET_NULL`, so nothing federated or shelved is lost. The modal copy says this explicitly.
- Tests: successful deletion (job + items gone), in-progress rejection, wrong-user 404, and a rendered-HTML check that the completed-import status page offers the button (`validate_html` passes).

- Related Issue #2097
- Closes #2097

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [x] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)

None.

## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [x] I intend to create a matching pull request in the Documentation repository after this PR is merged

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
