### PR TITLE
fix shelf rss path appending 'rss' to every path

### DIFF
--- a/bookwyrm/templates/shelf/shelf.html
+++ b/bookwyrm/templates/shelf/shelf.html
@@ -14,7 +14,7 @@
 
 
 {% block head_links %}
-    <link rel="alternate" type="application/rss+xml" href="{{ request.get_full_path }}/rss" title="{{ user.display_name }} - {{ shelf.name }}" />
+    <link rel="alternate" type="application/rss+xml" href="{{ shelf.remote_id }}/rss" title="{{ user.display_name }} - {{ shelf.name }}" />
 {% endblock %}
 
 {% block content %}

--- a/bookwyrm/tests/views/test_rss_feed.py
+++ b/bookwyrm/tests/views/test_rss_feed.py
@@ -1,7 +1,7 @@
 """testing import"""
 
 from unittest.mock import patch
-from django.test import RequestFactory, TestCase
+from django.test import Client, RequestFactory, TestCase
 
 from bookwyrm import models
 from bookwyrm.views import rss_feed
@@ -15,14 +15,11 @@ class RssFeedView(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "rss_user", "rss@test.rss", "password", local=True
-            )
+        """set up test data"""
+
+        cls.local_user = models.User.objects.create_user(
+            "rss_user", "rss@test.rss", "password", local=True, localname="rss_user"
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -157,3 +154,23 @@ class RssFeedView(TestCase):
         )
         self.assertEqual(result.status_code, 200)
         self.assertIn(b"Example Edition", result.content)
+
+    def test_shelf_renders_rss_link_correctly(self, *_):
+        """test the link is stable"""
+
+        shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=self.local_user
+        )
+
+        c = Client()
+        response = c.get(shelf.remote_id)
+        self.assertContains(
+            response,
+            f'<link rel="alternate" type="application/rss+xml" href="{shelf.remote_id}/rss" title="{self.local_user.localname} - {shelf.name}" />',
+        )
+
+        param_response = c.get(f"{shelf.remote_id}/?beep=boop")
+        self.assertContains(
+            param_response,
+            f'<link rel="alternate" type="application/rss+xml" href="{shelf.remote_id}/rss" title="{self.local_user.localname} - {shelf.name}" />',
+        )


### PR DESCRIPTION
## Description

We were using the wrong base on rss links for shelves.

- Related Issue #
- Closes #4105 

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
