### PR TITLE
Don't link to orphaned works in the other part of the work banner

### DIFF
--- a/bookwyrm/templates/snippets/merge_banner/layout.html
+++ b/bookwyrm/templates/snippets/merge_banner/layout.html
@@ -78,7 +78,9 @@
             <ol>
                 {% for candidate in candidates|slice:":20" %}
                 <li>
+                    {% block candidate_link %}
                     <a href="{{ candidate.local_path }}">{{ candidate.remote_id }}</a>
+                    {% endblock %}
                 </li>
                 {% endfor %}
             </ol>

--- a/bookwyrm/templates/snippets/merge_banner/work.html
+++ b/bookwyrm/templates/snippets/merge_banner/work.html
@@ -26,5 +26,13 @@
     {% endblocktrans %}
 {% endblock %}
 
+{% block candidate_link %}
+    {% if candidate.default_edition %}
+        <a href="{{ candidate.local_path }}">{{ candidate.remote_id }}</a>
+    {% else %}
+        <strong>{{ candidate|book_title }}</strong> (orphaned work)
+    {% endif %}
+{% endblock %}
+
 
 {% block merge_path %}{{ original.local_path }}/editions{% endblock %}


### PR DESCRIPTION
## Description
Links from the canonical to its dupes were including orphaned works.

- Related Issue #4155 
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [x] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
