### PR TITLE
Merge banner

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -29,6 +29,7 @@
 
 {% with user_authenticated=request.user.is_authenticated can_edit_book=perms.bookwyrm.edit_book %}
 <div class="block" itemscope itemtype="https://schema.org/Book">
+    {% include "snippets/merge_banner/work.html" with original=book.parent_work dupe=work_dupe object_type='work' %}
     {% include "snippets/merge_banner/edition.html" with original=book dupe=edition_dupe object_type='edition' %}
     <div class="columns is-mobile">
         {% include "book/sections/title.html" %}

--- a/bookwyrm/templates/settings/manage-data/merge_works.html
+++ b/bookwyrm/templates/settings/manage-data/merge_works.html
@@ -17,10 +17,18 @@
         <tbody>
             {% for work in works %}
             <tr class="has-text-centered">
-                <td><a href="{{work.remote_id}}">{{work.title}}</a></td>
+                <td>
+                    {% if work.default_edition %}
+                    <a href="{{work.remote_id}}">{{work.title}}</a>
+                    {% else %}
+                    {{ work.title }} {% trans "(Orphaned work)" %}
+                    {% endif %}
+                </td>
                 <td>{% for author in work.default_edition.authors.all %}{{author.name}}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
                 <td>{{work.merge_candidates.count}}</td>
-                <td><a class="button is-small is-link" href="{% url 'settings-manual-merge' 'work' edition.id %}?source=admin">{% trans 'Merge' %}</a></td>
+                <td>
+                    <a class="button is-small is-link" href="{% url 'settings-manual-merge' 'work' work.id %}?source=admin">{% trans 'Merge' %}</a>
+                </td>
             </tr>
             {% endfor %}
         </tbody>

--- a/bookwyrm/templates/snippets/merge_banner/layout.html
+++ b/bookwyrm/templates/snippets/merge_banner/layout.html
@@ -54,11 +54,13 @@
         <summary>
             <p>
             <span class="icon icon-warning" aria-hidden="true"></span>
+            {% block candidates_text %}
             {% blocktrans trimmed count counter=candidates.count with display_count=candidates.count|intcomma %}
                 A duplicate of this item has been identified.
                 {% plural %}
                 {{ display_count }} duplicates of this item have been detected.
             {% endblocktrans %}
+            {% endblock %}
 
             {% if merge_scheduled %}
                 {% blocktrans trimmed with date=original.pending_merge_date|naturalday %}

--- a/bookwyrm/templates/snippets/merge_banner/work.html
+++ b/bookwyrm/templates/snippets/merge_banner/work.html
@@ -1,14 +1,23 @@
 {% extends "snippets/merge_banner/layout.html" %}
 {% load i18n %}
 {% load utilities %}
+{% load humanize %}
 
 {% block content %}
 
 {% blocktrans trimmed with dupe_url=dupe.local_path dupe_title=dupe|book_title %}
-This work been identified as a duplicate of <strong><a href="{{ dupe_url }}">{{ dupe_title }}</a></strong>.
+This edition's work been identified as a duplicate of <strong><a href="{{ dupe_url }}">{{ dupe_title }}</a></strong>.
 {% endblocktrans %}
 <span class="details-close mt-4 mr-4 icon icon-x is-small" aria-hidden></span>
 
+{% endblock %}
+
+{% block candidates_text %}
+    {% blocktrans trimmed count counter=candidates.count with display_count=candidates.count|intcomma %}
+        A duplicate of this edition's work has been identified.
+        {% plural %}
+        {{ display_count }} duplicates of this work have been detected.
+    {% endblocktrans %}
 {% endblock %}
 
 

--- a/bookwyrm/templates/snippets/merge_banner/work.html
+++ b/bookwyrm/templates/snippets/merge_banner/work.html
@@ -16,7 +16,7 @@ This edition's work been identified as a duplicate of <strong><a href="{{ dupe_u
     {% blocktrans trimmed count counter=candidates.count with display_count=candidates.count|intcomma %}
         A duplicate of this edition's work has been identified.
         {% plural %}
-        {{ display_count }} duplicates of this work have been detected.
+        {{ display_count }} duplicates of this edition's work have been detected.
     {% endblocktrans %}
 {% endblock %}
 


### PR DESCRIPTION
## Description
I noticed while testing that the work merge page has some errors, and that the banner wasn't being used for works. I removed links to works that have no editions (those links just 404), changed the target of their merge button (it should be the work not the edition), and added back the merge work banner to the edition page with updated text that clarifies why there are two banners on one page.

Example header for a book with both a duplicate work and a duplicate edition:
<img width="1225" height="400" alt="Screenshot 2026-08-29 at 8 13 56 AM" src="https://github.com/user-attachments/assets/6b9aa105-e538-4f71-8481-e4cc39eb6718" />


- Related Issue #
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
