### PR TITLE
Remove stray closing div in manual merge template

### DIFF
--- a/bookwyrm/templates/settings/manage-data/manual-merge.html
+++ b/bookwyrm/templates/settings/manage-data/manual-merge.html
@@ -133,7 +133,6 @@ Merge {{plural_model}}
                 </td>
             </tr>
         </tbody>
-    </div>
     </form>
     </table>
     {% endif %}


### PR DESCRIPTION
## Description

I'm working on a django tempalte code formater and use this project in ci in my ecosystem check.
It started tripping on a template added yesterday because it contains a stray `</div>` with no mathcing opening.

This just fixes that:

```html
<table class="table is-fullwidth">     <!-- 52 -->
<form class="form" method="post">      <!-- 53 -->
    ...
    </tbody>
    </div>                             <!-- 136  ← unmatched, eats the form's scope -->
</form>                                <!-- 137 -->
</table>
```

Browser recovers from this already but still worth fixing for syntax highlighting at least

## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
