### PR TITLE
fix long urls breaking manual data merge page

### DIFF
--- a/bookwyrm/templates/settings/manage-data/manual-merge.html
+++ b/bookwyrm/templates/settings/manage-data/manual-merge.html
@@ -59,7 +59,7 @@ Merge {{plural_model}}
                 <td colspan="2">{% trans 'Duplicate values' %}</td>
             </tr>
         </thead>
-        <tbody>
+        <tbody class="is-break-word">
             {% for field in simple_fields %}
             <tr>
                 {% with canonical|getattr_filter:field.name as canonical_value %}


### PR DESCRIPTION
## Description
fix "Long wikidata url makes the merge form so long you can't find th…e button to perform the merge"


- Related Issue #4155
- Closes #

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)


## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [ ] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
