### PR TITLE
Display stand-in text for merging unnamed series

### DIFF
--- a/bookwyrm/templates/settings/manage-data/merge_series.html
+++ b/bookwyrm/templates/settings/manage-data/merge_series.html
@@ -16,7 +16,7 @@
         <tbody>
             {% for serie in series %}
             <tr class="has-text-centered">
-                <td><a href="{{serie.remote_id}}">{{serie.name}}</a></td>
+                <td><a href="{{serie.remote_id}}">{% firstof serie.name "Unnamed" %}</a></td>
                 <td>{{serie.merge_candidates.count}}</td>
                 <td><a class="button is-small is-link" href="{% url 'settings-manual-merge' 'series' serie.id %}?source=admin">{% trans 'Merge' %}</a></td>
             </tr>


### PR DESCRIPTION
## Description
If a series has no name, it looks weird in the merge UI. This doesn't address any underlying causes, just makes some links click-able
<img width="913" height="515" alt="Screenshot 2026-09-11 at 4 43 32 PM" src="https://github.com/user-attachments/assets/94de6c5a-d1ce-4a69-a7ff-22a4a35e67b3" />

- Related Issue #4155 
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
