### PR TITLE
fixed: save rating from being overwritten by localization

### DIFF
--- a/bookwyrm/templates/snippets/stars.html
+++ b/bookwyrm/templates/snippets/stars.html
@@ -17,10 +17,10 @@
 
         <span class="{% if not request.user.show_ratings %}is-hidden{% endif %}" id="rating-{{ uuid }}">
             <span class="is-sr-only">
-                {% blocktranslate trimmed with rating=rating|floatformat:1 count counter=rating|floatformat:0|add:0 %}
-                    {{ rating }} star
+                {% blocktranslate trimmed with display_rating=rating|floatformat:1 count counter=rating|default_if_none:0|floatformat:0|add:0 %}
+                    {{ display_rating }} star
                 {% plural %}
-                    {{ rating }} stars
+                    {{ display_rating }} stars
                 {% endblocktranslate %}
             </span>
             {% for i in '12345'|make_list %}


### PR DESCRIPTION
## Description

The variable `rating` is used in the with clause and localized by `floatformat`. It then is reused for `counter` where the evaluation may fail due to a decimal comma (depending on localization)

Fix: assign the display value to a different variable

- Related Issue #4129
- Closes #4129

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
