### PR TITLE
Removes failing broadcast in series migration

### DIFF
--- a/bookwyrm/migrations/0243_auto_20260730_0926.py
+++ b/bookwyrm/migrations/0243_auto_20260730_0926.py
@@ -21,7 +21,6 @@ def fix_series(apps, schema_editor):
         works = Work.objects.filter(series__startswith="[")
         for work in works:
             if edition := work.editions.order_by("-edition_rank").first():
-                print("edition", edition)
                 try:
                     series = json.loads(work.series)
                     work.series = series

--- a/bookwyrm/migrations/0243_auto_20260730_0926.py
+++ b/bookwyrm/migrations/0243_auto_20260730_0926.py
@@ -39,7 +39,7 @@ def fix_series(apps, schema_editor):
                 # childless work, just remove the series entry
                 work.series = None
                 work.series_number = None
-                work.save(broadcast=False)
+                work.save()
                 continue
 
         editions = Edition.objects.filter(series__startswith="[")
@@ -48,7 +48,7 @@ def fix_series(apps, schema_editor):
                 # orphaned edition, just remove the series entry
                 edition.series = None
                 edition.series_number = None
-                edition.save(broadcast=False)
+                edition.save()
                 continue
             try:
                 series = json.loads(edition.series)


### PR DESCRIPTION
## Description
My bad for not catching this earlier -- saves during migration work differently, so the broadcast keyword causes error. I also hit this error: `django.db.utils.ProgrammingError: multiple assignments to same column "first_published_date_precision"` which I need to investigate further

- Related Issue #
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [ ] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
