### PR TITLE
Fix repeated RSA key imports during broadcasts

### DIFF
--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -545,12 +545,22 @@ def broadcast_task(sender_id: int, activity: str, recipients: list[str]):
 
 async def async_broadcast(recipients: list[str], sender, data: str):
     """Send all the broadcasts simultaneously"""
+    signing_key = None
+    if recipients:
+        if not sender.key_pair.private_key:
+            raise ValueError("No private key found for sender")
+        signing_key = RSA.import_key(sender.key_pair.private_key)
+
     timeout = aiohttp.ClientTimeout(total=10)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         tasks = []
         for recipient in recipients:
             tasks.append(
-                asyncio.ensure_future(sign_and_send(session, sender, data, recipient))
+                asyncio.ensure_future(
+                    sign_and_send(
+                        session, sender, data, recipient, signing_key=signing_key
+                    )
+                )
             )
 
         results = await asyncio.gather(*tasks)
@@ -558,7 +568,12 @@ async def async_broadcast(recipients: list[str], sender, data: str):
 
 
 async def sign_and_send(
-    session: aiohttp.ClientSession, sender, data: str, destination: str, **kwargs
+    session: aiohttp.ClientSession,
+    sender,
+    data: str,
+    destination: str,
+    signing_key=None,
+    **kwargs,
 ):
     """Sign the messages and send them in an asynchronous bundle"""
     now = http_date()
@@ -574,6 +589,7 @@ async def sign_and_send(
         destination,
         now,
         digest=digest,
+        signing_key=signing_key,
         use_legacy_key=kwargs.get("use_legacy_key"),
     )
 
@@ -595,7 +611,12 @@ async def sign_and_send(
                     logger.info("Trying again with legacy keyId header value")
                     asyncio.ensure_future(
                         sign_and_send(
-                            session, sender, data, destination, use_legacy_key=True
+                            session,
+                            sender,
+                            data,
+                            destination,
+                            signing_key=signing_key,
+                            use_legacy_key=True,
                         )
                     )
 

--- a/bookwyrm/signatures.py
+++ b/bookwyrm/signatures.py
@@ -23,7 +23,7 @@ def create_key_pair():
     return private_key, public_key
 
 
-def make_signature(method, sender, destination, date, **kwargs):
+def make_signature(method, sender, destination, date, signing_key=None, **kwargs):
     """uses a private key to sign an outgoing message"""
     inbox_parts = urlparse(destination)
     signature_headers = [
@@ -38,7 +38,9 @@ def make_signature(method, sender, destination, date, **kwargs):
         headers = "(request-target) host date digest"
 
     message_to_sign = "\n".join(signature_headers)
-    signer = pkcs1_15.new(RSA.import_key(sender.key_pair.private_key))
+    if signing_key is None:
+        signing_key = RSA.import_key(sender.key_pair.private_key)
+    signer = pkcs1_15.new(signing_key)
     signed_message = signer.sign(SHA256.new(message_to_sign.encode("utf8")))
     # For legacy reasons we need to use an incorrect keyId for older Bookwyrm versions
     key_id = (

--- a/bookwyrm/tests/models/test_activitypub_mixin.py
+++ b/bookwyrm/tests/models/test_activitypub_mixin.py
@@ -1,6 +1,7 @@
 """testing model activitypub utilities"""
 
-from unittest.mock import Mock, patch
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
 from collections import namedtuple
 from dataclasses import dataclass
 import re
@@ -13,6 +14,7 @@ from bookwyrm.models import base_model
 from bookwyrm.models.activitypub_mixin import (
     ActivitypubMixin,
     ActivityMixin,
+    async_broadcast,
     broadcast_task,
     ObjectMixin,
     OrderedCollectionMixin,
@@ -461,6 +463,30 @@ class ActivitypubMixins(TestCase):
             broadcast_task(self.local_user.id, {}, recipients)
         self.assertTrue(mock.called)
         self.assertEqual(mock.call_count, 1)
+
+    def test_async_broadcast_imports_key_once(self, *_):
+        """A broadcast should reuse its imported signing key."""
+        recipients = [
+            "https://instance.example/user/inbox",
+            "https://instance.example/okay/inbox",
+        ]
+        signing_key = Mock()
+        with (
+            patch(
+                "bookwyrm.models.activitypub_mixin.RSA.import_key",
+                return_value=signing_key,
+            ) as import_key,
+            patch(
+                "bookwyrm.models.activitypub_mixin.sign_and_send",
+                new_callable=AsyncMock,
+            ) as send,
+        ):
+            asyncio.run(async_broadcast(recipients, self.local_user, "{}"))
+
+        import_key.assert_called_once_with(self.local_user.key_pair.private_key)
+        self.assertEqual(send.await_count, len(recipients))
+        for call in send.await_args_list:
+            self.assertIs(call.kwargs["signing_key"], signing_key)
 
     def test_broadcast_no_recipients(self, broadcast_mock, *_):
         """should not queue a task when there is nobody to send to"""


### PR DESCRIPTION
## Description

The ActivityPub broadcast was repeatedly importing the sender's RSA key to sign every recipient in a broadcast. It is changed to now load the key once and reuse it for every recipient, including legacy signature retires. Importing an RSA key is computationally expensive. Avoiding the repeated imports removes a major source of delay. Also, a test case was added to check if the RSA key is not imported multiple times. 

Performance verification was done by using BookWyrm’s `async_broadcast` function and RSA signing code with 18,000 synthetic recipients. The HTTP requests were replaced with immediate successful responses.

Before: 373.577 seconds
After: 14.022 seconds

The actual numbers will vary machine by machine, but the broadcast pipeline is now significantly improved.

- Related Issue #4159
- Closes #4159

<!--
Thanks for contributing! This template has some checkboxes that help keep track of what changes go into a release.
You can find more information and tips for BookWyrm contributors at https://docs.joinbookwyrm.com/contributing.html
-->
## What type of Pull Request is this?

- [x] Bug Fix
- [ ] Enhancement
- [ ] Plumbing / Internals / Dependencies
- [ ] Refactor

## Does this PR change settings or dependencies, or break something?

- [ ] This PR changes or adds default settings, configuration, or .env values
- [ ] This PR changes or adds dependencies
- [ ] This PR introduces other breaking changes

### Details of breaking or configuration changes (if any of above checked)
N/A

## Documentation
<!--
Our documentation is maintained in a separate repository at https://github.com/bookwyrm-social/documentation
-->

- [ ] New or amended documentation will be required if this PR is merged
- [ ] I have created a matching pull request in the Documentation repository
- [ ] I intend to create a matching pull request in the Documentation repository after this PR is merged

<!-- Amazing! Thanks for filling that out. Your PR will need to have passing tests and happy linters before we can merge
You will need to check your code with `ruff` and `mypy`, or `./bw-dev formatters`
-->

### Tests

- [ ] My changes do not need new tests
- [x] All tests I have added are passing
- [ ] I have written tests but need help to make them pass
- [ ] I have not written tests and need help to write them
